### PR TITLE
Improve room operation under latest matrix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,10 +43,22 @@
             },
         },
         {
-            "name": "flutter",
+            "name": "flutter (debug mode)",
             "cwd": "app",
             "request": "launch",
             "type": "dart",
+            "flutterMode": "debug",
+            "toolArgs": [
+                "--dart-define",
+                "RAGESHAKE_URL=http://localhost/api/submit"
+            ]
+        },
+        {
+            "name": "flutter (release mode)",
+            "cwd": "app",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release",
             "toolArgs": [
                 "--dart-define",
                 "RAGESHAKE_URL=http://localhost/api/submit"
@@ -57,7 +69,11 @@
             "cwd": "app",
             "request": "launch",
             "type": "dart",
-            "flutterMode": "profile"
+            "flutterMode": "profile",
+            "toolArgs": [
+                "--dart-define",
+                "RAGESHAKE_URL=http://localhost/api/submit"
+            ]
         },
         {
             "name": "rust",

--- a/app/lib/features/chat/controllers/chat_room_controller.dart
+++ b/app/lib/features/chat/controllers/chat_room_controller.dart
@@ -902,11 +902,7 @@ class ChatRoomController extends GetxController {
                 metadata['reactions'] = reactions;
               }
               //check whether string only contains emoji(s).
-              if (isOnlyEmojis(description.body())) {
-                metadata['enlargeEmoji'] = true;
-              } else {
-                metadata['enlargeEmoji'] = false;
-              }
+              metadata['enlargeEmoji'] = isOnlyEmojis(description.body());
               return types.TextMessage(
                 author: author,
                 createdAt: createdAt,

--- a/app/lib/features/chat/controllers/chat_room_controller.dart
+++ b/app/lib/features/chat/controllers/chat_room_controller.dart
@@ -129,7 +129,6 @@ class ChatRoomController extends GetxController {
 
   // get the timeline of room
   Future<void> setCurrentRoom(Conversation? convoRoom) async {
-    var receiptController = Get.find<ReceiptController>();
     if (convoRoom == null) {
       _messages.clear();
       typingUsers.clear();
@@ -138,9 +137,6 @@ class ChatRoomController extends GetxController {
       _diffSubscription?.cancel();
       _stream = null;
       _page = 0;
-      if (_currentRoom != null) {
-        receiptController.unloadRoom(_currentRoom!);
-      }
       _currentRoom = null;
       return;
     }
@@ -361,6 +357,7 @@ class ChatRoomController extends GetxController {
       isLoading.value = false;
       return;
     }
+    var receiptController = Get.find<ReceiptController>();
     receiptController.loadRoom(convoRoom, receipts);
     isLoading.value = false;
   }

--- a/app/lib/features/chat/controllers/receipt_controller.dart
+++ b/app/lib/features/chat/controllers/receipt_controller.dart
@@ -39,23 +39,10 @@ class ReceiptController extends GetxController {
   ReceiptController({required this.client}) : super();
 
   @override
-  void onClose() {
-    _subscription?.cancel();
-    super.onClose();
-  }
+  void onInit() {
+    super.onInit();
 
-  ReceiptRoom _getRoom(String roomId) {
-    if (_rooms.containsKey(roomId)) {
-      return _rooms[roomId]!;
-    }
-    ReceiptRoom room = ReceiptRoom();
-    _rooms[roomId] = room;
-    return room;
-  }
-
-  void loadRoom(Conversation conversation, List<ReceiptRecord> records) {
-    conversation.addEventHandler();
-    _subscription = conversation.receiptEventRx()?.listen((event) {
+    _subscription = client.receiptEventRx()?.listen((event) {
       String roomId = event.roomId();
       bool changed = false;
       for (var record in event.receiptRecords()) {
@@ -71,17 +58,30 @@ class ReceiptController extends GetxController {
         roomController.update(['Chat']);
       }
     });
+  }
 
+  @override
+  void onClose() {
+    _subscription?.cancel();
+
+    super.onClose();
+  }
+
+  ReceiptRoom _getRoom(String roomId) {
+    if (_rooms.containsKey(roomId)) {
+      return _rooms[roomId]!;
+    }
+    ReceiptRoom room = ReceiptRoom();
+    _rooms[roomId] = room;
+    return room;
+  }
+
+  void loadRoom(Conversation conversation, List<ReceiptRecord> records) {
     var room = _getRoom(conversation.getRoomId());
     for (var record in records) {
       String seenBy = record.seenBy();
       room.updateUser(seenBy, record.eventId(), record.ts());
     }
-  }
-
-  void unloadRoom(Conversation conversation) {
-    _subscription?.cancel();
-    conversation.removeEventHandler();
   }
 
   // this will be called via update(['Chat'])

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -42,6 +42,12 @@ Future<void> startApp() async {
     final license = await rootBundle.loadString('google_fonts/LICENSE.txt');
     yield LicenseEntryWithLineBreaks(['google_fonts'], license);
   });
+  final sdk = await ActerSdk.instance;
+  PlatformDispatcher.instance.onError = (exception, stackTrace) {
+    sdk.writeLog(exception.toString(), 'error');
+    sdk.writeLog(stackTrace.toString(), 'error');
+    return true; // make this error handled
+  };
   runApp(const ProviderScope(child: Acter()));
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -113,7 +113,7 @@ class ActerSdk {
       );
       _clients.add(client);
       loggedIn = client.loggedIn();
-    await _persistSessions();
+      await _persistSessions();
     }
     debugPrint('Restored $_clients: $loggedIn');
   }

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -5714,42 +5714,6 @@ class Api {
     return tmp9;
   }
 
-  ReceiptEvent? __conversationReceiptEventRxStreamPoll(
-    int boxed,
-    int postCobject,
-    int port,
-    int done,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    final tmp6 = done;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    var tmp7 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    tmp7 = tmp6;
-    final tmp8 = _conversationReceiptEventRxStreamPoll(
-      tmp1,
-      tmp3,
-      tmp5,
-      tmp7,
-    );
-    final tmp10 = tmp8.arg0;
-    final tmp11 = tmp8.arg1;
-    if (tmp10 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
-    final tmp11_1 = _Box(this, tmp11_0, "drop_box_ReceiptEvent");
-    tmp11_1._finalizer = this._registerFinalizer(tmp11_1);
-    final tmp9 = ReceiptEvent._(this, tmp11_1);
-    return tmp9;
-  }
-
   void __taskSubscribeStreamPoll(
     int boxed,
     int postCobject,
@@ -5810,42 +5774,6 @@ class Api {
       return null;
     }
     return;
-  }
-
-  ReceiptEvent? __groupReceiptEventRxStreamPoll(
-    int boxed,
-    int postCobject,
-    int port,
-    int done,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    final tmp6 = done;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    var tmp7 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    tmp7 = tmp6;
-    final tmp8 = _groupReceiptEventRxStreamPoll(
-      tmp1,
-      tmp3,
-      tmp5,
-      tmp7,
-    );
-    final tmp10 = tmp8.arg0;
-    final tmp11 = tmp8.arg1;
-    if (tmp10 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
-    final tmp11_1 = _Box(this, tmp11_0, "drop_box_ReceiptEvent");
-    tmp11_1._finalizer = this._registerFinalizer(tmp11_1);
-    final tmp9 = ReceiptEvent._(this, tmp11_1);
-    return tmp9;
   }
 
   bool? __syncStateFirstSyncedRxStreamPoll(
@@ -6096,6 +6024,42 @@ class Api {
     final tmp11_1 = _Box(this, tmp11_0, "drop_box_TypingEvent");
     tmp11_1._finalizer = this._registerFinalizer(tmp11_1);
     final tmp9 = TypingEvent._(this, tmp11_1);
+    return tmp9;
+  }
+
+  ReceiptEvent? __clientReceiptEventRxStreamPoll(
+    int boxed,
+    int postCobject,
+    int port,
+    int done,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    final tmp6 = done;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    var tmp7 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    tmp7 = tmp6;
+    final tmp8 = _clientReceiptEventRxStreamPoll(
+      tmp1,
+      tmp3,
+      tmp5,
+      tmp7,
+    );
+    final tmp10 = tmp8.arg0;
+    final tmp11 = tmp8.arg1;
+    if (tmp10 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+    final tmp11_1 = _Box(this, tmp11_0, "drop_box_ReceiptEvent");
+    tmp11_1._finalizer = this._registerFinalizer(tmp11_1);
+    final tmp9 = ReceiptEvent._(this, tmp11_1);
     return tmp9;
   }
 
@@ -8145,39 +8109,6 @@ class Api {
     int,
     int,
   )>();
-  late final _conversationAddEventHandlerPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-    ffi.Int64,
-  )>>("__Conversation_add_event_handler");
-
-  late final _conversationAddEventHandler =
-      _conversationAddEventHandlerPtr.asFunction<
-          void Function(
-    int,
-  )>();
-  late final _conversationRemoveEventHandlerPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-    ffi.Int64,
-  )>>("__Conversation_remove_event_handler");
-
-  late final _conversationRemoveEventHandler =
-      _conversationRemoveEventHandlerPtr.asFunction<
-          void Function(
-    int,
-  )>();
-  late final _conversationReceiptEventRxPtr = _lookup<
-      ffi.NativeFunction<
-          _ConversationReceiptEventRxReturn Function(
-    ffi.Int64,
-  )>>("__Conversation_receipt_event_rx");
-
-  late final _conversationReceiptEventRx =
-      _conversationReceiptEventRxPtr.asFunction<
-          _ConversationReceiptEventRxReturn Function(
-    int,
-  )>();
   late final _conversationUpdatePowerLevelPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -9980,36 +9911,6 @@ class Api {
       _GroupPinDraftReturn Function(
     int,
   )>();
-  late final _groupAddEventHandlerPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-    ffi.Int64,
-  )>>("__Group_add_event_handler");
-
-  late final _groupAddEventHandler = _groupAddEventHandlerPtr.asFunction<
-      void Function(
-    int,
-  )>();
-  late final _groupRemoveEventHandlerPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-    ffi.Int64,
-  )>>("__Group_remove_event_handler");
-
-  late final _groupRemoveEventHandler = _groupRemoveEventHandlerPtr.asFunction<
-      void Function(
-    int,
-  )>();
-  late final _groupReceiptEventRxPtr = _lookup<
-      ffi.NativeFunction<
-          _GroupReceiptEventRxReturn Function(
-    ffi.Int64,
-  )>>("__Group_receipt_event_rx");
-
-  late final _groupReceiptEventRx = _groupReceiptEventRxPtr.asFunction<
-      _GroupReceiptEventRxReturn Function(
-    int,
-  )>();
   late final _memberGetProfilePtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -10456,6 +10357,16 @@ class Api {
 
   late final _clientTypingEventRx = _clientTypingEventRxPtr.asFunction<
       _ClientTypingEventRxReturn Function(
+    int,
+  )>();
+  late final _clientReceiptEventRxPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientReceiptEventRxReturn Function(
+    ffi.Int64,
+  )>>("__Client_receipt_event_rx");
+
+  late final _clientReceiptEventRx = _clientReceiptEventRxPtr.asFunction<
+      _ClientReceiptEventRxReturn Function(
     int,
   )>();
   late final _clientIncomingMessageRxPtr = _lookup<
@@ -12756,23 +12667,6 @@ class Api {
     int,
     int,
   )>();
-  late final _conversationReceiptEventRxStreamPollPtr = _lookup<
-      ffi.NativeFunction<
-          _ConversationReceiptEventRxStreamPollReturn Function(
-    ffi.Int64,
-    ffi.Int64,
-    ffi.Int64,
-    ffi.Int64,
-  )>>("__Conversation_receipt_event_rx_stream_poll");
-
-  late final _conversationReceiptEventRxStreamPoll =
-      _conversationReceiptEventRxStreamPollPtr.asFunction<
-          _ConversationReceiptEventRxStreamPollReturn Function(
-    int,
-    int,
-    int,
-    int,
-  )>();
   late final _taskSubscribeStreamPollPtr = _lookup<
       ffi.NativeFunction<
           ffi.Uint8 Function(
@@ -12801,23 +12695,6 @@ class Api {
   late final _taskListSubscribeStreamPoll =
       _taskListSubscribeStreamPollPtr.asFunction<
           int Function(
-    int,
-    int,
-    int,
-    int,
-  )>();
-  late final _groupReceiptEventRxStreamPollPtr = _lookup<
-      ffi.NativeFunction<
-          _GroupReceiptEventRxStreamPollReturn Function(
-    ffi.Int64,
-    ffi.Int64,
-    ffi.Int64,
-    ffi.Int64,
-  )>>("__Group_receipt_event_rx_stream_poll");
-
-  late final _groupReceiptEventRxStreamPoll =
-      _groupReceiptEventRxStreamPollPtr.asFunction<
-          _GroupReceiptEventRxStreamPollReturn Function(
     int,
     int,
     int,
@@ -12937,6 +12814,23 @@ class Api {
   late final _clientTypingEventRxStreamPoll =
       _clientTypingEventRxStreamPollPtr.asFunction<
           _ClientTypingEventRxStreamPollReturn Function(
+    int,
+    int,
+    int,
+    int,
+  )>();
+  late final _clientReceiptEventRxStreamPollPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientReceiptEventRxStreamPollReturn Function(
+    ffi.Int64,
+    ffi.Int64,
+    ffi.Int64,
+    ffi.Int64,
+  )>>("__Client_receipt_event_rx_stream_poll");
+
+  late final _clientReceiptEventRxStreamPoll =
+      _clientReceiptEventRxStreamPollPtr.asFunction<
+          _ClientReceiptEventRxStreamPollReturn Function(
     int,
     int,
     int,
@@ -17522,47 +17416,6 @@ class Conversation {
     return tmp18;
   }
 
-  /// Install event handler
-  void addEventHandler() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._conversationAddEventHandler(
-      tmp0,
-    );
-    return;
-  }
-
-  /// Uninstall event handler
-  void removeEventHandler() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._conversationRemoveEventHandler(
-      tmp0,
-    );
-    return;
-  }
-
-  /// Return the receipt event receiver
-  Stream<ReceiptEvent>? receiptEventRx() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._conversationReceiptEventRx(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    if (tmp3 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 =
-        _Box(_api, tmp4_0, "__Conversation_receipt_event_rx_stream_drop");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 =
-        _nativeStream(tmp4_1, _api.__conversationReceiptEventRxStreamPoll);
-    return tmp2;
-  }
-
   /// update the power levels of specified member
   Future<EventId> updatePowerLevel(
     String userId,
@@ -20406,45 +20259,6 @@ class Group {
     return tmp2;
   }
 
-  /// Install event handler
-  void addEventHandler() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._groupAddEventHandler(
-      tmp0,
-    );
-    return;
-  }
-
-  /// Uninstall event handler
-  void removeEventHandler() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._groupRemoveEventHandler(
-      tmp0,
-    );
-    return;
-  }
-
-  /// Return the receipt event receiver
-  Stream<ReceiptEvent>? receiptEventRx() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._groupReceiptEventRx(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    if (tmp3 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "__Group_receipt_event_rx_stream_drop");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = _nativeStream(tmp4_1, _api.__groupReceiptEventRxStreamPoll);
-    return tmp2;
-  }
-
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -21293,6 +21107,25 @@ class Client {
     final tmp4_1 = _Box(_api, tmp4_0, "__Client_typing_event_rx_stream_drop");
     tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
     final tmp2 = _nativeStream(tmp4_1, _api.__clientTypingEventRxStreamPoll);
+    return tmp2;
+  }
+
+  /// Return the receipt event receiver
+  Stream<ReceiptEvent>? receiptEventRx() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._clientReceiptEventRx(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "__Client_receipt_event_rx_stream_drop");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = _nativeStream(tmp4_1, _api.__clientReceiptEventRxStreamPoll);
     return tmp2;
   }
 
@@ -23482,13 +23315,6 @@ class _ConversationRoomTypeReturn extends ffi.Struct {
   external int arg2;
 }
 
-class _ConversationReceiptEventRxReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
 class _CommentContentTextReturn extends ffi.Struct {
   @ffi.Int64()
   external int arg0;
@@ -23856,13 +23682,6 @@ class _GroupPinDraftReturn extends ffi.Struct {
   external int arg4;
 }
 
-class _GroupReceiptEventRxReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
 class _MemberUserIdReturn extends ffi.Struct {
   @ffi.Int64()
   external int arg0;
@@ -23953,6 +23772,13 @@ class _ClientDeviceLeftEventRxReturn extends ffi.Struct {
 }
 
 class _ClientTypingEventRxReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+}
+
+class _ClientReceiptEventRxReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()
@@ -25747,20 +25573,6 @@ class _TimelineStreamDiffRxStreamPollReturn extends ffi.Struct {
   external int arg1;
 }
 
-class _ConversationReceiptEventRxStreamPollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
-class _GroupReceiptEventRxStreamPollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
 class _SyncStateFirstSyncedRxStreamPollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -25804,6 +25616,13 @@ class _ClientDeviceLeftEventRxStreamPollReturn extends ffi.Struct {
 }
 
 class _ClientTypingEventRxStreamPollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+}
+
+class _ClientReceiptEventRxStreamPollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -500,15 +500,6 @@ object Conversation {
     /// redact any message (including text/image/file and reaction)
     fn redact_message(event_id: string, reason: Option<string>, txn_id: Option<string>) -> Future<Result<EventId>>;
 
-    /// Install event handler
-    fn add_event_handler();
-
-    /// Uninstall event handler
-    fn remove_event_handler();
-
-    /// Return the receipt event receiver
-    fn receipt_event_rx() -> Option<Stream<ReceiptEvent>>;
-
     /// update the power levels of specified member
     fn update_power_level(user_id: string, level: i32) -> Future<Result<EventId>>;
 }
@@ -876,15 +867,6 @@ object Group {
 
     /// pin draft builder
     fn pin_draft() -> Result<PinDraft>;
-
-    /// Install event handler
-    fn add_event_handler();
-
-    /// Uninstall event handler
-    fn remove_event_handler();
-
-    /// Return the receipt event receiver
-    fn receipt_event_rx() -> Option<Stream<ReceiptEvent>>;
 }
 
 object Member {
@@ -1017,6 +999,9 @@ object Client {
 
     /// Return the typing event receiver
     fn typing_event_rx() -> Option<Stream<TypingEvent>>;
+
+    /// Return the receipt event receiver
+    fn receipt_event_rx() -> Option<Stream<ReceiptEvent>>;
 
     /// Return the message receiver
     fn incoming_message_rx() -> Option<Stream<RoomMessage>>;

--- a/native/acter/src/api/conversation.rs
+++ b/native/acter/src/api/conversation.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use super::{
     client::Client,
     message::{sync_event_to_message, RoomMessage},
-    receipt::{ReceiptController, ReceiptRecord},
+    receipt::ReceiptRecord,
     room::Room,
     RUNTIME,
 };
@@ -44,7 +44,6 @@ use super::{
 pub struct Conversation {
     inner: Room,
     latest_message: Option<RoomMessage>,
-    pub(crate) receipt_controller: ReceiptController,
 }
 
 impl Conversation {
@@ -52,7 +51,6 @@ impl Conversation {
         Conversation {
             inner,
             latest_message: Default::default(),
-            receipt_controller: ReceiptController::new(),
         }
     }
 

--- a/native/acter/src/api/group.rs
+++ b/native/acter/src/api/group.rs
@@ -46,10 +46,7 @@ struct HistoryState {
 
 impl Group {
     pub fn new(client: Client, inner: Room) -> Self {
-        Group {
-            client,
-            inner,
-        }
+        Group { client, inner }
     }
 
     pub async fn create_onboarding_data(&self) -> Result<()> {

--- a/native/acter/src/api/group.rs
+++ b/native/acter/src/api/group.rs
@@ -25,7 +25,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     client::{devide_groups_from_convos, Client},
-    receipt::ReceiptController,
     room::Room,
 };
 use crate::api::RUNTIME;
@@ -37,7 +36,6 @@ pub type CreateGroupSettingsBuilder = CreateSpaceSettingsBuilder;
 pub struct Group {
     pub client: Client,
     pub(crate) inner: Room,
-    pub(crate) receipt_controller: ReceiptController,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,7 +49,6 @@ impl Group {
         Group {
             client,
             inner,
-            receipt_controller: ReceiptController::new(),
         }
     }
 

--- a/native/acter/src/api/receipt.rs
+++ b/native/acter/src/api/receipt.rs
@@ -15,7 +15,7 @@ use matrix_sdk::{
 };
 use std::sync::Arc;
 
-use super::{conversation::Conversation, group::Group};
+use super::client::Client;
 
 #[derive(Clone, Debug)]
 pub struct ReceiptRecord {
@@ -143,39 +143,10 @@ impl ReceiptController {
     }
 }
 
-impl Conversation {
-    pub fn add_event_handler(&mut self) {
-        let client = self.room.client();
-        self.receipt_controller.add_event_handler(&client);
-    }
-
-    pub fn remove_event_handler(&mut self) {
-        let client = self.room.client();
-        self.receipt_controller.remove_event_handler(&client);
-    }
-
+impl Client {
     pub fn receipt_event_rx(&self) -> Option<Receiver<ReceiptEvent>> {
         match self.receipt_controller.event_rx.try_lock() {
             Ok(mut rx) => rx.take(),
-            Err(e) => None,
-        }
-    }
-}
-
-impl Group {
-    pub fn add_event_handler(&mut self) {
-        let client = self.room.client();
-        self.receipt_controller.add_event_handler(&client);
-    }
-
-    pub fn remove_event_handler(&mut self) {
-        let client = self.room.client();
-        self.receipt_controller.remove_event_handler(&client);
-    }
-
-    pub fn receipt_event_rx(&self) -> Option<Receiver<ReceiptEvent>> {
-        match self.receipt_controller.event_rx.try_lock() {
-            Ok(mut r) => r.take(),
             Err(e) => None,
         }
     }

--- a/native/test/src/tests/receipt.rs
+++ b/native/test/src/tests/receipt.rs
@@ -47,14 +47,13 @@ async fn sisko_detects_kyra_read() -> Result<()> {
     let kyra_syncer = kyra.start_sync();
     let mut first_synced = kyra_syncer.first_synced_rx().expect("note yet read");
     while first_synced.next().await != Some(true) {} // let's wait for it to have synced
-    let mut kyra_group = kyra
+    let kyra_group = kyra
         .get_group(format!("#ops:{homeserver_name}"))
         .await
         .expect("kyra should belong to ops");
-    kyra_group.add_event_handler();
     kyra_group.read_receipt(event_id.to_string()).await?;
 
-    let mut event_rx = kyra_group.receipt_event_rx().unwrap();
+    let mut event_rx = kyra.receipt_event_rx().unwrap();
     loop {
         match event_rx.try_next() {
             Ok(Some(event)) => {


### PR DESCRIPTION
1. Upgrade send msg.
2. Restore unexpected exception handler in flutter.
3. Revert receipt event handler from room to client, because it doesn't use `add_room_event_handler()` after migration to room.
    - It must pass `receipt::sisko_detects_kyra_read()` in integration test.