### PR TITLE
Trigger first-sync before refreshing all history

### DIFF
--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -61,8 +61,6 @@ class _HomeShellState extends ConsumerState<HomeShell> {
     final location =
         ref.watch(goRouterProvider.select((value) => value.location));
     final client = ref.watch(clientProvider);
-    final clientState = ref.watch(clientProvider.notifier);
-    final loading = !clientState.hasFirstSynced;
     if (client == null) {
       return const Scaffold(
         body: Center(
@@ -70,6 +68,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
         ),
       );
     }
+    final hasFirstSynced = ref.watch(syncStateProvider);
     final bottomBarIdx =
         ref.watch(currentSelectedBottomBarIndexProvider(context));
 
@@ -87,7 +86,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
           child: AdaptiveLayout(
             key: _key,
             bodyRatio: bodyRatio,
-            topNavigation: loading
+            topNavigation: !hasFirstSynced
                 ? SlotLayout(
                     config: <Breakpoint, SlotLayoutConfig?>{
                       Breakpoints.smallAndUp: SlotLayout.from(

--- a/app/lib/features/home/providers/client_providers.dart
+++ b/app/lib/features/home/providers/client_providers.dart
@@ -1,7 +1,13 @@
 import 'package:acter/features/home/providers/notifiers/client_notifier.dart';
+import 'package:acter/features/home/providers/notifiers/sync_state.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart' show Client;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final clientProvider = StateNotifierProvider<ClientNotifier, Client?>(
   (ref) => ClientNotifier(ref),
 );
+
+final syncStateProvider = StateNotifierProvider<SyncNotifier, bool>((ref) {
+  final client = ref.watch(clientProvider);
+  return SyncNotifier(client!);
+});

--- a/app/lib/features/home/providers/notifiers/client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/client_notifier.dart
@@ -1,21 +1,16 @@
-import 'package:acter/features/chat/controllers/chat_room_controller.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:get/get.dart';
 
 // ignore_for_file: avoid_print
 class ClientNotifier extends StateNotifier<Client?> {
-  late SyncState syncState;
-  bool hasFirstSynced = false;
-
   ClientNotifier(Ref ref) : super(null) {
     _loadUp(ref);
   }
 
-  Future<ActerSdk> _loadUp(Ref ref) async {
+  Future<void> _loadUp(Ref ref) async {
     final asyncSdk = await ref.watch(sdkProvider.future);
     PlatformDispatcher.instance.onError = (exception, stackTrace) {
       asyncSdk.writeLog(exception.toString(), 'error');
@@ -23,27 +18,5 @@ class ClientNotifier extends StateNotifier<Client?> {
       return true; // make this error handled
     };
     state = asyncSdk.currentClient;
-    if (state != null || !state!.isGuest()) {
-      print('starting sync loop');
-      Get.put(ChatRoomController(client: state!));
-      // Get.put(ReceiptController(client: state!));
-      // on release we have a really weird behavior, where, if we schedule
-      // any async call in rust too early, they just pend forever. this
-      // hack unfortunately means we have two wait a bit but that means
-      // we get past the threshold where it is okay to schedule...
-      await Future.delayed(const Duration(milliseconds: 1500));
-      syncState = state!.startSync();
-      print('sync started');
-      final firstSyncer = syncState.firstSyncedRx();
-      print(firstSyncer != null);
-      firstSyncer!.forEach((event) {
-        print('first sync received: $event');
-        if (event) {
-          print('first synced received');
-          hasFirstSynced = true;
-        }
-      });
-    }
-    return asyncSdk;
   }
 }

--- a/app/lib/features/home/providers/notifiers/sync_state.dart
+++ b/app/lib/features/home/providers/notifiers/sync_state.dart
@@ -1,0 +1,31 @@
+import 'package:acter/features/chat/controllers/chat_room_controller.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get/get.dart';
+
+// ignore_for_file: avoid_print
+class SyncNotifier extends StateNotifier<bool> {
+  late SyncState syncState;
+  late Stream<bool>? syncPoller;
+
+  SyncNotifier(Client client) : super(false) {
+    startSync(client);
+  }
+
+  Future<void> startSync(Client client) async {
+    Get.put(ChatRoomController(client: client));
+    // Get.put(ReceiptController(client: state!));
+    // on release we have a really weird behavior, where, if we schedule
+    // any async call in rust too early, they just pend forever. this
+    // hack unfortunately means we have two wait a bit but that means
+    // we get past the threshold where it is okay to schedule...
+    await Future.delayed(const Duration(milliseconds: 1500));
+    syncState = client.startSync();
+    final syncPoller = syncState.firstSyncedRx();
+    syncPoller!.listen((event) {
+      if (event) {
+        state = true;
+      }
+    });
+  }
+}

--- a/app/lib/features/onboarding/providers/notifiers/auth_notifier.dart
+++ b/app/lib/features/onboarding/providers/notifiers/auth_notifier.dart
@@ -22,7 +22,6 @@ class AuthStateNotifier extends StateNotifier<bool> {
       final client = await sdk.login(username, password);
       ref.read(isLoggedInProvider.notifier).update((state) => !state);
       ref.watch(clientProvider.notifier).state = client;
-      ref.watch(clientProvider.notifier).syncState = client.startSync();
       // inject chat dependencies once actual client is logged in.
       Get.replace(ChatRoomController(client: client));
       // Get.replace(ReceiptController(client: client));


### PR DESCRIPTION
This revamps the first-sync-state manager in two significant ways:
1. it is its own StateNotifier with proper observability now
2. the firstSyncedRx doesn't wait for the (potentially never ending) refresh_history_on_start before triggering but happens before now.