### PR TITLE
Fix space tab navigation

### DIFF
--- a/app/lib/features/space/pages/overview_page.dart
+++ b/app/lib/features/space/pages/overview_page.dart
@@ -5,7 +5,6 @@ import 'package:acter/features/space/widgets/chats_card.dart';
 import 'package:acter/features/space/widgets/events_card.dart';
 import 'package:acter/features/space/widgets/links_card.dart';
 import 'package:acter/features/space/widgets/related_spaces_card.dart';
-import 'package:acter/features/space/widgets/top_nav.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -21,11 +20,6 @@ class SpaceOverview extends ConsumerWidget {
     // get platform of context.
     return Column(
       children: [
-        TopNavBar(
-          spaceId: spaceIdOrAlias,
-          key: Key('$spaceIdOrAlias::topnav'),
-          selectedKey: const Key('overview'),
-        ),
         Padding(
           padding: const EdgeInsets.all(20),
           child: StaggeredGrid.count(

--- a/app/lib/features/space/pages/related_spaces_page.dart
+++ b/app/lib/features/space/pages/related_spaces_page.dart
@@ -6,7 +6,6 @@ import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
-import 'package:acter/features/space/widgets/top_nav.dart';
 import 'package:go_router/go_router.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -61,13 +60,6 @@ class RelatedSpacesPage extends ConsumerWidget {
       padding: const EdgeInsets.all(20),
       child: CustomScrollView(
         slivers: [
-          SliverToBoxAdapter(
-            child: TopNavBar(
-              spaceId: spaceIdOrAlias,
-              key: Key('$spaceIdOrAlias::topnav'),
-              selectedKey: const Key('spaces'),
-            ),
-          ),
           ...spaces.when(
             data: (spaces) {
               final widthCount =

--- a/app/lib/features/space/pages/shell_page.dart
+++ b/app/lib/features/space/pages/shell_page.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/space/widgets/top_nav.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/space/widgets/member_avatar.dart';
 import 'package:acter_avatar/acter_avatar.dart';
@@ -57,6 +58,10 @@ class _SpaceShellState extends ConsumerState<SpaceShell> {
                     children: <Widget>[
                       _ShellToolbar(space),
                       _ShellHeader(widget.spaceIdOrAlias, profile),
+                      TopNavBar(
+                        spaceId: widget.spaceIdOrAlias,
+                        key: Key('${widget.spaceIdOrAlias}::top-nav'),
+                      ),
                       SizedBox(
                         height: h < 300 ? h * 2 : h,
                         child: widget.child,

--- a/app/lib/features/space/providers/space_navbar_provider.dart
+++ b/app/lib/features/space/providers/space_navbar_provider.dart
@@ -1,0 +1,114 @@
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
+import 'package:acter/features/settings/providers/settings_providers.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class TabEntry {
+  final Key key;
+  final String label;
+  final String target;
+  final Widget icon;
+
+  const TabEntry({
+    required this.key,
+    required this.icon,
+    required this.label,
+    required this.target,
+  });
+}
+
+final tabsProvider =
+    Provider.family<List<TabEntry>, BuildContext>((ref, context) {
+  final features = ref.watch(featuresProvider);
+  bool isActive(f) => features.isActive(f);
+  List<TabEntry> tabs = [
+    TabEntry(
+      key: const Key('overview'),
+      label: 'Overview',
+      icon: const Icon(Atlas.layout_half_thin),
+      target: Routes.space.name,
+    ),
+  ];
+
+  if (isActive(LabsFeature.pins)) {
+    tabs.add(
+      TabEntry(
+        key: const Key('pins'),
+        label: 'Pins',
+        icon: const Icon(Atlas.pin_thin),
+        target: Routes.space.name,
+      ),
+    );
+  }
+
+  if (isActive(LabsFeature.tasks)) {
+    tabs.add(
+      TabEntry(
+        key: const Key('tasks'),
+        label: 'Tasks',
+        icon: SvgPicture.asset(
+          'assets/images/tasks.svg',
+          semanticsLabel: 'tasks',
+          width: 24,
+          height: 24,
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+        target: Routes.space.name,
+      ),
+    );
+  }
+
+  if (isActive(LabsFeature.events)) {
+    tabs.add(
+      TabEntry(
+        key: const Key('events'),
+        label: 'Events',
+        icon: const Icon(Atlas.calendar_schedule_thin),
+        target: Routes.space.name,
+      ),
+    );
+  }
+
+  tabs.add(
+    TabEntry(
+      key: const Key('chat'),
+      label: 'Chat',
+      icon: const Icon(Atlas.chats_thin),
+      target: Routes.space.name,
+    ),
+  );
+  tabs.add(
+    TabEntry(
+      key: const Key('spaces'),
+      label: 'Spaces',
+      icon: const Icon(Atlas.connection_thin),
+      target: Routes.relatedSpaces.name,
+    ),
+  );
+  return tabs;
+});
+
+class SelectedTabNotifier extends Notifier<Key> {
+  @override
+  Key build() {
+    return const Key('overview');
+  }
+
+  void switchTo(Key input) {
+    Future(() => state = input);
+  }
+}
+
+final selectedTabKeyProvider =
+    NotifierProvider<SelectedTabNotifier, Key>(() => SelectedTabNotifier());
+
+final selectedTabIdxProvider =
+    StateProvider.autoDispose.family<int, BuildContext>((ref, context) {
+  final tabs = ref.watch(tabsProvider(context));
+  final selectedKey = ref.watch(selectedTabKeyProvider);
+  final index = tabs.indexWhere((e) => e.key == selectedKey);
+  return index < 0 ? 0 : index;
+});

--- a/app/lib/features/space/widgets/top_nav.dart
+++ b/app/lib/features/space/widgets/top_nav.dart
@@ -1,105 +1,14 @@
-import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
-import 'package:acter/features/settings/providers/settings_providers.dart';
-import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
-
-class TabEntry {
-  final Key key;
-  final String label;
-  final String target;
-  final Widget icon;
-
-  const TabEntry({
-    required this.key,
-    required this.icon,
-    required this.label,
-    required this.target,
-  });
-}
-
-final tabsProvider =
-    Provider.family<List<TabEntry>, BuildContext>((ref, context) {
-  final features = ref.watch(featuresProvider);
-  bool isActive(f) => features.isActive(f);
-  List<TabEntry> tabs = [
-    TabEntry(
-      key: const Key('overview'),
-      label: 'Overview',
-      icon: const Icon(Atlas.layout_half_thin),
-      target: Routes.space.name,
-    ),
-  ];
-
-  if (isActive(LabsFeature.pins)) {
-    tabs.add(
-      TabEntry(
-        key: const Key('pins'),
-        label: 'Pins',
-        icon: const Icon(Atlas.pin_thin),
-        target: Routes.space.name,
-      ),
-    );
-  }
-
-  if (isActive(LabsFeature.tasks)) {
-    tabs.add(
-      TabEntry(
-        key: const Key('tasks'),
-        label: 'Tasks',
-        icon: SvgPicture.asset(
-          'assets/images/tasks.svg',
-          semanticsLabel: 'tasks',
-          width: 24,
-          height: 24,
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-        target: Routes.space.name,
-      ),
-    );
-  }
-
-  if (isActive(LabsFeature.events)) {
-    tabs.add(
-      TabEntry(
-        key: const Key('events'),
-        label: 'Events',
-        icon: const Icon(Atlas.calendar_schedule_thin),
-        target: Routes.space.name,
-      ),
-    );
-  }
-
-  tabs.add(
-    TabEntry(
-      key: const Key('chat'),
-      label: 'Chat',
-      icon: const Icon(Atlas.chats_thin),
-      target: Routes.space.name,
-    ),
-  );
-  tabs.add(
-    TabEntry(
-      key: const Key('spaces'),
-      label: 'Spaces',
-      icon: const Icon(Atlas.connection_thin),
-      target: Routes.relatedSpaces.name,
-    ),
-  );
-  return tabs;
-});
+import 'package:acter/features/space/providers/space_navbar_provider.dart';
 
 class TopNavBar extends ConsumerStatefulWidget {
   final String spaceId;
-  final Key selectedKey;
 
   const TopNavBar({
     super.key,
     required this.spaceId,
-    required this.selectedKey,
   });
 
   @override
@@ -116,11 +25,10 @@ class _TopNavBarState extends ConsumerState<TopNavBar>
     recentWatchScreenTabStateTestProvider = Provider.autoDispose
         .family<TabController, BuildContext>((ref, context) {
       final tabs = ref.watch(tabsProvider(context));
-      final selectedIndex = tabs.indexWhere((e) => e.key == widget.selectedKey);
       return TabController(
         length: tabs.length,
         vsync: this,
-        initialIndex: selectedIndex < 0 ? 0 : selectedIndex,
+        initialIndex: 0,
       );
     });
     super.initState();
@@ -132,6 +40,8 @@ class _TopNavBarState extends ConsumerState<TopNavBar>
 
     final _tabController =
         ref.watch(recentWatchScreenTabStateTestProvider(context));
+    final selectedIndex = ref.watch(selectedTabIdxProvider(context));
+    _tabController.animateTo(selectedIndex);
     return LayoutBuilder(
       builder: (context, constraints) {
         final useCols = constraints.maxWidth < (150 * tabs.length);

--- a/app/lib/router/providers/notifiers/router_notifier.dart
+++ b/app/lib/router/providers/notifiers/router_notifier.dart
@@ -1,15 +1,17 @@
 import 'package:acter/router/router.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class RouterNotifier extends AutoDisposeAsyncNotifier<void>
     implements Listenable {
   VoidCallback? routerListener;
 
-  final routeList = routes;
+  late List<RouteBase> routeList;
 
   @override
   Future<void> build() async {
+    routeList = makeRoutes(ref);
     ref.listenSelf((_, __) {
       // One could write more conditional logic for when to call redirection
       routerListener?.call();

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -30,11 +30,13 @@ import 'package:acter/features/settings/pages/labs_page.dart';
 import 'package:acter/features/settings/pages/licenses_page.dart';
 import 'package:acter/features/space/pages/overview_page.dart';
 import 'package:acter/features/space/pages/shell_page.dart';
+import 'package:acter/features/space/providers/space_navbar_provider.dart';
 import 'package:acter/features/todo/pages/create_task_sidesheet.dart';
 import 'package:acter/features/todo/pages/todo_page.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:riverpod/riverpod.dart';
 
 Future<String?> authGuardRedirect(
   BuildContext context,
@@ -73,369 +75,386 @@ final GlobalKey<NavigatorState> shellNavigatorKey =
 final GlobalKey<NavigatorState> spaceNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'space');
 
-final routes = [
-   GoRoute(
-    name: Routes.intro.name,
-    path: Routes.intro.route,
-    builder: (context, state) => const IntroPage(),
-  ),
-  GoRoute(
-    name: Routes.start.name,
-    path: Routes.start.route,
-    builder: (context, state) => const StartPage(),
-  ),
-   GoRoute(
-    name: Routes.introProfile.name,
-    path: Routes.introProfile.route,
-    builder: (context, state) => const IntroProfile(),
-  ),
-  GoRoute(
-    name: Routes.authLogin.name,
-    path: Routes.authLogin.route,
-    builder: (context, state) => const LoginPage(),
-  ),
-  GoRoute(
-    name: Routes.authRegister.name,
-    path: Routes.authRegister.route,
-    builder: (context, state) => const RegisterPage(),
-  ),
-  GoRoute(
-    path: '/gallery', 
-    builder: (context, state) => const GalleryPage(),
-  ),
-  GoRoute(
-    parentNavigatorKey: rootNavigatorKey,
-    name: Routes.bugReport.name,
-    path: Routes.bugReport.route,
-    pageBuilder: (context, state) => DialogPage(
-      builder: (BuildContext ctx) => BugReportPage(
-        imagePath: state.queryParameters['screenshot'],
+List<RouteBase> makeRoutes(Ref ref) => [
+      GoRoute(
+        name: Routes.intro.name,
+        path: Routes.intro.route,
+        builder: (context, state) => const IntroPage(),
       ),
-    ),
-  ),
-  GoRoute(
-    parentNavigatorKey: rootNavigatorKey,
-    name: Routes.quickJump.name,
-    path: Routes.quickJump.route,
-    pageBuilder: (context, state) => DialogPage(
-      builder: (BuildContext ctx) => const QuickjumpDialog(),
-    ),
-  ),
-  GoRoute(
-    parentNavigatorKey: rootNavigatorKey,
-    name: Routes.actionAddTask.name,
-    path: Routes.actionAddTask.route,
-    pageBuilder: (context, state) {
-      return SideSheetPage(
-        key: state.pageKey,
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return SlideTransition(
-            position: Tween(
-              begin: const Offset(1, 0),
-              end: const Offset(0, 0),
-            ).animate(
-              animation,
-            ),
-            child: child,
-          );
-        },
-        child: const AddTaskActionSideSheet(),
-      );
-    },
-  ),
-  GoRoute(
-    parentNavigatorKey: rootNavigatorKey,
-    name: Routes.createSpace.name,
-    path: Routes.createSpace.route,
-    pageBuilder: (context, state) {
-      return SideSheetPage(
-        key: state.pageKey,
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return SlideTransition(
-            position: Tween(
-              begin: const Offset(1, 0),
-              end: const Offset(0, 0),
-            ).animate(
-              animation,
-            ),
-            child: child,
-          );
-        },
-        child: CreateSpacePage(
-          initialParentsSpaceId: state.queryParameters['parentSpaceId'],
-        ),
-      );
-    },
-  ),
-
-  /// Application shell
-  ShellRoute(
-    navigatorKey: shellNavigatorKey,
-    // FIXME: unfortunately ShellRoute doesn't support redirects yet,
-    // thus we have to put it onto every route. Once that is fixed,
-    // remove that param from the sub-routes and use only here instead
-    // ref: https://github.com/flutter/flutter/issues/114559
-    // redirect: authGuardRedirect,
-
-    pageBuilder: (context, state, child) {
-      return NoTransitionPage(
-        key: state.pageKey,
-        child: HomeShell(child: child),
-      );
-    },
-    routes: <RouteBase>[
+      GoRoute(
+        name: Routes.start.name,
+        path: Routes.start.route,
+        builder: (context, state) => const StartPage(),
+      ),
+      GoRoute(
+        name: Routes.introProfile.name,
+        path: Routes.introProfile.route,
+        builder: (context, state) => const IntroProfile(),
+      ),
+      GoRoute(
+        name: Routes.authLogin.name,
+        path: Routes.authLogin.route,
+        builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        name: Routes.authRegister.name,
+        path: Routes.authRegister.route,
+        builder: (context, state) => const RegisterPage(),
+      ),
       GoRoute(
         path: '/gallery',
         builder: (context, state) => const GalleryPage(),
       ),
       GoRoute(
-        name: Routes.myProfile.name,
-        path: Routes.myProfile.route,
-        redirect: authGuardRedirect,
+        parentNavigatorKey: rootNavigatorKey,
+        name: Routes.bugReport.name,
+        path: Routes.bugReport.route,
+        pageBuilder: (context, state) => DialogPage(
+          builder: (BuildContext ctx) => BugReportPage(
+            imagePath: state.queryParameters['screenshot'],
+          ),
+        ),
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        name: Routes.quickJump.name,
+        path: Routes.quickJump.route,
+        pageBuilder: (context, state) => DialogPage(
+          builder: (BuildContext ctx) => const QuickjumpDialog(),
+        ),
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        name: Routes.actionAddTask.name,
+        path: Routes.actionAddTask.route,
         pageBuilder: (context, state) {
-          return NoTransitionPage(
+          return SideSheetPage(
             key: state.pageKey,
-            child: const MyProfile(),
+            transitionsBuilder:
+                (context, animation, secondaryAnimation, child) {
+              return SlideTransition(
+                position: Tween(
+                  begin: const Offset(1, 0),
+                  end: const Offset(0, 0),
+                ).animate(
+                  animation,
+                ),
+                child: child,
+              );
+            },
+            child: const AddTaskActionSideSheet(),
           );
         },
       ),
       GoRoute(
-        name: Routes.activities.name,
-        path: Routes.activities.route,
-        redirect: authGuardRedirect,
+        parentNavigatorKey: rootNavigatorKey,
+        name: Routes.createSpace.name,
+        path: Routes.createSpace.route,
         pageBuilder: (context, state) {
-          return NoTransitionPage(
+          return SideSheetPage(
             key: state.pageKey,
-            child: const ActivitiesPage(),
+            transitionsBuilder:
+                (context, animation, secondaryAnimation, child) {
+              return SlideTransition(
+                position: Tween(
+                  begin: const Offset(1, 0),
+                  end: const Offset(0, 0),
+                ).animate(
+                  animation,
+                ),
+                child: child,
+              );
+            },
+            child: CreateSpacePage(
+              initialParentsSpaceId: state.queryParameters['parentSpaceId'],
+            ),
           );
         },
       ),
 
-      GoRoute(
-        name: Routes.tasks.name,
-        path: Routes.tasks.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
+      /// Application shell
+      ShellRoute(
+        navigatorKey: shellNavigatorKey,
+        // FIXME: unfortunately ShellRoute doesn't support redirects yet,
+        // thus we have to put it onto every route. Once that is fixed,
+        // remove that param from the sub-routes and use only here instead
+        // ref: https://github.com/flutter/flutter/issues/114559
+        // redirect: authGuardRedirect,
+
+        pageBuilder: (context, state, child) {
           return NoTransitionPage(
             key: state.pageKey,
-            child: const TodoPage(),
-          );
-        },
-      ),
-      GoRoute(
-        name: Routes.updates.name,
-        path: Routes.updates.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const NewsPage(),
+            child: HomeShell(child: child),
           );
         },
         routes: <RouteBase>[
-          // hide bottom nav for nested pages, use rootNavigatorKey
           GoRoute(
-            parentNavigatorKey: rootNavigatorKey,
-            name: Routes.updatesEdit.name,
-            path: Routes.updatesEdit.route,
+            path: '/gallery',
+            builder: (context, state) => const GalleryPage(),
+          ),
+          GoRoute(
+            name: Routes.myProfile.name,
+            path: Routes.myProfile.route,
             redirect: authGuardRedirect,
             pageBuilder: (context, state) {
               return NoTransitionPage(
                 key: state.pageKey,
-                child: const NewsBuilderPage(),
+                child: const MyProfile(),
               );
             },
           ),
           GoRoute(
-            parentNavigatorKey: rootNavigatorKey,
-            name: Routes.updatesPost.name,
-            path: Routes.updatesPost.route,
+            name: Routes.activities.name,
+            path: Routes.activities.route,
             redirect: authGuardRedirect,
             pageBuilder: (context, state) {
               return NoTransitionPage(
                 key: state.pageKey,
-                child: PostPage(
-                  attachmentUri: state.extra as String?,
+                child: const ActivitiesPage(),
+              );
+            },
+          ),
+
+          GoRoute(
+            name: Routes.tasks.name,
+            path: Routes.tasks.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const TodoPage(),
+              );
+            },
+          ),
+          GoRoute(
+            name: Routes.updates.name,
+            path: Routes.updates.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const NewsPage(),
+              );
+            },
+            routes: <RouteBase>[
+              // hide bottom nav for nested pages, use rootNavigatorKey
+              GoRoute(
+                parentNavigatorKey: rootNavigatorKey,
+                name: Routes.updatesEdit.name,
+                path: Routes.updatesEdit.route,
+                redirect: authGuardRedirect,
+                pageBuilder: (context, state) {
+                  return NoTransitionPage(
+                    key: state.pageKey,
+                    child: const NewsBuilderPage(),
+                  );
+                },
+              ),
+              GoRoute(
+                parentNavigatorKey: rootNavigatorKey,
+                name: Routes.updatesPost.name,
+                path: Routes.updatesPost.route,
+                redirect: authGuardRedirect,
+                pageBuilder: (context, state) {
+                  return NoTransitionPage(
+                    key: state.pageKey,
+                    child: PostPage(
+                      attachmentUri: state.extra as String?,
+                    ),
+                  );
+                },
+                routes: <RouteBase>[
+                  GoRoute(
+                    parentNavigatorKey: rootNavigatorKey,
+                    name: Routes.updatesPostSearch.name,
+                    path: Routes.updatesPostSearch.route,
+                    redirect: authGuardRedirect,
+                    pageBuilder: (context, state) {
+                      return NoTransitionPage(
+                        key: state.pageKey,
+                        child: const SearchSpacePage(),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+
+          GoRoute(
+            name: Routes.search.name,
+            path: Routes.search.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const SearchPage(),
+              );
+            },
+          ),
+          GoRoute(
+            name: Routes.chatroom.name,
+            path: Routes.chatroom.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const ChatPage(),
+              );
+            },
+          ),
+
+          GoRoute(
+            name: Routes.chat.name,
+            path: Routes.chat.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const ChatPage(),
+              );
+            },
+          ),
+
+          GoRoute(
+            name: Routes.dashboard.name,
+            path: Routes.dashboard.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const Dashboard(),
+              );
+            },
+          ),
+
+          // ---- SETTINGS
+
+          GoRoute(
+            name: Routes.info.name,
+            path: Routes.info.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const SettingsInfoPage(),
+              );
+            },
+          ),
+          GoRoute(
+            name: Routes.licenses.name,
+            path: Routes.licenses.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const SettingsLicensesPage(),
+              );
+            },
+          ),
+
+          GoRoute(
+            name: Routes.settings.name,
+            path: Routes.settings.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const SettingsMenuPage(),
+              );
+            },
+          ),
+
+          GoRoute(
+            name: Routes.settingsLabs.name,
+            path: Routes.settingsLabs.route,
+            redirect: authGuardRedirect,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: const SettingsLabsPage(),
+              );
+            },
+          ),
+
+          /// Space subshell
+          ShellRoute(
+            navigatorKey: spaceNavigatorKey,
+            pageBuilder: (context, state, child) {
+              return NoTransitionPage(
+                key: state.pageKey,
+                child: SpaceShell(
+                  spaceIdOrAlias: state.pathParameters['spaceId']!,
+                  child: child,
                 ),
               );
             },
             routes: <RouteBase>[
               GoRoute(
-                parentNavigatorKey: rootNavigatorKey,
-                name: Routes.updatesPostSearch.name,
-                path: Routes.updatesPostSearch.route,
+                name: Routes.relatedSpaces.name,
+                path: Routes.relatedSpaces.route,
                 redirect: authGuardRedirect,
                 pageBuilder: (context, state) {
+                  debugPrint('in spaces related');
+                  ref
+                      .read(selectedTabKeyProvider.notifier)
+                      .switchTo(const Key('spaces'));
                   return NoTransitionPage(
                     key: state.pageKey,
-                    child: const SearchSpacePage(),
+                    child: RelatedSpacesPage(
+                      spaceIdOrAlias: state.pathParameters['spaceId']!,
+                    ),
+                  );
+                },
+              ),
+              GoRoute(
+                name: Routes.space.name,
+                path: Routes.space.route,
+                redirect: authGuardRedirect,
+                pageBuilder: (context, state) {
+                  debugPrint('in overview');
+                  ref
+                      .read(selectedTabKeyProvider.notifier)
+                      .switchTo(const Key('overview'));
+                  return NoTransitionPage(
+                    key: state.pageKey,
+                    child: SpaceOverview(
+                      spaceIdOrAlias: state.pathParameters['spaceId']!,
+                    ),
                   );
                 },
               ),
             ],
           ),
-        ],
-      ),
 
-      GoRoute(
-        name: Routes.search.name,
-        path: Routes.search.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SearchPage(),
-          );
-        },
-      ),
-      GoRoute(
-        name: Routes.chatroom.name,
-        path: Routes.chatroom.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(key: state.pageKey, child: const ChatPage());
-        },
-      ),
-
-      GoRoute(
-        name: Routes.chat.name,
-        path: Routes.chat.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(key: state.pageKey, child: const ChatPage());
-        },
-      ),
-
-      GoRoute(
-        name: Routes.dashboard.name,
-        path: Routes.dashboard.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(key: state.pageKey, child: const Dashboard());
-        },
-      ),
-
-      // ---- SETTINGS
-
-      GoRoute(
-        name: Routes.info.name,
-        path: Routes.info.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SettingsInfoPage(),
-          );
-        },
-      ),
-      GoRoute(
-        name: Routes.licenses.name,
-        path: Routes.licenses.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SettingsLicensesPage(),
-          );
-        },
-      ),
-
-      GoRoute(
-        name: Routes.settings.name,
-        path: Routes.settings.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SettingsMenuPage(),
-          );
-        },
-      ),
-
-      GoRoute(
-        name: Routes.settingsLabs.name,
-        path: Routes.settingsLabs.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SettingsLabsPage(),
-          );
-        },
-      ),
-
-      /// Space subshell
-      ShellRoute(
-        navigatorKey: spaceNavigatorKey,
-        pageBuilder: (context, state, child) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: SpaceShell(
-              spaceIdOrAlias: state.pathParameters['spaceId']!,
-              child: child,
-            ),
-          );
-        },
-        routes: <RouteBase>[
           GoRoute(
-            name: Routes.relatedSpaces.name,
-            path: Routes.relatedSpaces.route,
+            name: Routes.spaces.name,
+            path: Routes.spaces.route,
             redirect: authGuardRedirect,
             pageBuilder: (context, state) {
-              debugPrint('in spaces related');
               return NoTransitionPage(
                 key: state.pageKey,
-                child: RelatedSpacesPage(
-                  spaceIdOrAlias: state.pathParameters['spaceId']!,
-                ),
+                child: const SpacesPage(),
               );
             },
           ),
+
           GoRoute(
-            name: Routes.space.name,
-            path: Routes.space.route,
-            redirect: authGuardRedirect,
-            pageBuilder: (context, state) {
-              debugPrint('in overview');
-              return NoTransitionPage(
-                key: state.pageKey,
-                child: SpaceOverview(
-                  spaceIdOrAlias: state.pathParameters['spaceId']!,
-                ),
-              );
+            name: Routes.main.name,
+            path: Routes.main.route,
+            redirect: (BuildContext context, GoRouterState state) async {
+              // we first check if there is a client available for us to use
+              final authGuarded = await authGuardRedirect(context, state);
+              if (authGuarded != null) {
+                return authGuarded;
+              }
+              if (isDesktop(context)) {
+                return Routes.dashboard.route;
+              } else {
+                return Routes.updates.route;
+              }
             },
           ),
         ],
       ),
