### PR TITLE
Return even id as object not string

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1818,7 +1818,7 @@ class Api {
     return tmp7;
   }
 
-  String? __conversationSendPlainMessageFuturePoll(
+  EventId? __conversationSendPlainMessageFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -1843,8 +1843,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -1858,17 +1856,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationSendFormattedMessageFuturePoll(
+  EventId? __conversationSendFormattedMessageFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -1893,8 +1888,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -1908,17 +1901,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationSendReactionFuturePoll(
+  EventId? __conversationSendReactionFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -1943,8 +1933,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -1958,17 +1946,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationSendImageMessageFuturePoll(
+  EventId? __conversationSendImageMessageFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -1993,8 +1978,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2008,13 +1991,10 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
@@ -2236,7 +2216,7 @@ class Api {
     return tmp7;
   }
 
-  String? __conversationSendFileMessageFuturePoll(
+  EventId? __conversationSendFileMessageFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -2261,8 +2241,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2276,13 +2254,10 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
@@ -2519,7 +2494,7 @@ class Api {
     return tmp7;
   }
 
-  String? __conversationSendTextReplyFuturePoll(
+  EventId? __conversationSendTextReplyFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -2544,8 +2519,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2559,17 +2532,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationSendImageReplyFuturePoll(
+  EventId? __conversationSendImageReplyFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -2594,8 +2564,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2609,17 +2577,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationSendFileReplyFuturePoll(
+  EventId? __conversationSendFileReplyFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -2644,8 +2609,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2659,17 +2622,14 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
-  String? __conversationRedactMessageFuturePoll(
+  EventId? __conversationRedactMessageFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -2694,8 +2654,6 @@ class Api {
     final tmp11 = tmp6.arg3;
     final tmp12 = tmp6.arg4;
     final tmp13 = tmp6.arg5;
-    final tmp14 = tmp6.arg6;
-    final tmp15 = tmp6.arg7;
     if (tmp8 == 0) {
       return null;
     }
@@ -2709,13 +2667,10 @@ class Api {
       }
       throw tmp9_0;
     }
-    final ffi.Pointer<ffi.Uint8> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp7 = utf8.decode(tmp13_0.asTypedList(tmp14));
-    if (tmp15 > 0) {
-      final ffi.Pointer<ffi.Void> tmp13_0;
-      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-      this.__deallocate(tmp13_0, tmp15 * 1, 1);
-    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
@@ -15897,7 +15852,7 @@ class Conversation {
   /// Send a simple plain text message to the room
   /// returns the event_id as given by the server of the event soon after
   /// received over timeline().next()
-  Future<String> sendPlainMessage(
+  Future<EventId> sendPlainMessage(
     String textMessage,
   ) {
     final tmp1 = textMessage;
@@ -15930,7 +15885,7 @@ class Conversation {
   }
 
   /// Send a text message in MarkDown format to the room
-  Future<String> sendFormattedMessage(
+  Future<EventId> sendFormattedMessage(
     String markdownMessage,
   ) {
     final tmp1 = markdownMessage;
@@ -15963,7 +15918,7 @@ class Conversation {
   }
 
   /// Send reaction about existing event
-  Future<String> sendReaction(
+  Future<EventId> sendReaction(
     String eventId,
     String key,
   ) {
@@ -16011,7 +15966,7 @@ class Conversation {
   }
 
   /// send the image message to this room
-  Future<String> sendImageMessage(
+  Future<EventId> sendImageMessage(
     String uri,
     String name,
     String mimetype,
@@ -16246,7 +16201,7 @@ class Conversation {
   }
 
   /// send the file message to this room
-  Future<String> sendFileMessage(
+  Future<EventId> sendFileMessage(
     String uri,
     String name,
     String mimetype,
@@ -16456,7 +16411,7 @@ class Conversation {
   }
 
   /// send reply as text
-  Future<String> sendTextReply(
+  Future<EventId> sendTextReply(
     String msg,
     String eventId,
     String? txnId,
@@ -16527,7 +16482,7 @@ class Conversation {
   }
 
   /// send reply as image
-  Future<String> sendImageReply(
+  Future<EventId> sendImageReply(
     String uri,
     String name,
     String mimetype,
@@ -16667,7 +16622,7 @@ class Conversation {
   }
 
   /// send reply as file
-  Future<String> sendFileReply(
+  Future<EventId> sendFileReply(
     String uri,
     String name,
     String mimetype,
@@ -16781,7 +16736,7 @@ class Conversation {
   }
 
   /// redact any message (including text/image/file and reaction)
-  Future<String> redactMessage(
+  Future<EventId> redactMessage(
     String eventId,
     String? reason,
     String? txnId,
@@ -23518,10 +23473,6 @@ class _ConversationSendPlainMessageFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSendFormattedMessageFuturePollReturn extends ffi.Struct {
@@ -23537,10 +23488,6 @@ class _ConversationSendFormattedMessageFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSendReactionFuturePollReturn extends ffi.Struct {
@@ -23556,10 +23503,6 @@ class _ConversationSendReactionFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSendImageMessageFuturePollReturn extends ffi.Struct {
@@ -23575,10 +23518,6 @@ class _ConversationSendImageMessageFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationInviteUserFuturePollReturn extends ffi.Struct {
@@ -23669,10 +23608,6 @@ class _ConversationSendFileMessageFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSaveFileFuturePollReturn extends ffi.Struct {
@@ -23771,10 +23706,6 @@ class _ConversationSendTextReplyFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSendImageReplyFuturePollReturn extends ffi.Struct {
@@ -23790,10 +23721,6 @@ class _ConversationSendImageReplyFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationSendFileReplyFuturePollReturn extends ffi.Struct {
@@ -23809,10 +23736,6 @@ class _ConversationSendFileReplyFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _ConversationRedactMessageFuturePollReturn extends ffi.Struct {
@@ -23828,10 +23751,6 @@ class _ConversationRedactMessageFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Int64()
   external int arg5;
-  @ffi.Uint64()
-  external int arg6;
-  @ffi.Uint64()
-  external int arg7;
 }
 
 class _CommentDraftSendFuturePollReturn extends ffi.Struct {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -404,16 +404,16 @@ object Conversation {
     /// Send a simple plain text message to the room
     /// returns the event_id as given by the server of the event soon after
     /// received over timeline().next()
-    fn send_plain_message(text_message: string) -> Future<Result<string>>;
+    fn send_plain_message(text_message: string) -> Future<Result<EventId>>;
 
     /// Send a text message in MarkDown format to the room
-    fn send_formatted_message(markdown_message: string) -> Future<Result<string>>;
+    fn send_formatted_message(markdown_message: string) -> Future<Result<EventId>>;
 
     /// Send reaction about existing event
-    fn send_reaction(event_id: string, key: string) -> Future<Result<string>>;
+    fn send_reaction(event_id: string, key: string) -> Future<Result<EventId>>;
 
     /// send the image message to this room
-    fn send_image_message(uri: string, name: string, mimetype: string, size: Option<u32>, width: Option<u32>, height: Option<u32>) -> Future<Result<string>>;
+    fn send_image_message(uri: string, name: string, mimetype: string, size: Option<u32>, width: Option<u32>, height: Option<u32>) -> Future<Result<EventId>>;
 
     /// get the user status on this room
     fn room_type() -> string;
@@ -436,7 +436,7 @@ object Conversation {
     fn image_binary(event_id: string) -> Future<Result<buffer<u8>>>;
 
     /// send the file message to this room
-    fn send_file_message(uri: string, name: string, mimetype: string, size: u32) -> Future<Result<string>>;
+    fn send_file_message(uri: string, name: string, mimetype: string, size: u32) -> Future<Result<EventId>>;
 
     /// save file in specified path
     fn save_file(event_id: string, dir_path: string) -> Future<Result<string>>;
@@ -454,16 +454,16 @@ object Conversation {
     fn get_message(event_id: string) -> Future<Result<RoomMessage>>;
 
     /// send reply as text
-    fn send_text_reply(msg: string, event_id: string, txn_id: Option<string>) -> Future<Result<string>>;
+    fn send_text_reply(msg: string, event_id: string, txn_id: Option<string>) -> Future<Result<EventId>>;
 
     /// send reply as image
-    fn send_image_reply(uri: string, name: string, mimetype: string, size: Option<u32>, width: Option<u32>, height: Option<u32>, event_id: string, txn_id: Option<string>) -> Future<Result<string>>;
+    fn send_image_reply(uri: string, name: string, mimetype: string, size: Option<u32>, width: Option<u32>, height: Option<u32>, event_id: string, txn_id: Option<string>) -> Future<Result<EventId>>;
 
     /// send reply as file
-    fn send_file_reply(uri: string, name: string, mimetype: string, size: Option<u32>, event_id: string, txn_id: Option<string>) -> Future<Result<string>>;
+    fn send_file_reply(uri: string, name: string, mimetype: string, size: Option<u32>, event_id: string, txn_id: Option<string>) -> Future<Result<EventId>>;
 
     /// redact any message (including text/image/file and reaction)
-    fn redact_message(event_id: string, reason: Option<string>, txn_id: Option<string>) -> Future<Result<string>>;
+    fn redact_message(event_id: string, reason: Option<string>, txn_id: Option<string>) -> Future<Result<EventId>>;
 }
 
 object CommentDraft {

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -1,7 +1,6 @@
-use acter_core::spaces::is_acter_space;
+use acter_core::{ruma::OwnedEventId, spaces::is_acter_space};
 use anyhow::{bail, Context, Result};
 use log::{info, warn};
-
 use matrix_sdk::{
     attachment::{AttachmentConfig, AttachmentInfo, BaseFileInfo, BaseImageInfo},
     media::{MediaFormat, MediaRequest},
@@ -190,7 +189,7 @@ impl Room {
             .await?
     }
 
-    pub async fn send_plain_message(&self, message: String) -> Result<String> {
+    pub async fn send_plain_message(&self, message: String) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -202,12 +201,12 @@ impl Room {
                     RoomMessageEventContent::text_plain(message),
                 );
                 let response = room.send(content, None).await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
 
-    pub async fn send_formatted_message(&self, markdown: String) -> Result<String> {
+    pub async fn send_formatted_message(&self, markdown: String) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -219,12 +218,12 @@ impl Room {
                     RoomMessageEventContent::text_markdown(markdown),
                 );
                 let response = room.send(content, None).await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
 
-    pub async fn send_reaction(&self, event_id: String, key: String) -> Result<String> {
+    pub async fn send_reaction(&self, event_id: String, key: String) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -236,7 +235,7 @@ impl Room {
                 let relates_to = Annotation::new(event_id, key);
                 let content = ReactionEventContent::new(relates_to);
                 let response = room.send(content, None).await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -249,7 +248,7 @@ impl Room {
         size: Option<u32>,
         width: Option<u32>,
         height: Option<u32>,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -269,7 +268,7 @@ impl Room {
                 let response = room
                     .send_attachment(name.as_str(), &mime_type, image_buf, config)
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -394,7 +393,7 @@ impl Room {
         name: String,
         mimetype: String,
         size: u32,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -411,7 +410,7 @@ impl Room {
                 let response = room
                     .send_attachment(name.as_str(), &mime_type, image_buf, config)
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -772,7 +771,7 @@ impl Room {
         msg: String,
         event_id: String,
         txn_id: Option<String>,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -805,7 +804,7 @@ impl Room {
                 let response = room
                     .send(content, txn_id.as_deref().map(Into::into))
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -821,7 +820,7 @@ impl Room {
         height: Option<u32>,
         event_id: String,
         txn_id: Option<String>,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -872,7 +871,7 @@ impl Room {
                 let response = room
                     .send(content, txn_id.as_deref().map(Into::into))
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -885,7 +884,7 @@ impl Room {
         size: Option<u32>,
         event_id: String,
         txn_id: Option<String>,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -934,7 +933,7 @@ impl Room {
                 let response = room
                     .send(content, txn_id.as_deref().map(Into::into))
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }
@@ -944,7 +943,7 @@ impl Room {
         event_id: String,
         reason: Option<String>,
         txn_id: Option<String>,
-    ) -> Result<String> {
+    ) -> Result<OwnedEventId> {
         let room = if let MatrixRoom::Joined(r) = &self.room {
             r.clone()
         } else {
@@ -958,7 +957,7 @@ impl Room {
                 let response = room
                     .redact(&event_id, reason.as_deref(), txn_id.map(Into::into))
                     .await?;
-                Ok(response.event_id.to_string())
+                Ok(response.event_id)
             })
             .await?
     }

--- a/native/test/src/tests/reaction.rs
+++ b/native/test/src/tests/reaction.rs
@@ -1,4 +1,4 @@
-use acter::{api::login_new_client, matrix_sdk::ruma::EventId};
+use acter::api::login_new_client;
 use anyhow::Result;
 use futures::stream::StreamExt;
 use tempfile::TempDir;
@@ -143,25 +143,24 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
         .expect("odo should belong to ops");
 
     kyra_group
-        .send_reaction(event_id.clone(), "👏".to_string())
+        .send_reaction(event_id.to_string(), "👏".to_string())
         .await?;
     worf_group
-        .send_reaction(event_id.clone(), "😎".to_string())
+        .send_reaction(event_id.to_string(), "😎".to_string())
         .await?;
     bashir_group
-        .send_reaction(event_id.clone(), "😜".to_string())
+        .send_reaction(event_id.to_string(), "😜".to_string())
         .await?;
     miles_group
-        .send_reaction(event_id.clone(), "🤩".to_string())
+        .send_reaction(event_id.to_string(), "🤩".to_string())
         .await?;
     jadzia_group
-        .send_reaction(event_id.clone(), "😍".to_string())
+        .send_reaction(event_id.to_string(), "😍".to_string())
         .await?;
     odo_group
-        .send_reaction(event_id.clone(), "😂".to_string())
+        .send_reaction(event_id.to_string(), "😂".to_string())
         .await?;
 
-    let event_id = EventId::parse(event_id)?;
     let event = sisko_group.event(&event_id).await?;
     println!("reactions: {event:?}");
 

--- a/native/test/src/tests/receipt.rs
+++ b/native/test/src/tests/receipt.rs
@@ -51,7 +51,7 @@ async fn sisko_detects_kyra_read() -> Result<()> {
         .get_group(format!("#ops:{homeserver_name}"))
         .await
         .expect("kyra should belong to ops");
-    kyra_group.read_receipt(event_id).await?;
+    kyra_group.read_receipt(event_id.to_string()).await?;
 
     let mut event_rx = kyra.receipt_event_rx().unwrap();
     loop {

--- a/native/test/src/tests/redact.rs
+++ b/native/test/src/tests/redact.rs
@@ -1,7 +1,4 @@
-use acter::matrix_sdk::ruma::{
-    events::{AnyMessageLikeEvent, AnyTimelineEvent},
-    EventId,
-};
+use acter::matrix_sdk::ruma::events::{AnyMessageLikeEvent, AnyTimelineEvent};
 use anyhow::Result;
 use futures::stream::StreamExt;
 
@@ -24,10 +21,9 @@ async fn message_redaction() -> Result<()> {
     println!("event id: {event_id:?}");
 
     let redact_id = group
-        .redact_message(event_id.clone(), Some("redact-test".to_string()), None)
+        .redact_message(event_id.to_string(), Some("redact-test".to_string()), None)
         .await?;
 
-    let redact_id = EventId::parse(redact_id)?;
     let ev = group.event(&redact_id).await?;
     println!("redact: {ev:?}");
 
@@ -37,9 +33,8 @@ async fn message_redaction() -> Result<()> {
 
     let Some(e) = r.as_original() else {
         panic!("This should be m.room.redaction event");
-
     };
 
-    assert_eq!(e.redacts.to_string(), event_id);
+    assert_eq!(e.redacts, event_id);
     Ok(())
 }

--- a/native/test/src/tests/reply.rs
+++ b/native/test/src/tests/reply.rs
@@ -1,9 +1,6 @@
 use acter::{
     api::login_new_client,
-    matrix_sdk::ruma::{
-        events::{AnyMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent},
-        EventId,
-    },
+    matrix_sdk::ruma::events::{AnyMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent},
 };
 use anyhow::{bail, Result};
 use futures::stream::StreamExt;
@@ -43,10 +40,9 @@ async fn sisko_replies_message() -> Result<()> {
     let event_id = group.send_plain_message("Hi, everyone".to_string()).await?;
 
     let reply_id = group
-        .send_text_reply("Sorry, it's my bad".to_string(), event_id, None)
+        .send_text_reply("Sorry, it's my bad".to_string(), event_id.to_string(), None)
         .await?;
 
-    let reply_id = EventId::parse(reply_id)?;
     let ev = group.event(&reply_id).await?;
     println!("reply: {ev:?}");
 


### PR DESCRIPTION
Some methods in `Room` return the event id as string.
For convenience, I will change its type from string to `OwnedEventId`.
It uses several times in rust integration tests.