### PR TITLE
Pin rust nightly toolchain for mac arm64

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-04-10"
 components = ["rustfmt", "clippy", "rls", "rust-src"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
Now nightly occurs error about `aarch64-apple-darwin` (mac) in toolchain.
Will fix it.