-
-      GoRoute(
-        name: Routes.spaces.name,
-        path: Routes.spaces.route,
-        redirect: authGuardRedirect,
-        pageBuilder: (context, state) {
-          return NoTransitionPage(
-            key: state.pageKey,
-            child: const SpacesPage(),
-          );
-        },
-      ),
-
-      GoRoute(
-        name: Routes.main.name,
-        path: Routes.main.route,
-        redirect: (BuildContext context, GoRouterState state) async {
-          // we first check if there is a client available for us to use
-          final authGuarded = await authGuardRedirect(context, state);
-          if (authGuarded != null) {
-            return authGuarded;
-          }
-          if (isDesktop(context)) {
-            return Routes.dashboard.route;
-          } else {
-            return Routes.updates.route;
-          }
-        },
-      ),
-    ],
-  ),
-];
+    ];


### PR DESCRIPTION
Moves the space/* tabbar navigation management over into riverpod. Trick is not only use an external notifier we can ping from the routing, but also to delay the actual update in the notifier via `Future(() {})` or it fails terribly (with a notification that you can't change state while it renders).

Either way, before we had the navbar on each subview and re-rendering it lead to weird errors around ticks. Now there is a single one on the outer shell and it updates whenever we route to subpage, regardless of whether that was triggered by the tabbar or through any other click.