### PR TITLE
Filter out left spaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "acter",
  "acter-core",
  "anyhow",
+ "async-broadcast",
  "env_logger",
  "futures",
  "log",

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1232,7 +1232,7 @@ object Client {
     fn create_acter_space(settings: CreateSpaceSettings) -> Future<Result<RoomId>>;
 
     /// listen to updates to any model key
-    fn subscribe(key: string) -> Stream<bool>;
+    fn subscribe(key: string) -> Stream<()>;
 
     /// Fetch the Comment or use its event_id to wait for it to come down the wire
     fn wait_for_comment(key: string, timeout: Option<EfkDuration>) -> Future<Result<Comment>>;

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -443,12 +443,12 @@ impl Client {
                     } else {
                         // see if we have new spaces to catch up upon
                         let mut new_spaces = Vec::new();
-                        for (room_id, _) in &response.rooms.join {
-                            if sync_state_history.lock_mut().knows_room(&room_id) {
+                        for room_id in response.rooms.join.keys() {
+                            if sync_state_history.lock_mut().knows_room(room_id) {
                                 // we are already loading this room
                                 continue;
                             }
-                            let Some(full_room) = me.get_room(&room_id) else {
+                            let Some(full_room) = me.get_room(room_id) else {
                                 tracing::warn!("room not found. how can that be?");
                                 continue;
                             };
@@ -469,7 +469,7 @@ impl Client {
                         .keys()
                         .chain(response.rooms.leave.keys())
                         .chain(response.rooms.invite.keys())
-                        .map(|id| format!("SPACE::{}", id))
+                        .map(|id| id.to_string()) // FIXME: handle aliases, too?!?
                         .collect::<Vec<_>>();
 
                     if (!changed_rooms.is_empty()) {

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -522,8 +522,8 @@ impl Client {
             .context("Room not found")
     }
 
-    pub fn subscribe(&self, key: String) -> impl Stream<Item = bool> {
-        self.executor().subscribe(key).map(|()| true)
+    pub fn subscribe(&self, key: String) -> async_broadcast::Receiver<()> {
+        self.executor().subscribe(key)
     }
 
     pub(crate) async fn wait_for(

--- a/native/acter/src/api/invitation.rs
+++ b/native/acter/src/api/invitation.rs
@@ -320,7 +320,7 @@ impl Client {
                     .collect::<Vec<OwnedUserId>>();
                 // iterate my rooms to get user list
                 let mut profiles: Vec<UserProfile> = vec![];
-                let (spaces, convos) = devide_spaces_from_convos(client.clone()).await;
+                let (spaces, convos) = devide_spaces_from_convos(client.clone(), None).await;
                 for convo in convos {
                     if convo.room_id() == room_id {
                         continue;

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 use super::{
-    client::{devide_spaces_from_convos, Client},
+    client::{devide_spaces_from_convos, Client, SpaceFilter, SpaceFilterBuilder},
     room::Room,
     RUNTIME,
 };
@@ -537,9 +537,10 @@ impl Client {
 
     pub async fn spaces(&self) -> Result<Vec<Space>> {
         let c = self.clone();
+        let filter = SpaceFilterBuilder::default().include_left(false).build()?;
         RUNTIME
             .spawn(async move {
-                let (spaces, convos) = devide_spaces_from_convos(c).await;
+                let (spaces, convos) = devide_spaces_from_convos(c, Some(filter)).await;
                 Ok(spaces)
             })
             .await?

--- a/native/test/Cargo.toml
+++ b/native/test/Cargo.toml
@@ -14,6 +14,7 @@ features = ["testing"]
 path = "../core"
 
 [dependencies]
+async-broadcast = { workspace = true }
 anyhow = "1"
 env_logger = "0.10.0"
 futures = "0.3.17"

--- a/native/test/src/tests.rs
+++ b/native/test/src/tests.rs
@@ -9,6 +9,7 @@ mod reaction;
 mod receipt;
 mod redact;
 mod reply;
+mod spaces;
 mod tasks;
 mod templates;
 mod typing;

--- a/native/test/src/tests/spaces.rs
+++ b/native/test/src/tests/spaces.rs
@@ -56,9 +56,9 @@ async fn spaces_deleted() -> Result<()> {
     let last = spaces.pop().unwrap();
 
     let all_listener = user.subscribe("SPACES".to_owned());
-    let mut first_listener = user.subscribe(format!("SPACE::{}", first.room_id()));
-    let mut second_listener = user.subscribe(format!("SPACE::{}", second.room_id()));
-    let mut last_listener = user.subscribe(format!("SPACE::{}", last.room_id()));
+    let mut first_listener = user.subscribe(first.room_id().to_string());
+    let mut second_listener = user.subscribe(second.room_id().to_string());
+    let mut last_listener = user.subscribe(last.room_id().to_string());
 
     first.leave().await?;
     let fetcher_client = user.clone();

--- a/native/test/src/tests/spaces.rs
+++ b/native/test/src/tests/spaces.rs
@@ -1,0 +1,102 @@
+use anyhow::{bail, Result};
+use async_broadcast::TryRecvError;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::random_user_with_template;
+
+const TMPL: &str = r#"
+version = "0.1"
+name = "Smoketest Template"
+
+[inputs]
+main = { type = "user", is-default = true, required = true, description = "The starting user" }
+
+[objects.main_space]
+type = "space"
+name = "{{ main.display_name }}'s main test space"
+
+[objects.second_space]
+type = "space"
+name = "{{ main.display_name }}'s first test space"
+
+[objects.third_space]
+type = "space"
+name = "{{ main.display_name }}'s second test space"
+"#;
+
+#[tokio::test]
+async fn spaces_deleted() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (user, _sync_state, _engine) = random_user_with_template("spaces-deleted-", TMPL).await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 3 {
+                bail!("not all spaces found");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
+    let mut spaces = user.spaces().await?;
+
+    assert_eq!(spaces.len(), 3);
+
+    let first = spaces.pop().unwrap();
+    let second = spaces.pop().unwrap();
+    let last = spaces.pop().unwrap();
+
+    let mut all_listener = user.subscribe("SPACES".to_owned());
+    let mut first_listener = user.subscribe(format!("SPACE::{}", first.room_id()));
+    let mut second_listener = user.subscribe(format!("SPACE::{}", second.room_id()));
+    let mut last_listener = user.subscribe(format!("SPACE::{}", last.room_id()));
+
+    first.leave().await?;
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 2 {
+                bail!("not the right number of  spaces found");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
+    assert_eq!(all_listener.try_recv(), Ok(()));
+    assert_eq!(first_listener.try_recv(), Ok(()));
+    assert_eq!(second_listener.try_recv(), Err(TryRecvError::Empty));
+    assert_eq!(last_listener.try_recv(), Err(TryRecvError::Empty));
+
+    second.leave().await?;
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 1 {
+                bail!("not the right number of  spaces found");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
+    assert_eq!(all_listener.try_recv(), Ok(()));
+    assert_eq!(first_listener.try_recv(), Err(TryRecvError::Empty));
+    assert_eq!(second_listener.try_recv(), Ok(()));
+    assert_eq!(last_listener.try_recv(), Err(TryRecvError::Empty));
+
+    Ok(())
+}

--- a/native/test/src/tests/spaces.rs
+++ b/native/test/src/tests/spaces.rs
@@ -74,10 +74,10 @@ async fn spaces_deleted() -> Result<()> {
     })
     .await?;
 
-    assert_eq!(all_listener.try_recv(), Ok(()));
     assert_eq!(first_listener.try_recv(), Ok(()));
     assert_eq!(second_listener.try_recv(), Err(TryRecvError::Empty));
     assert_eq!(last_listener.try_recv(), Err(TryRecvError::Empty));
+    assert_eq!(all_listener.try_recv(), Ok(()));
 
     second.leave().await?;
     let fetcher_client = user.clone();


### PR DESCRIPTION
Before this change we'd hand out all spaces, regardless of whether the underlying room was one we had joined, left or just received an invite for. The splitting code now takes a filter parameter that allows for filtering only certain types of spaces, which is applied to `client.spaces()` to filter out any spaces we had left (or were kicked off).

An integration test shows that this works as expect _and_ that the information subscription system works as expected, too. Including to inform you the space you listened to had been removed.