### PR TITLE
conversations list improvements

### DIFF
--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -6,20 +6,18 @@ import 'package:acter/features/chat/models/invitation_profile.dart';
 import 'package:acter/features/chat/models/joined_room/joined_room.dart';
 import 'package:acter/features/chat/providers/notifiers/invitation_list_notifier.dart';
 import 'package:acter/features/chat/providers/notifiers/joined_room_notifier.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart'
     show Invitation, UserProfile, DispName;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // CHAT PAGE state provider
 final chatListProvider =
-    StateNotifierProvider.autoDispose<ChatListNotifier, ChatListState>((ref) {
-  final client = ref.watch(clientProvider);
-  return ChatListNotifier(ref, client: client!);
-});
+    StateNotifierProvider.autoDispose<ChatListNotifier, ChatListState>(
+  (ref) => ChatListNotifier(ref),
+);
 
 // Conversations List Provider (CHAT PAGE)
-final roomListProvider =
+final joinedRoomListProvider =
     StateNotifierProvider.autoDispose<JoinedRoomNotifier, List<JoinedRoom>>(
   (ref) => JoinedRoomNotifier(),
 );

--- a/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
@@ -124,7 +124,7 @@ class ChatListNotifier extends StateNotifier<ChatListState> {
       RoomId? currentRoomId = roomController.currentRoomId();
       if (currentRoomId == null) {
         // we are in chat list page
-        final List<JoinedRoom> tempState = roomList;
+        List<JoinedRoom> tempState = roomList;
         tempState[idx] = tempState[idx].copyWith(typingUsers: typingUsers);
         ref.read(joinedRoomListProvider.notifier).removeRoom(idx);
         ref

--- a/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
@@ -107,10 +107,10 @@ class ChatListNotifier extends StateNotifier<ChatListState> {
       }
       List<types.User> typingUsers = [];
       for (var userId in event.userIds()) {
-        // if (userId == client.userId()) {
-        //   // filter out my typing
-        //   continue;
-        // }
+        if (userId == client.userId()) {
+          // filter out my typing
+          continue;
+        }
         String uid = userId.toString();
         var user = types.User(
           id: uid,

--- a/app/lib/features/chat/providers/notifiers/joined_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/joined_room_notifier.dart
@@ -23,17 +23,20 @@ class JoinedRoomNotifier extends StateNotifier<List<JoinedRoom>> {
 
   void sortRooms() {
     List<JoinedRoom> tempState = state;
+    // rooms could contain RoomMessage as null, so handle null values differently.
     tempState.sort((a, b) {
-      if (a.latestMessage != null && b.latestMessage != null) {
+      if (a.latestMessage == null) {
+        return 1;
+      }
+      if (b.latestMessage == null) {
+        return -1;
+      } else {
         return b.latestMessage!
             .eventItem()!
             .originServerTs()
             .compareTo(a.latestMessage!.eventItem()!.originServerTs());
-      } else {
-        return 0;
       }
     });
-    tempState.reversed;
     state = tempState;
   }
 

--- a/app/lib/features/chat/providers/notifiers/receipt_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/receipt_notifier.dart
@@ -5,22 +5,20 @@ import 'package:acter/features/chat/models/receipt_user.dart';
 import 'package:acter/features/chat/models/reciept_room/receipt_room.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 
-class ReceiptNotifier extends StateNotifier<ReceiptRoom?> {
+class ReceiptNotifier extends StateNotifier<ReceiptRoom> {
   final Ref ref;
   final Map<RoomId, ReceiptRoom> _rooms = {};
-  ReceiptNotifier(this.ref) : super(null) {
+  ReceiptNotifier(this.ref) : super(const ReceiptRoom(users: {})) {
     _init();
   }
 
   void _init() {
-    final client = ref.read(clientProvider);
-    state = const ReceiptRoom(users: {});
+    final client = ref.read(clientProvider)!;
     StreamSubscription<ReceiptEvent>? _subscription;
-    _subscription = client?.receiptEventRx()?.listen((event) {
+    _subscription = client.receiptEventRx()?.listen((event) {
       String myId = client.userId().toString();
       RoomId roomId = event.roomId();
       bool changed = false;
@@ -45,7 +43,7 @@ class ReceiptNotifier extends StateNotifier<ReceiptRoom?> {
   }
 
   void updateUser(String userId, String eventId, int? ts) {
-    final Map<String, ReceiptUser> receiptUsers = state!.users;
+    Map<String, ReceiptUser> receiptUsers = state.users;
     if (receiptUsers.containsKey(userId)) {
       receiptUsers[userId]!.eventId = eventId;
       if (ts != null) {
@@ -55,16 +53,15 @@ class ReceiptNotifier extends StateNotifier<ReceiptRoom?> {
       receiptUsers[userId] =
           ReceiptUser(userId: userId, eventId: eventId, ts: ts);
     }
-    state = state!.copyWith(users: receiptUsers);
+    state = state.copyWith(users: receiptUsers);
   }
 
   ReceiptRoom _getRoom(RoomId roomId) {
-    if (state!.users.containsKey(roomId)) {
+    if (state.users.containsKey(roomId)) {
       return _rooms[roomId]!;
     }
     var room = const ReceiptRoom();
     _rooms[roomId] = room;
-    debugPrint('$_rooms');
     return room;
   }
 

--- a/app/lib/features/chat/widgets/conversation_list.dart
+++ b/app/lib/features/chat/widgets/conversation_list.dart
@@ -16,8 +16,8 @@ class ConversationsList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final chatList = ref.watch(chatListProvider);
-    final joinedRooms = ref.watch(roomListProvider);
-    return !chatList.initialLoaded
+    final joinedRooms = ref.watch(joinedRoomListProvider);
+    return !ref.watch(chatListProvider.select((e) => e.initialLoaded))
         ? Center(
             heightFactor: 10,
             child: Column(

--- a/app/lib/features/chat/widgets/invitation_card.dart
+++ b/app/lib/features/chat/widgets/invitation_card.dart
@@ -65,7 +65,7 @@ class InvitationCard extends ConsumerWidget {
                     child: ElevatedButton(
                       onPressed: () async {
                         if (await invitation.accept() == true) {
-                          final joinedRooms = ref.watch(roomListProvider);
+                          final joinedRooms = ref.watch(joinedRoomListProvider);
                           for (var room in joinedRooms) {
                             if (room.conversation.getRoomId() ==
                                 invitation.roomId()) {


### PR DESCRIPTION
### PR Description:
- Simplify ```chatListProvider```.
- Earlier we were fetching conversations list based on calling future provider ```chatsProvider```. However ```Conversations.latestMessage()``` object is giving null for all conversations (FIXME added), causing messages to not show. The conversations stream, on the other hand, fetches fresh conversation list so it made sense to just apply that and stream conversation ```latestMessage()``` doesn't give null value in all cases.
- Added delay between fetching and sorting rooms, so we get updated provider data.
- Regarding sorting rooms, since we could get null value  in ```RoomMessage```, sorting on rooms based on timestamps has been modified to handle null cases and position null case rooms at the end.
- Fix ```ReceiptUsers``` modification exception. 
- Renamed ```roomListProvider``` to ```joinedRoomListProvider``` for better understanding.