### PR TITLE
News navigation fixes

### DIFF
--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs= -Xmx1024m -XX:ReservedCodeCacheSize=2048m -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs= -Xmx4608m -XX:ReservedCodeCacheSize=2048m -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/app/lib/common/snackbars/custom_msg.dart
+++ b/app/lib/common/snackbars/custom_msg.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-void showNotYetImplementedMsg(BuildContext context, String message) {
+void customMsgSnackbar(BuildContext context, String message) {
   ScaffoldMessenger.of(context).clearSnackBars();
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(

--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -21,6 +21,11 @@ enum Routes {
   chat('/chat'),
   chatroom('/chat/:spaceId([!#][^/]+)'), // !roomId, #roomName
 
+  // --- updates
+  updatesEdit('updates_edit'),
+  updatesPost('updates_post'),
+  updatesPostSearch('post_search'),
+
   // -- spaces
   space('/:spaceId([!#][^/]+)'), // !spaceId, #spaceName
 

--- a/app/lib/features/activities/presentation/pages/activities_page.dart
+++ b/app/lib/features/activities/presentation/pages/activities_page.dart
@@ -1,5 +1,5 @@
 import 'package:acter/common/providers/common_providers.dart';
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/widgets/default_page_header.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
@@ -22,7 +22,7 @@ class ActivitiesPage extends ConsumerWidget {
               IconButton(
                 icon: const Icon(Atlas.funnel_sort_thin),
                 onPressed: () {
-                  showNotYetImplementedMsg(
+                  customMsgSnackbar(
                     context,
                     'Activities filters not yet implemented',
                   );
@@ -31,7 +31,7 @@ class ActivitiesPage extends ConsumerWidget {
               IconButton(
                 icon: const Icon(Atlas.gear_thin),
                 onPressed: () {
-                  showNotYetImplementedMsg(
+                  customMsgSnackbar(
                     context,
                     'Notifications Settings page not yet implemented',
                   );

--- a/app/lib/features/chat/pages/chat_page.dart
+++ b/app/lib/features/chat/pages/chat_page.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/features/chat/controllers/chat_list_controller.dart';
 import 'package:acter/features/chat/widgets/invite_info_card.dart';
@@ -94,7 +94,7 @@ class ChatPage extends ConsumerWidget {
                         ),
                         IconButton(
                           onPressed: () {
-                            showNotYetImplementedMsg(
+                            customMsgSnackbar(
                               context,
                               'Multiselect is not implemented yet',
                             );
@@ -106,7 +106,7 @@ class ChatPage extends ConsumerWidget {
                         ),
                         IconButton(
                           onPressed: () {
-                            showNotYetImplementedMsg(
+                            customMsgSnackbar(
                               context,
                               'Starting a new chat is not implemented yet',
                             );

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/chat_theme.dart';
 import 'package:acter/features/chat/controllers/chat_list_controller.dart';
 import 'package:acter/features/chat/controllers/chat_room_controller.dart';
@@ -211,7 +211,7 @@ class _RoomPageState extends State<RoomPage> {
                                   ),
                                   GestureDetector(
                                     onTap: () {
-                                      showNotYetImplementedMsg(
+                                      customMsgSnackbar(
                                         ctx,
                                         'Report feature not yet implemented',
                                       );
@@ -523,7 +523,7 @@ class _RoomPageState extends State<RoomPage> {
               showUserAvatars: true,
               onAttachmentPressed: () => handleAttachmentPressed(context),
               onAvatarTap: (types.User user) {
-                showNotYetImplementedMsg(
+                customMsgSnackbar(
                   context,
                   'Chat Profile view is not implemented yet',
                 );

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/widgets/user_avatar.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -31,7 +31,7 @@ class Dashboard extends ConsumerWidget {
                 IconButton(
                   icon: const Icon(Atlas.settings_monitor_thin),
                   onPressed: () {
-                    showNotYetImplementedMsg(
+                    customMsgSnackbar(
                       context,
                       'Configuration Page for Dashboard not yet implemented',
                     );

--- a/app/lib/features/news/pages/news_builder_page.dart
+++ b/app/lib/features/news/pages/news_builder_page.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/utils/constants.dart';
+import 'package:acter/common/utils/routes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -21,8 +22,8 @@ class _NewsBuilderPageState extends ConsumerState<NewsBuilderPage> {
           child: StoriesEditor(
             giphyKey: giphyKey,
             onDone: (uri) {
-              debugPrint(uri);
-              context.push('/updates/post', extra: uri);
+              debugPrint('Post URI:$uri');
+              context.pushNamed(Routes.updatesPost.name, extra: uri);
             },
             middleBottomWidget: const BottomWidget(),
             onDoneButtonStyle: const DoneButton(),

--- a/app/lib/features/news/pages/news_page.dart
+++ b/app/lib/features/news/pages/news_page.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/constants.dart';
+import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/news/widgets/news_widget.dart';
 import 'package:acter_avatar/acter_avatar.dart';
@@ -76,7 +77,7 @@ class NewsPage extends ConsumerWidget {
             child: IconButton(
               /// [GoRouter] use context.push() for preserving states
               /// of previous route and context.go() for vice versa.
-              onPressed: () => context.push('/updates/edit'),
+              onPressed: () => context.pushNamed(Routes.updatesEdit.name),
               icon: Icon(
                 Atlas.plus_circle_thin,
                 color: Theme.of(context).colorScheme.neutral5,

--- a/app/lib/features/news/pages/post_page.dart
+++ b/app/lib/features/news/pages/post_page.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
 
+import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/space/providers/space_providers.dart';
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/custom_app_bar.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -28,7 +29,6 @@ class _PostPageState extends ConsumerState<PostPage> {
 
   @override
   Widget build(BuildContext context) {
-    final client = ref.watch(clientProvider)!;
     final selectedSpace = ref.watch(selectedSpaceProvider);
     // pre-fetch spaces prior to selection
     ref.watch(searchSpaceProvider);
@@ -104,23 +104,36 @@ class _PostPageState extends ConsumerState<PostPage> {
               ),
               const Divider(indent: 10, endIndent: 10),
               GestureDetector(
-                onTap: () => context.push('/updates/post/search_space'),
+                onTap: () => context.pushNamed(Routes.updatesPostSearch.name),
                 child: Padding(
                   padding: const EdgeInsets.all(8),
                   child: Wrap(
                     spacing: 10,
                     crossAxisAlignment: WrapCrossAlignment.center,
                     children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 5),
-                        child: ActerAvatar(
-                          mode: DisplayMode.Space,
-                          uniqueId: client.userId().toString(),
-                          avatar:
-                              selectedSpace?.spaceProfileData.getAvatarImage(),
-                          size: 36,
-                        ),
-                      ),
+                      selectedSpace != null
+                          ? Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 5),
+                              child: ActerAvatar(
+                                mode: DisplayMode.Space,
+                                uniqueId: selectedSpace.roomId,
+                                avatar: selectedSpace.spaceProfileData
+                                    .getAvatarImage(),
+                                size: 36,
+                                displayName:
+                                    selectedSpace.spaceProfileData.displayName,
+                              ),
+                            )
+                          : Container(
+                              height: 36,
+                              width: 36,
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.neutral5,
+                                shape: BoxShape.rectangle,
+                                borderRadius: BorderRadius.circular(5),
+                              ),
+                            ),
                       Text(
                         selectedSpace != null
                             ? selectedSpace.spaceProfileData.displayName!
@@ -218,7 +231,10 @@ class _PostPageState extends ConsumerState<PostPage> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
               ElevatedButton(
-                onPressed: () {},
+                onPressed: () => customMsgSnackbar(
+                  context,
+                  'Save to Draft is not implemented yet',
+                ),
                 child: Text(
                   'Save to Draft',
                   style: Theme.of(context).textTheme.bodyMedium,
@@ -240,7 +256,10 @@ class _PostPageState extends ConsumerState<PostPage> {
               ElevatedButton(
                 onPressed: () => ref.read(selectedSpaceProvider) != null
                     ? handlePost(context, mounted)
-                    : null,
+                    : customMsgSnackbar(
+                        context,
+                        'Please select space to continue',
+                      ),
                 child: Text(
                   'Post',
                   style: Theme.of(context).textTheme.bodyMedium,
@@ -335,9 +354,5 @@ class _PostPageState extends ConsumerState<PostPage> {
         ),
       );
     }
-  }
-
-  void handleDraft(SpaceItem? selectedSpace) {
-    showNotYetImplementedMsg(context, "'Save to Draft' is not implemented yet");
   }
 }

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/like_button.dart';
 import 'package:acter/common/widgets/user_avatar.dart';

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -286,7 +286,7 @@ class _NewsSideBarState extends State<NewsSideBar> {
                           ),
                           IconButton(
                             onPressed: () {
-                              showNotYetImplementedMsg(
+                              customMsgSnackbar(
                                 context,
                                 'Send not yet implemented',
                               );
@@ -358,7 +358,7 @@ class _ProfileImageWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        showNotYetImplementedMsg(context, 'Profile Action not yet implemented');
+        customMsgSnackbar(context, 'Profile Action not yet implemented');
       },
       child: CachedNetworkImage(
         imageUrl:

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -1,5 +1,5 @@
 import 'package:acter/common/providers/common_providers.dart';
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -20,7 +20,7 @@ class MyProfile extends ConsumerWidget {
             IconButton(
               icon: const Icon(Atlas.pencil_edit_thin),
               onPressed: () {
-                showNotYetImplementedMsg(
+                customMsgSnackbar(
                   context,
                   'Profile Edit page not yet implemented',
                 );

--- a/app/lib/features/todo/pages/task_detail_page.dart
+++ b/app/lib/features/todo/pages/task_detail_page.dart
@@ -1,4 +1,4 @@
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/todo/controllers/todo_controller.dart';
 import 'package:acter/models/ToDoComment.dart';
@@ -838,7 +838,7 @@ class _SubscribersWidget extends StatelessWidget {
             style: Theme.of(context).textTheme.bodySmall,
           ),
           InkWell(
-            onTap: () => showNotYetImplementedMsg(
+            onTap: () => customMsgSnackbar(
               context,
               'Subscriber Screen not yet implemented',
             ),

--- a/app/lib/features/todo/pages/todo_mine_page.dart
+++ b/app/lib/features/todo/pages/todo_mine_page.dart
@@ -1,4 +1,4 @@
-import 'package:acter/common/snackbars/not_implemented.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/features/todo/pages/assignments_page.dart';
 import 'package:acter/features/todo/pages/recent_activity_page.dart';
 import 'package:acter/features/todo/pages/bookmarks_page.dart';
@@ -70,7 +70,7 @@ class _ToDoMinePageState extends State<ToDoMinePage> {
         ),
         ListTile(
           onTap: () {
-            showNotYetImplementedMsg(
+            customMsgSnackbar(
               context,
               'Upcoming events is not yet Implemented',
             );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -40,12 +40,6 @@ Future<void> startAppInner() async {
     final license = await rootBundle.loadString('google_fonts/LICENSE.txt');
     yield LicenseEntryWithLineBreaks(['google_fonts'], license);
   });
-  final sdk = await ActerSdk.instance;
-  PlatformDispatcher.instance.onError = (exception, stackTrace) {
-    sdk.writeLog(exception.toString(), 'error');
-    sdk.writeLog(stackTrace.toString(), 'error');
-    return true; // make this error handled
-  };
   runApp(const ProviderScope(child: Acter()));
 }
 

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -7,7 +7,10 @@ import 'package:acter/features/chat/pages/chat_page.dart';
 import 'package:acter/features/gallery/pages/gallery_page.dart';
 import 'package:acter/features/home/pages/dashboard.dart';
 import 'package:acter/features/home/pages/home_shell.dart';
+import 'package:acter/features/news/pages/news_builder_page.dart';
 import 'package:acter/features/news/pages/news_page.dart';
+import 'package:acter/features/news/pages/post_page.dart';
+import 'package:acter/features/news/pages/search_space_page.dart';
 import 'package:acter/features/onboarding/pages/login_page.dart';
 import 'package:acter/features/onboarding/pages/register_page.dart';
 import 'package:acter/features/onboarding/pages/start_page.dart';
@@ -175,9 +178,50 @@ final routes = [
             child: const NewsPage(),
           );
         },
+        routes: <RouteBase>[
+          // hide bottom nav for nested pages, use rootNavigatorKey
+          GoRoute(
+            parentNavigatorKey: rootNavigatorKey,
+            name: Routes.updatesEdit.name,
+            path: Routes.updatesEdit.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const NewsBuilderPage(),
+              );
+            },
+          ),
+          GoRoute(
+            parentNavigatorKey: rootNavigatorKey,
+            name: Routes.updatesPost.name,
+            path: Routes.updatesPost.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: PostPage(
+                  attachmentUri: state.extra as String?,
+                ),
+              );
+            },
+            routes: <RouteBase>[
+              GoRoute(
+                parentNavigatorKey: rootNavigatorKey,
+                name: Routes.updatesPostSearch.name,
+                path: Routes.updatesPostSearch.route,
+                redirect: authGuardRedirect,
+                pageBuilder: (context, state) {
+                  return NoTransitionPage(
+                    key: state.pageKey,
+                    child: const SearchSpacePage(),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
       ),
-
-      
 
       GoRoute(
         name: Routes.search.name,


### PR DESCRIPTION
- Add missing nested routes for news (Updates) navigation. This can only be tested on mobile devices.
- ```notYetImplementedMsg``` has been renamed to ```customMsgSnackbar``` as to support generic cases.