### PR TITLE
Bugfix - too many logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "mime",
  "oslog",
  "parking_lot 0.11.2",
+ "parse-env-filter",
  "ruma 0.7.4 (git+https://github.com/ruma/ruma?rev=62ed200a56d00353eea128191311c4c8016def9f)",
  "sanitize-filename-reader-friendly",
  "serde",
@@ -2219,6 +2220,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "parse-env-filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63323aaa6ab655fccb0f13a03e0ab9be8e8751514c316d204c3f7d7653c096e"
 
 [[package]]
 name = "parse-zoneinfo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,6 @@ dependencies = [
  "async-broadcast",
  "chrono",
  "derive_builder 0.10.2",
- "env_logger",
  "fern",
  "ffi-gen",
  "ffi-gen-macro",

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -526,7 +526,7 @@ class Api {
   /// Initialize logging
   void initLogging(
     String logDir,
-    String? filter,
+    String filter,
   ) {
     final tmp0 = logDir;
     final tmp4 = filter;
@@ -534,9 +534,8 @@ class Api {
     var tmp2 = 0;
     var tmp3 = 0;
     var tmp5 = 0;
+    var tmp6 = 0;
     var tmp7 = 0;
-    var tmp8 = 0;
-    var tmp9 = 0;
     final tmp0_0 = utf8.encode(tmp0);
     tmp2 = tmp0_0.length;
     final ffi.Pointer<ffi.Uint8> tmp1_0 = this.__allocate(tmp2 * 1, 1);
@@ -544,41 +543,34 @@ class Api {
     tmp1_1.setAll(0, tmp0_0);
     tmp1 = tmp1_0.address;
     tmp3 = tmp2;
-    if (tmp4 == null) {
-      tmp5 = 0;
-    } else {
-      tmp5 = 1;
-      final tmp6 = tmp4;
-      final tmp6_0 = utf8.encode(tmp6);
-      tmp8 = tmp6_0.length;
-      final ffi.Pointer<ffi.Uint8> tmp7_0 = this.__allocate(tmp8 * 1, 1);
-      final Uint8List tmp7_1 = tmp7_0.asTypedList(tmp8);
-      tmp7_1.setAll(0, tmp6_0);
-      tmp7 = tmp7_0.address;
-      tmp9 = tmp8;
-    }
-    final tmp10 = _initLogging(
+    final tmp4_0 = utf8.encode(tmp4);
+    tmp6 = tmp4_0.length;
+    final ffi.Pointer<ffi.Uint8> tmp5_0 = this.__allocate(tmp6 * 1, 1);
+    final Uint8List tmp5_1 = tmp5_0.asTypedList(tmp6);
+    tmp5_1.setAll(0, tmp4_0);
+    tmp5 = tmp5_0.address;
+    tmp7 = tmp6;
+    final tmp8 = _initLogging(
       tmp1,
       tmp2,
       tmp3,
       tmp5,
+      tmp6,
       tmp7,
-      tmp8,
-      tmp9,
     );
-    final tmp12 = tmp10.arg0;
-    final tmp13 = tmp10.arg1;
-    final tmp14 = tmp10.arg2;
-    final tmp15 = tmp10.arg3;
-    if (tmp12 == 0) {
-      final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      final tmp12_0 = utf8.decode(tmp13_0.asTypedList(tmp14));
-      if (tmp14 > 0) {
-        final ffi.Pointer<ffi.Void> tmp13_0;
-        tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-        this.__deallocate(tmp13_0, tmp15, 1);
+    final tmp10 = tmp8.arg0;
+    final tmp11 = tmp8.arg1;
+    final tmp12 = tmp8.arg2;
+    final tmp13 = tmp8.arg3;
+    if (tmp10 == 0) {
+      final ffi.Pointer<ffi.Uint8> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+      final tmp10_0 = utf8.decode(tmp11_0.asTypedList(tmp12));
+      if (tmp12 > 0) {
+        final ffi.Pointer<ffi.Void> tmp11_0;
+        tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+        this.__deallocate(tmp11_0, tmp13, 1);
       }
-      throw tmp12_0;
+      throw tmp10_0;
     }
     return;
   }
@@ -6021,7 +6013,6 @@ class Api {
     ffi.Int64,
     ffi.Uint64,
     ffi.Uint64,
-    ffi.Uint8,
     ffi.Int64,
     ffi.Uint64,
     ffi.Uint64,
@@ -6029,7 +6020,6 @@ class Api {
 
   late final _initLogging = _initLoggingPtr.asFunction<
       _InitLoggingReturn Function(
-    int,
     int,
     int,
     int,

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -32,6 +32,7 @@ log = "0.4"
 log-panics = "2.0.0"
 mime = "0.3.16"
 parking_lot = "0.11.2"
+parse-env-filter = "0.1.0"
 ruma = { workspace = true }
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { version = "1", features = ["derive"] }

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = "1.0.51"
 async-broadcast = { workspace = true }
 chrono = "0.4"
 derive_builder = { version = "0.10.2" }
-env_logger = "0.10.0"
 fern = { git = "https://github.com/acterglobal/fern", branch = "rotate", features = ["manual"] }
 ffi-gen-macro = { git = "https://github.com/acterglobal/ffi-gen" }
 futures = "0.3.17"

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1,5 +1,5 @@
 /// Initialize logging
-fn init_logging(log_dir: string, filter: Option<string>) -> Result<()>;
+fn init_logging(log_dir: string, filter: string) -> Result<()>;
 
 /// Rotate the logging file
 fn rotate_log_file() -> Result<string>;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -87,7 +87,7 @@ mod api {
     }
 }
 
-fn init_logging(log_dir: String, filter: Option<String>) -> Result<()> {
+fn init_logging(log_dir: String, filter: String) -> Result<()> {
     platform::init_logging(log_dir, filter)
 }
 

--- a/native/acter/src/platform/android.rs
+++ b/native/acter/src/platform/android.rs
@@ -16,13 +16,11 @@ pub async fn new_client_config(base_path: String, home: String) -> Result<Client
 
 const APP_TAG: &str = "global.acter.app"; // package name in manifest, application id in build.gradle
 
-pub fn init_logging(log_dir: String, filter: Option<String>) -> Result<()> {
+pub fn init_logging(log_dir: String, filter: String) -> Result<()> {
     let mut log_config = Config::default()
         .with_max_level(LevelFilter::Trace)
-        .with_tag(APP_TAG);
-    if let Some(ref filter) = filter {
-        log_config = log_config.with_filter(FilterBuilder::new().parse(filter).build());
-    }
+        .with_tag(APP_TAG)
+        .with_filter(FilterBuilder::new().parse(filter.as_str()).build());
     let console_logger = LoggerWrapper::new(log_config).cloned_boxed_logger();
     native::init_logging(log_dir, filter, Some(console_logger))
 }

--- a/native/acter/src/platform/android.rs
+++ b/native/acter/src/platform/android.rs
@@ -1,6 +1,5 @@
 use android_logger::{AndroidLogger, Config};
 use anyhow::Result;
-use env_logger::filter::Builder as FilterBuilder;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use matrix_sdk::ClientBuilder;
 use std::sync::{Arc, Mutex};
@@ -19,8 +18,7 @@ const APP_TAG: &str = "global.acter.app"; // package name in manifest, applicati
 pub fn init_logging(log_dir: String, filter: String) -> Result<()> {
     let mut log_config = Config::default()
         .with_max_level(LevelFilter::Trace)
-        .with_tag(APP_TAG)
-        .with_filter(FilterBuilder::new().parse(filter.as_str()).build());
+        .with_tag(APP_TAG);
     let console_logger = LoggerWrapper::new(log_config).cloned_boxed_logger();
     native::init_logging(log_dir, filter, Some(console_logger))
 }

--- a/native/acter/src/platform/desktop.rs
+++ b/native/acter/src/platform/desktop.rs
@@ -16,6 +16,6 @@ pub async fn new_client_config(base_path: String, home: String) -> Result<Client
 
 // this excludes macos, because macos and ios is very much alike in logging
 
-pub fn init_logging(log_dir: String, filter: Option<String>) -> Result<()> {
+pub fn init_logging(log_dir: String, filter: String) -> Result<()> {
     native::init_logging(log_dir, filter, None)
 }

--- a/native/acter/src/platform/ios.rs
+++ b/native/acter/src/platform/ios.rs
@@ -30,7 +30,7 @@ pub async fn new_client_config(base_path: String, home: String) -> Result<Client
 
 const APP_TAG: &str = "global.acter.app"; // product bundle id in project config
 
-pub fn init_logging(log_dir: String, filter: Option<String>) -> Result<()> {
+pub fn init_logging(log_dir: String, filter: String) -> Result<()> {
     let console_logger = LoggerWrapper::new(APP_TAG, "viewcycle").cloned_boxed_logger();
     native::init_logging(log_dir, filter, Some(console_logger))
 }

--- a/native/acter/src/platform/native.rs
+++ b/native/acter/src/platform/native.rs
@@ -26,17 +26,13 @@ lazy_static! {
 
 pub fn init_logging(
     log_dir: String,
-    filter: Option<String>,
+    filter: String,
     console_logger: Option<Box<dyn Log>>,
 ) -> Result<()> {
     std::env::set_var("RUST_BACKTRACE", "1");
     log_panics::init();
 
-    let log_level = match filter {
-        Some(ref filter) => FilterBuilder::new().parse(filter).build(),
-        None => FilterBuilder::new().build(),
-    };
-
+    let log_level = FilterBuilder::new().parse(filter.as_str()).build();
     let mut path = PathBuf::from(log_dir.as_str());
     path.push("app_");
 

--- a/native/acter/src/platform/native.rs
+++ b/native/acter/src/platform/native.rs
@@ -32,21 +32,25 @@ pub fn init_logging(
     std::env::set_var("RUST_BACKTRACE", "1");
     log_panics::init();
 
-    let mut builder = fern::Dispatch::new()
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "{}[{}][{}] {}",
-                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-                record.target(),
-                record.level(),
-                message
-            ))
-        });
+    let mut builder = fern::Dispatch::new().format(|out, message, record| {
+        out.finish(format_args!(
+            "{}[{}][{}] {}",
+            chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+            record.target(),
+            record.level(),
+            message
+        ))
+    });
 
     let Ok(items) = filters(&filter) else {
         bail!("Parsing log filters failed");
     };
-    for Filter { target, span, level } in items {
+    for Filter {
+        target,
+        span,
+        level,
+    } in items
+    {
         match level {
             Some(level) => {
                 if let Some(level) = get_log_filter(level) {

--- a/native/acter/src/platform/native.rs
+++ b/native/acter/src/platform/native.rs
@@ -55,18 +55,17 @@ pub fn init_logging(
         // - and per-module overrides
         .level_for("acter-sdk", log_level.filter())*/;
 
-    if let Ok(items) = filters(filter.as_str()) {
-        for Filter { target, span, level } in items {
-            match level {
-                Some(level) => {
-                    if let Some(level) = get_log_filter(level) {
-                        builder = builder.level_for(target, level);
-                    }
+    let Ok(items) = filters(&filter) else { anyhow::bail!("Parsing log filters failed"); };
+    for Filter { target, span, level } in items {
+        match level {
+            Some(level) => {
+                if let Some(level) = get_log_filter(level) {
+                    builder = builder.level_for(target.to_owned(), level);
                 }
-                None => {
-                    if let Some(level) = get_log_filter(target) {
-                        builder = builder.level(level);
-                    }
+            }
+            None => {
+                if let Some(level) = get_log_filter(target) {
+                    builder = builder.level(level);
                 }
             }
         }


### PR DESCRIPTION
Now too many logs appear in console, including unnecessary logs.
Keep only `acter` module related logs.