### PR TITLE
Update NDK to r25, cargo-ndk to 3.2, unbreak Android

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -34,7 +34,7 @@ jobs:
           #   os: ubuntu-latest
           #   cargo_make_setup: setup-android
           #   cargo_make_args: android-arm
-          #   with_ndk_version: r22b
+          #   with_ndk_version: r23c
           #   flutter_build_args: 'build apk --target-platform android-arm64'
           #   artifact_prefix: acter-demo-android-arm64
           #   artifact_path:  app/build/app/outputs/apk/release/

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Check legibility
     outputs:
-      should_run: ${{steps.PR.outputs.pr_found == "true" && contains(steps.PR.outputs.pr_labels, "build-demo")}}
+      should_run: ${{steps.PR.outputs.pr_found == 'true' && contains(steps.PR.outputs.pr_labels, 'build-demo')}}
     steps:
       - uses: 8BitJonny/gh-get-current-pr@2.2.0
-        id: pr
+        id: PR
         with:
           # Only return if PR is still open. (By default it returns PRs in any state.)
           filterOutClosed: true
@@ -34,7 +34,7 @@ jobs:
           #   os: ubuntu-latest
           #   cargo_make_setup: setup-android
           #   cargo_make_args: android-arm
-          #   with_ndk_version: r23c
+          #   with_ndk_version: r25
           #   flutter_build_args: 'build apk --target-platform android-arm64'
           #   artifact_prefix: acter-demo-android-arm64
           #   artifact_path:  app/build/app/outputs/apk/release/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r22b
+          ndk-version: r25
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
       - run: cargo make setup-android

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
             os: ubuntu-latest
             cargo_make_setup: setup-android
             cargo_make_args: android-arm
-            with_ndk_version: r22b
+            with_ndk_version: r25
             flutter_build_args: "build apk --target-platform android-arm64"
             artifact_prefix: acter-nightly-android-arm64
             artifact_path:  app/build/app/outputs/apk/release/

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,7 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = ["native/acter"]
-ANDROID_PLATFORM_VERSION = "28"
+ANDROID_PLATFORM_VERSION = "23"
 TARGET_PLUGIN = "app/packages/rust_sdk"
 LIB_OUT_DIR = "debug"
 TARGET_OS = "unknown"
@@ -16,7 +16,7 @@ LIB_OUT_DIR = "release"
 [tasks.setup-android]
 # set up the system for android
 script = [
-    "cargo install cargo-ndk@2.12.7",
+    "cargo install cargo-ndk@3.2.0",
 ]
 
 [tasks.setup-ios]
@@ -270,7 +270,6 @@ args = [
     "--target",
     "${ANDROID_BUILD_TARGET}",
     "build",
-    "-Zbuild-std",
 ]
 
 [tasks.android-build-release]
@@ -284,7 +283,6 @@ args = [
     "--target",
     "${ANDROID_BUILD_TARGET}",
     "build",
-    "-Zbuild-std",
     "--release"
 ]
 

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -27,15 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion flutter.compileSdkVersion
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
+    ndkVersion "25.2.9519653"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/app/packages/rust_sdk/android/build.gradle
+++ b/app/packages/rust_sdk/android/build.gradle
@@ -27,15 +27,6 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/docs/content/docs/getting-started/setup.md
+++ b/docs/content/docs/getting-started/setup.md
@@ -10,13 +10,13 @@ toc = true
 top = false
 +++
 
-
 ## Requirements
 
 You'll need a recent:
- - [Rustup](https://rustup.rs/) setup for Rust
- - Android NDK / XCode setup for the target - and device or simulator set up
- - [flutter](https://docs.flutter.dev/get-started/install)
+
+- [Rustup](https://rustup.rs/) setup for Rust
+- Android NDK / XCode setup for the target - and device or simulator set up
+- [flutter](https://docs.flutter.dev/get-started/install)
 
 ## Setup
 

--- a/docs/content/docs/getting-started/troubleshooting.md
+++ b/docs/content/docs/getting-started/troubleshooting.md
@@ -12,21 +12,7 @@ top = false
 
 ## NDK compile error
 
-The current system has a problem with the latest android native development kit (NDK), please downgrade to version r22.\* - then things should be fine.
-
-### libgcc issue
-
-Android NDK missed `libgcc.a` from linking stage since `r25`.
-Rust standard library uses `libgcc` for its unwinder implementation on Android, but `libgcc` is not included in new versions of the NDK.
-Without sqlite, rust build works well under `ndk r24` and `cargo-ndk v3.1.2`.
-
-### SQLite issue on android x86_64 architecture
-
-`matrix-sdk-sqlite` is the alternative of `matrix-sdk-sled`.
-Acording to [this document](https://github.com/mozilla/rust-android-gradle/issues/105), SQLite uses `long double` type but rust doesn't support it.
-Not only `rust 1.70` but also `rust 1.68` doesn't support `long double` on x86_64 architecture.
-Android NDK r22 supports `long double` type for rust, so we will use `ndk r22` and `cargo-ndk v2.12.7`.
-When you built on `ndk r23`, you will get this runtime error `dlopen failed: cannot locate symbol "__extenddftf2" referenced by "/data/app/global.acter.a3-1/lib/x86_64/libacter.so"...`.
+The setup required NDK of 25 and `cargo-ndk > 3.0`. It has been tested and its nightly is built against `25.2.9519653` with `cargo-ndk 3.2.0`.
 
 ## Android Build in Windows
 
@@ -83,6 +69,7 @@ The compile command of release build is the following:
 ## Resolving flutter package `intl 0.18` fails
 
 If you see
+
 ```
 Resolving dependencies...
 Because acter depends on flutter_localizations from sdk which depends on intl 0.18.0, intl 0.18.0 is required.


### PR DESCRIPTION
Since nightly-2023-06-10 the built for Android wasn't properly working, caused by us dropping the NDK version to below r23c. This updates to latest NDK 25 (so you might have to install that via the Android platform tools) and uses the cargo-ndk 3.2 series (which you might want to install, too with `cargo make setup-android`) to built the library again.

To fix the `-lgcc` problem that came from the previous update including the new `sqlite`-feature, we had to drop the `-Zbuild-std` from `cargo-ndk` and instead include the prebuilt android SDK so that libsqlite can piggy back off that. Unfortunately, `-Zbuild-std` was a useful optimisation which decreased the built size a lot (around 40mb for the entire App before is now 111mb) , so we want to get back to it when we can. But for now it is more important to get android nightly to work again.