### PR TITLE
Support registration-token driven UI-test

### DIFF
--- a/app/integration_test/steps/given_login.dart
+++ b/app/integration_test/steps/given_login.dart
@@ -3,6 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gherkin/flutter_gherkin.dart';
 import 'package:acter/common/utils/constants.dart';
 
+const registrationToken = String.fromEnvironment(
+  'REGISTRATION_TOKEN',
+  defaultValue: '',
+);
+
 StepDefinitionGeneric givenWellKnownUserIsLoggedIn() {
   return given1<String, FlutterWorld>(
     r'(kyra|sisko|odo) has logged in',
@@ -22,6 +27,12 @@ StepDefinitionGeneric givenWellKnownUserIsLoggedIn() {
 
       // await context.world.appDriver.tap(sidebar);
       // await context.world.appDriver.waitForAppToSettle();
+      var passwordText;
+      if (registrationToken.isNotEmpty) {
+        passwordText = registrationToken + ':' + username;
+      } else {
+        passwordText = username;
+      }
 
       Finder skip = find.byKey(Keys.skipBtn);
       context.expect(skip, findsOneWidget);
@@ -43,7 +54,7 @@ StepDefinitionGeneric givenWellKnownUserIsLoggedIn() {
       Finder password = find.byKey(LoginPageKeys.passwordField);
       context.expect(password, findsOneWidget);
 
-      await context.world.appDriver.enterText(password, username);
+      await context.world.appDriver.enterText(password, passwordText);
 
       Finder submitBtn = find.byKey(LoginPageKeys.submitBtn);
       context.expect(submitBtn, findsOneWidget);

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -900,7 +900,7 @@ class Api {
     String registrationToken,
     String defaultHomeserverName,
     String defaultHomeserverUrl,
-    String? deviceName,
+    String deviceName,
   ) {
     final tmp0 = basepath;
     final tmp4 = username;
@@ -928,9 +928,8 @@ class Api {
     var tmp22 = 0;
     var tmp23 = 0;
     var tmp25 = 0;
+    var tmp26 = 0;
     var tmp27 = 0;
-    var tmp28 = 0;
-    var tmp29 = 0;
     final tmp0_0 = utf8.encode(tmp0);
     tmp2 = tmp0_0.length;
     final ffi.Pointer<ffi.Uint8> tmp1_0 = this.__allocate(tmp2 * 1, 1);
@@ -973,20 +972,14 @@ class Api {
     tmp21_1.setAll(0, tmp20_0);
     tmp21 = tmp21_0.address;
     tmp23 = tmp22;
-    if (tmp24 == null) {
-      tmp25 = 0;
-    } else {
-      tmp25 = 1;
-      final tmp26 = tmp24;
-      final tmp26_0 = utf8.encode(tmp26);
-      tmp28 = tmp26_0.length;
-      final ffi.Pointer<ffi.Uint8> tmp27_0 = this.__allocate(tmp28 * 1, 1);
-      final Uint8List tmp27_1 = tmp27_0.asTypedList(tmp28);
-      tmp27_1.setAll(0, tmp26_0);
-      tmp27 = tmp27_0.address;
-      tmp29 = tmp28;
-    }
-    final tmp30 = _registerWithToken(
+    final tmp24_0 = utf8.encode(tmp24);
+    tmp26 = tmp24_0.length;
+    final ffi.Pointer<ffi.Uint8> tmp25_0 = this.__allocate(tmp26 * 1, 1);
+    final Uint8List tmp25_1 = tmp25_0.asTypedList(tmp26);
+    tmp25_1.setAll(0, tmp24_0);
+    tmp25 = tmp25_0.address;
+    tmp27 = tmp26;
+    final tmp28 = _registerWithToken(
       tmp1,
       tmp2,
       tmp3,
@@ -1006,16 +999,15 @@ class Api {
       tmp22,
       tmp23,
       tmp25,
+      tmp26,
       tmp27,
-      tmp28,
-      tmp29,
     );
-    final tmp32 = tmp30;
-    final ffi.Pointer<ffi.Void> tmp32_0 = ffi.Pointer.fromAddress(tmp32);
-    final tmp32_1 = _Box(this, tmp32_0, "__register_with_token_future_drop");
-    tmp32_1._finalizer = this._registerFinalizer(tmp32_1);
-    final tmp31 = _nativeFuture(tmp32_1, this.__registerWithTokenFuturePoll);
-    return tmp31;
+    final tmp30 = tmp28;
+    final ffi.Pointer<ffi.Void> tmp30_0 = ffi.Pointer.fromAddress(tmp30);
+    final tmp30_1 = _Box(this, tmp30_0, "__register_with_token_future_drop");
+    tmp30_1._finalizer = this._registerFinalizer(tmp30_1);
+    final tmp29 = _nativeFuture(tmp30_1, this.__registerWithTokenFuturePoll);
+    return tmp29;
   }
 
   EfkDuration durationFromSecs(
@@ -7334,7 +7326,6 @@ class Api {
     ffi.Int64,
     ffi.Uint64,
     ffi.Uint64,
-    ffi.Uint8,
     ffi.Int64,
     ffi.Uint64,
     ffi.Uint64,
@@ -7342,7 +7333,6 @@ class Api {
 
   late final _registerWithToken = _registerWithTokenPtr.asFunction<
       int Function(
-    int,
     int,
     int,
     int,

--- a/docs/content/docs/dev/testing.md
+++ b/docs/content/docs/dev/testing.md
@@ -40,12 +40,21 @@ flutter test
 
 ### Infrastructure
 
-You need a fresh [`synapse` matrix backend](https://matrix-org.github.io/synapse/latest/) with a specific configuration. We recommend to just use our docker-compose setup for that:
+You need a fresh [`synapse` matrix backend](https://matrix-org.github.io/synapse/latest/) with a specific configuration. We recommend to just use our docker-compose setup for that to run them locally - for an installation guide see below. As a team member with access to bitwarden, you can also run them against the stageing / testing instances (see below).
 
 #### Docker Container
 
 We have a `docker` container image available with that setup already for you at `lightyear/acter-synapse-ci:latest`. Easiest is to use `docker-compose up -d` to run it locally from the root directory. This will also create the necessary `admin` account.
 
+**Alternatives**
+
+<details>
+<summary><strong>Using the shared testing servers</strong></summary>
+
+If you are a team member with access to bitwarden, you can also use the staging and testing instances we have set up. They registered with a registration token to prevent unauthorized access, which are also prefixed to each password and thus need to be supplied for running the tests. Currently the following servers are available for testing with mock-data pre-installed, the registration tokens can be found in bitwarden under the same name.
+
+- **`m-1.acter.global`** (`export DEFAULT_HOMESERVER_URL=https://matrix.m-1.acter.global DEFAULT_HOMESERVER_NAME=m-1.acter.global`)
+</details>
 <details>
 <summary><strong>Custom Synapse-Server</strong></summary>
 
@@ -406,9 +415,11 @@ Flutter integration tests can be found `app/integration_test/features`. We use (
 
 To run the rust integration tests, you need a fresh integration testing infrastructure (see above) available at `$DEFAULT_HOMESERVER_URL` with the `$DEFAULT_HOMESERVER_NAME` set. The following will build the App and run the tests with on the default target (or you specify it via `-d`, e.g. `-d linux` or `-d windows`).
 
+_Reminder_: If running against the testing/staging server, you need the registration token from Bitwarden to access the server.
+
 ```
 cd app
-flutter test integration_test/gherkin_suite_test.dart --dart-define DEFAULT_HOMESERVER_URL=$DEFAULT_HOMESERVER_URL --dart-define DEFAULT_HOMESERVER_NAME=$DEFAULT_HOMESERVER_NAME
+flutter test integration_test/gherkin_suite_test.dart --dart-define DEFAULT_HOMESERVER_URL=$DEFAULT_HOMESERVER_URL --dart-define DEFAULT_HOMESERVER_NAME=$DEFAULT_HOMESERVER_NAME --dart-define REGISTRATION_TOKEN=$REGISTRATION_TOKEN
 ```
 
 **From Visual Studio Code**

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -17,7 +17,7 @@ fn login_with_token(basepath: string, restore_token: string) -> Future<Result<Cl
 fn guest_client(basepath: string, default_homeserver_name: string, default_homeserver_url: string, device_name: Option<string>) -> Future<Result<Client>>;
 
 /// Create a new client from the registration token
-fn register_with_token(basepath: string, username: string, password: string, registration_token: string, default_homeserver_name: string, default_homeserver_url: string, device_name: Option<string>) -> Future<Result<Client>>;
+fn register_with_token(basepath: string, username: string, password: string, registration_token: string, default_homeserver_name: string, default_homeserver_url: string, device_name: string) -> Future<Result<Client>>;
 
 /// Representing a time frame
 object EfkDuration {}

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -46,7 +46,12 @@ pub use acter_core::{
 };
 pub use auth::{
     guest_client, login_new_client, login_new_client_under_config, login_with_token,
-    login_with_token_under_config, make_client_config, register_with_token,
+    make_client_config, register_with_token,
+};
+
+pub(crate) use auth::{
+    login_with_token_under_config, register_under_config, register_with_token_under_config,
+    sanatize_user,
 };
 pub use calendar_events::CalendarEvent;
 pub use client::{Client, ClientStateBuilder, HistoryLoadState, SyncState};

--- a/native/cli/src/config.rs
+++ b/native/cli/src/config.rs
@@ -6,8 +6,11 @@ use std::path::PathBuf;
 
 use crate::action::Action;
 
+pub const ENV_DEFAULT_HOMESERVER_URL: &str = "DEFAULT_HOMESERVER_URL";
+pub const ENV_DEFAULT_HOMESERVER_NAME: &str = "DEFAULT_HOMESERVER_NAME";
 pub const ENV_USER: &str = "ACTER_USER";
 pub const ENV_PASSWORD: &str = "ACTER_PASSWORD";
+pub const ENV_REG_TOKEN: &str = "ACTER_REGISTRATIOn_TOKEN";
 pub const ENV_ROOM: &str = "ACTER_ROOM";
 
 /// Generic Login Configuration helper
@@ -16,7 +19,7 @@ pub struct LoginConfig {
     /// the URL to the homeserver are we running against
     #[clap(
         long = "homeserver-url",
-        env = "DEFAULT_HOMESERVER_URL",
+        env = ENV_DEFAULT_HOMESERVER_URL,
         default_value = "http://localhost:8118"
     )]
     pub homeserver: String,
@@ -24,7 +27,7 @@ pub struct LoginConfig {
     /// name of that homeserver
     #[clap(
         long = "homeserver-name",
-        env = "DEFAULT_HOMESERVER_NAME",
+        env = ENV_DEFAULT_HOMESERVER_NAME,
         default_value = "localhost"
     )]
     pub server_name: String,
@@ -37,6 +40,13 @@ pub struct LoginConfig {
         env = ENV_USER
     )]
     login_username: String,
+
+    /// optional registration token
+    #[clap(
+        long = "registration=-token",
+        env = ENV_REG_TOKEN
+    )]
+    reg_token: Option<String>,
 
     #[clap(long="password", env = ENV_PASSWORD)]
     login_password: Option<String>,
@@ -90,7 +100,7 @@ impl LoginConfig {
         let client = login_new_client(
             base_path,
             username.clone(),
-            password,
+            self.reg_token.as_ref().map(|r| format!("{r}:{password}")).unwrap_or_else(|| password.clone()),
             self.server_name.clone(),
             self.homeserver.clone(),
             Some(format!("acter-cli/{}", crate_version!())),


### PR DESCRIPTION
With this patch merged, we can run the flutter UI integration tests against the publicly hosted synapse-matrix instances for testing. The server `m-1.acter.global` has the appropriate mock data and accounts set up and can be used from anywhere. Note that, in order to prevent spam and abuse, you need a registration token to register, which is also prefixed to all mock-account passwords - thus is also needed for each test run. See the docs for details.


Specifically this contains:

- Refactor the auth module for better registration and registration-token-driven registration support, make `testing` module reuse as much code as possible to ensure we are not diverging
- mock-cli update for registration token
- flutter integration tests update for registration-token support
- docs explaining it all.

