### PR TITLE
Replace u64 with u32 in api.rsh for wasm support

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -8010,7 +8010,7 @@ class Api {
   )>();
   late final _reactionDescCountPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Uint64 Function(
+          ffi.Uint32 Function(
     ffi.Int64,
   )>>("__ReactionDesc_count");
 
@@ -11215,8 +11215,8 @@ class Api {
       ffi.NativeFunction<
           ffi.Int64 Function(
     ffi.Int64,
-    ffi.Uint64,
-    ffi.Uint64,
+    ffi.Uint32,
+    ffi.Uint32,
   )>>("__UserProfile_get_thumbnail");
 
   late final _userProfileGetThumbnail = _userProfileGetThumbnailPtr.asFunction<
@@ -11260,8 +11260,8 @@ class Api {
       ffi.NativeFunction<
           ffi.Int64 Function(
     ffi.Int64,
-    ffi.Uint64,
-    ffi.Uint64,
+    ffi.Uint32,
+    ffi.Uint32,
   )>>("__RoomProfile_get_thumbnail");
 
   late final _roomProfileGetThumbnail = _roomProfileGetThumbnailPtr.asFunction<
@@ -24549,21 +24549,21 @@ class _ThumbnailInfoMimetypeReturn extends ffi.Struct {
 class _ThumbnailInfoSizeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _ThumbnailInfoWidthReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _ThumbnailInfoHeightReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -24773,21 +24773,21 @@ class _ImageDescMimetypeReturn extends ffi.Struct {
 class _ImageDescSizeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _ImageDescWidthReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _ImageDescHeightReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -24828,14 +24828,14 @@ class _AudioDescMimetypeReturn extends ffi.Struct {
 class _AudioDescSizeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _AudioDescDurationReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -24862,21 +24862,21 @@ class _VideoDescMimetypeReturn extends ffi.Struct {
 class _VideoDescSizeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _VideoDescWidthReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _VideoDescHeightReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -24894,7 +24894,7 @@ class _VideoDescBlurhashReturn extends ffi.Struct {
 class _VideoDescDurationReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -24935,7 +24935,7 @@ class _FileDescMimetypeReturn extends ffi.Struct {
 class _FileDescSizeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int arg1;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -243,11 +243,11 @@ object ThumbnailInfo {
     /// thumbnail mimetype
     fn mimetype() -> Option<string>;
     /// thumbnail size
-    fn size() -> Option<u64>;
+    fn size() -> Option<u32>;
     /// thumbnail width
-    fn width() -> Option<u64>;
+    fn width() -> Option<u32>;
     /// thumbnail height
-    fn height() -> Option<u64>;
+    fn height() -> Option<u32>;
 }
 
 object DeviceId {
@@ -350,13 +350,13 @@ object ImageDesc {
     fn mimetype() -> Option<string>;
 
     /// file size in bytes
-    fn size() -> Option<u64>;
+    fn size() -> Option<u32>;
 
     /// image width
-    fn width() -> Option<u64>;
+    fn width() -> Option<u32>;
 
     /// image height
-    fn height() -> Option<u64>;
+    fn height() -> Option<u32>;
 
     /// thumbnail info
     fn thumbnail_info() -> Option<ThumbnailInfo>;
@@ -376,10 +376,10 @@ object AudioDesc {
     fn mimetype() -> Option<string>;
 
     /// file size in bytes
-    fn size() -> Option<u64>;
+    fn size() -> Option<u32>;
 
     /// duration in seconds
-    fn duration() -> Option<u64>;
+    fn duration() -> Option<u32>;
 }
 
 object VideoDesc {
@@ -393,19 +393,19 @@ object VideoDesc {
     fn mimetype() -> Option<string>;
 
     /// file size in bytes
-    fn size() -> Option<u64>;
+    fn size() -> Option<u32>;
 
     /// image width
-    fn width() -> Option<u64>;
+    fn width() -> Option<u32>;
 
     /// image height
-    fn height() -> Option<u64>;
+    fn height() -> Option<u32>;
 
     /// blurhash
     fn blurhash() -> Option<string>;
 
     /// duration in seconds
-    fn duration() -> Option<u64>;
+    fn duration() -> Option<u32>;
 
     /// thumbnail info
     fn thumbnail_info() -> Option<ThumbnailInfo>;
@@ -425,7 +425,7 @@ object FileDesc {
     fn mimetype() -> Option<string>;
 
     /// file size in bytes
-    fn size() -> Option<u64>;
+    fn size() -> Option<u32>;
 
     /// thumbnail info
     fn thumbnail_info() -> Option<ThumbnailInfo>;
@@ -436,7 +436,7 @@ object FileDesc {
 
 object ReactionDesc {
     /// how many times this key was clicked
-    fn count() -> u64;
+    fn count() -> u32;
 
     /// which users selected this key
     fn senders() -> Vec<string>;
@@ -1148,7 +1148,7 @@ object UserProfile {
     fn get_avatar() -> Future<Result<buffer<u8>>>;
 
     /// get the binary data of thumbnail
-    fn get_thumbnail(width: u64, height: u64) -> Future<Result<buffer<u8>>>;
+    fn get_thumbnail(width: u32, height: u32) -> Future<Result<buffer<u8>>>;
 
     /// get the display name
     fn get_display_name() -> Option<string>;
@@ -1162,7 +1162,7 @@ object RoomProfile {
     fn get_avatar() -> Future<Result<buffer<u8>>>;
 
     /// get the binary data of thumbnail
-    fn get_thumbnail(width: u64, height: u64) -> Future<Result<buffer<u8>>>;
+    fn get_thumbnail(width: u32, height: u32) -> Future<Result<buffer<u8>>>;
 
     /// get the display name
     fn get_display_name() -> Option<string>;

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -34,16 +34,34 @@ impl ThumbnailInfo {
         self.inner.mimetype.clone()
     }
 
-    pub fn size(&self) -> Option<u64> {
-        self.inner.size.map(u64::from)
+    pub fn size(&self) -> Option<u32> {
+        self.inner.size.map(|x| {
+            let size = u64::from(x);
+            if size > u32::MAX as u64 {
+                panic!("thumbnail size overflowed");
+            }
+            size as u32
+        })
     }
 
-    pub fn width(&self) -> Option<u64> {
-        self.inner.width.map(u64::from)
+    pub fn width(&self) -> Option<u32> {
+        self.inner.width.map(|x| {
+            let width = u64::from(x);
+            if width > u32::MAX as u64 {
+                panic!("thumbnail width overflowed");
+            }
+            width as u32
+        })
     }
 
-    pub fn height(&self) -> Option<u64> {
-        self.inner.height.map(u64::from)
+    pub fn height(&self) -> Option<u32> {
+        self.inner.height.map(|x| {
+            let height = u64::from(x);
+            if height > u32::MAX as u64 {
+                panic!("thumbnail height overflowed");
+            }
+            height as u32
+        })
     }
 }
 
@@ -104,16 +122,34 @@ impl ImageDesc {
         self.info.mimetype.clone()
     }
 
-    pub fn size(&self) -> Option<u64> {
-        self.info.size.map(u64::from)
+    pub fn size(&self) -> Option<u32> {
+        self.info.size.map(|x| {
+            let size = u64::from(x);
+            if size > u32::MAX as u64 {
+                panic!("image size overflowed");
+            }
+            size as u32
+        })
     }
 
-    pub fn width(&self) -> Option<u64> {
-        self.info.width.map(u64::from)
+    pub fn width(&self) -> Option<u32> {
+        self.info.width.map(|x| {
+            let width = u64::from(x);
+            if width > u32::MAX as u64 {
+                panic!("image width overflowed");
+            }
+            width as u32
+        })
     }
 
-    pub fn height(&self) -> Option<u64> {
-        self.info.height.map(u64::from)
+    pub fn height(&self) -> Option<u32> {
+        self.info.height.map(|x| {
+            let height = u64::from(x);
+            if height > u32::MAX as u64 {
+                panic!("image height overflowed");
+            }
+            height as u32
+        })
     }
 
     pub fn thumbnail_info(&self) -> Option<ThumbnailInfo> {
@@ -153,16 +189,28 @@ impl AudioDesc {
         }
     }
 
-    pub fn duration(&self) -> Option<u64> {
-        self.info.duration.map(|x| x.as_secs())
+    pub fn duration(&self) -> Option<u32> {
+        self.info.duration.map(|x| {
+            let secs = x.as_secs();
+            if secs > u32::MAX as u64 {
+                panic!("audio duration overflowed");
+            }
+            secs as u32
+        })
     }
 
     pub fn mimetype(&self) -> Option<String> {
         self.info.mimetype.clone()
     }
 
-    pub fn size(&self) -> Option<u64> {
-        self.info.size.map(u64::from)
+    pub fn size(&self) -> Option<u32> {
+        self.info.size.map(|x| {
+            let size = u64::from(x);
+            if size > u32::MAX as u64 {
+                panic!("audio size overflowed");
+            }
+            size as u32
+        })
     }
 }
 
@@ -192,24 +240,48 @@ impl VideoDesc {
         self.info.blurhash.clone()
     }
 
-    pub fn duration(&self) -> Option<u64> {
-        self.info.duration.map(|x| x.as_secs())
+    pub fn duration(&self) -> Option<u32> {
+        self.info.duration.map(|x| {
+            let secs = x.as_secs();
+            if secs > u32::MAX as u64 {
+                panic!("video duration overflowed");
+            }
+            secs as u32
+        })
     }
 
     pub fn mimetype(&self) -> Option<String> {
         self.info.mimetype.clone()
     }
 
-    pub fn size(&self) -> Option<u64> {
-        self.info.size.map(u64::from)
+    pub fn size(&self) -> Option<u32> {
+        self.info.size.map(|x| {
+            let size = u64::from(x);
+            if size > u32::MAX as u64 {
+                panic!("video size overflowed");
+            }
+            size as u32
+        })
     }
 
-    pub fn width(&self) -> Option<u64> {
-        self.info.width.map(u64::from)
+    pub fn width(&self) -> Option<u32> {
+        self.info.width.map(|x| {
+            let width = u64::from(x);
+            if width > u32::MAX as u64 {
+                panic!("video width overflowed");
+            }
+            width as u32
+        })
     }
 
-    pub fn height(&self) -> Option<u64> {
-        self.info.height.map(u64::from)
+    pub fn height(&self) -> Option<u32> {
+        self.info.height.map(|x| {
+            let height = u64::from(x);
+            if height > u32::MAX as u64 {
+                panic!("video height overflowed");
+            }
+            height as u32
+        })
     }
 
     pub fn thumbnail_info(&self) -> Option<ThumbnailInfo> {
@@ -253,8 +325,14 @@ impl FileDesc {
         self.info.mimetype.clone()
     }
 
-    pub fn size(&self) -> Option<u64> {
-        self.info.size.map(u64::from)
+    pub fn size(&self) -> Option<u32> {
+        self.info.size.map(|x| {
+            let size = u64::from(x);
+            if size > u32::MAX as u64 {
+                panic!("file size overflowed");
+            }
+            size as u32
+        })
     }
 
     pub fn thumbnail_info(&self) -> Option<ThumbnailInfo> {
@@ -274,16 +352,16 @@ impl FileDesc {
 
 #[derive(Clone, Debug)]
 pub struct ReactionDesc {
-    count: u64,
+    count: u32,
     senders: Vec<OwnedUserId>,
 }
 
 impl ReactionDesc {
-    pub(crate) fn new(count: u64, senders: Vec<OwnedUserId>) -> Self {
+    pub(crate) fn new(count: u32, senders: Vec<OwnedUserId>) -> Self {
         ReactionDesc { count, senders }
     }
 
-    pub fn count(&self) -> u64 {
+    pub fn count(&self) -> u32 {
         self.count
     }
 

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -2685,7 +2685,7 @@ impl RoomMessage {
                     .senders()
                     .map(|x| x.to_owned())
                     .collect::<Vec<OwnedUserId>>();
-                let description = ReactionDesc::new(senders.len() as u64, senders);
+                let description = ReactionDesc::new(senders.len() as u32, senders);
                 reactions.insert(key.clone(), description);
             }
         }

--- a/native/acter/src/api/profile.rs
+++ b/native/acter/src/api/profile.rs
@@ -78,15 +78,15 @@ impl UserProfile {
             .await?
     }
 
-    pub async fn get_thumbnail(&self, width: u64, height: u64) -> Result<FfiBuffer<u8>> {
+    pub async fn get_thumbnail(&self, width: u32, height: u32) -> Result<FfiBuffer<u8>> {
         let client = self.client.clone();
         let avatar_url = self.avatar_url.clone().unwrap();
         RUNTIME
             .spawn(async move {
                 let size = MediaThumbnailSize {
                     method: Method::Scale,
-                    width: UInt::new(width).unwrap(),
-                    height: UInt::new(height).unwrap(),
+                    width: UInt::from(width),
+                    height: UInt::from(height),
                 };
                 let request = MediaRequest {
                     source: MediaSource::Plain(avatar_url),
@@ -159,15 +159,15 @@ impl RoomProfile {
             .await?
     }
 
-    pub async fn get_thumbnail(&self, width: u64, height: u64) -> Result<FfiBuffer<u8>> {
+    pub async fn get_thumbnail(&self, width: u32, height: u32) -> Result<FfiBuffer<u8>> {
         let client = self.client.clone();
         let avatar_url = self.avatar_url.clone().unwrap();
         RUNTIME
             .spawn(async move {
                 let size = MediaThumbnailSize {
                     method: Method::Scale,
-                    width: UInt::new(width).unwrap(),
-                    height: UInt::new(height).unwrap(),
+                    width: UInt::from(width),
+                    height: UInt::from(height),
                 };
                 let request = MediaRequest {
                     source: MediaSource::Plain(avatar_url),


### PR DESCRIPTION
Will replace `u64` with `u32` about outer functions in `api.rsh`.