### PR TITLE
String deallocation fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "ffi-gen"
 version = "0.1.13"
-source = "git+https://github.com/acterglobal/ffi-gen#ac2761991b7b18038c02782dc7e26a7edf484b2d"
+source = "git+https://github.com/acterglobal/ffi-gen#403b64a7d23b66d0d618817abd47b9e78c6bfd93"
 dependencies = [
  "anyhow",
  "genco",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "ffi-gen-macro"
 version = "0.1.2"
-source = "git+https://github.com/acterglobal/ffi-gen#ac2761991b7b18038c02782dc7e26a7edf484b2d"
+source = "git+https://github.com/acterglobal/ffi-gen#403b64a7d23b66d0d618817abd47b9e78c6bfd93"
 dependencies = [
  "ffi-gen",
  "proc-macro2",

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -421,6 +421,11 @@ class FfiString {
     final parts = _api._ffiStringIntoParts(_box.borrow());
     final ffi.Pointer<ffi.Uint8> tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
     final tmp1 = utf8.decode(tmp2_0.asTypedList(parts.len));
+    if (parts.capacity > 0) {
+      final ffi.Pointer<ffi.Void> tmp2_0;
+      tmp2_0 = ffi.Pointer.fromAddress(parts.addr);
+      _api.__deallocate(tmp2_0, parts.capacity * 1, 1);
+    }
     return tmp1;
   }
 

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -185,7 +185,11 @@ impl RoomEventItem {
     }
 
     pub fn reaction_keys(&self) -> Vec<String> {
-        self.reactions.keys().cloned().collect()
+        let mut keys = vec![];
+        for key in self.reactions.keys() {
+            keys.push(String::from(key.to_owned()));
+        }
+        keys
     }
 
     pub fn reaction_desc(&self, key: String) -> Option<ReactionDesc> {

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -187,7 +187,7 @@ impl RoomEventItem {
     pub fn reaction_keys(&self) -> Vec<String> {
         let mut keys = vec![];
         for key in self.reactions.keys() {
-            keys.push(String::from(key.to_owned()));
+            keys.push(key.to_owned());
         }
         keys
     }

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -185,6 +185,9 @@ impl RoomEventItem {
     }
 
     pub fn reaction_keys(&self) -> Vec<String> {
+        // don't use cloned().
+        // create string vector to deallocate string item using toDartString().
+        // apply this way for only function that string vector is calculated indirectly.
         let mut keys = vec![];
         for key in self.reactions.keys() {
             keys.push(key.to_owned());

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -335,11 +335,19 @@ impl TaskList {
     }
 
     pub fn keywords(&self) -> Vec<String> {
-        self.content.keywords.clone()
+        let mut result = vec![];
+        for keyword in &self.content.keywords {
+            result.push(String::from(keyword.to_owned()));
+        }
+        result
     }
 
     pub fn categories(&self) -> Vec<String> {
-        self.content.categories.clone()
+        let mut result = vec![];
+        for category in &self.content.categories {
+            result.push(String::from(category.to_owned()));
+        }
+        result
     }
 
     pub fn space(&self) -> Space {
@@ -529,11 +537,19 @@ impl Task {
     }
 
     pub fn keywords(&self) -> Vec<String> {
-        self.content.keywords.clone()
+        let mut result = vec![];
+        for keyword in &self.content.keywords {
+            result.push(String::from(keyword.to_owned()));
+        }
+        result
     }
 
     pub fn categories(&self) -> Vec<String> {
-        self.content.categories.clone()
+        let mut result = vec![];
+        for category in &self.content.categories {
+            result.push(String::from(category.to_owned()));
+        }
+        result
     }
 }
 

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -337,7 +337,7 @@ impl TaskList {
     pub fn keywords(&self) -> Vec<String> {
         let mut result = vec![];
         for keyword in &self.content.keywords {
-            result.push(String::from(keyword.to_owned()));
+            result.push(keyword.to_owned());
         }
         result
     }
@@ -345,7 +345,7 @@ impl TaskList {
     pub fn categories(&self) -> Vec<String> {
         let mut result = vec![];
         for category in &self.content.categories {
-            result.push(String::from(category.to_owned()));
+            result.push(category.to_owned());
         }
         result
     }
@@ -539,7 +539,7 @@ impl Task {
     pub fn keywords(&self) -> Vec<String> {
         let mut result = vec![];
         for keyword in &self.content.keywords {
-            result.push(String::from(keyword.to_owned()));
+            result.push(keyword.to_owned());
         }
         result
     }
@@ -547,7 +547,7 @@ impl Task {
     pub fn categories(&self) -> Vec<String> {
         let mut result = vec![];
         for category in &self.content.categories {
-            result.push(String::from(category.to_owned()));
+            result.push(category.to_owned());
         }
         result
     }

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -335,6 +335,9 @@ impl TaskList {
     }
 
     pub fn keywords(&self) -> Vec<String> {
+        // don't use cloned().
+        // create string vector to deallocate string item using toDartString().
+        // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for keyword in &self.content.keywords {
             result.push(keyword.to_owned());
@@ -343,6 +346,9 @@ impl TaskList {
     }
 
     pub fn categories(&self) -> Vec<String> {
+        // don't use cloned().
+        // create string vector to deallocate string item using toDartString().
+        // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for category in &self.content.categories {
             result.push(category.to_owned());
@@ -537,6 +543,9 @@ impl Task {
     }
 
     pub fn keywords(&self) -> Vec<String> {
+        // don't use cloned().
+        // create string vector to deallocate string item using toDartString().
+        // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for keyword in &self.content.keywords {
             result.push(keyword.to_owned());
@@ -545,6 +554,9 @@ impl Task {
     }
 
     pub fn categories(&self) -> Vec<String> {
+        // don't use cloned().
+        // create string vector to deallocate string item using toDartString().
+        // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for category in &self.content.categories {
             result.push(category.to_owned());


### PR DESCRIPTION
Clone string item using `String::from()` to deallocate string with `toDartString()`.
Among the functions that returns `Vec<String>`, will apply this way for only functions that calculates string vector indirectly.
Will not touch the functions that fetches from direct property of crate.
![image](https://github.com/acterglobal/a3/assets/48786056/9effa026-46d5-4a61-80ac-564e56f679b6)
