### PR TITLE
Add API to set space name

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -4778,6 +4778,52 @@ class Api {
     return tmp7;
   }
 
+  EventId? __spaceSetNameFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceSetNameFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(tmp10_0.asTypedList(tmp11));
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
   FfiListMember? __spaceActiveMembersFuturePoll(
     int boxed,
     int postCobject,
@@ -13776,6 +13822,24 @@ class Api {
     int,
     int,
   )>();
+  late final _spaceSetNamePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+    ffi.Int64,
+    ffi.Uint8,
+    ffi.Int64,
+    ffi.Uint64,
+    ffi.Uint64,
+  )>>("__Space_set_name");
+
+  late final _spaceSetName = _spaceSetNamePtr.asFunction<
+      int Function(
+    int,
+    int,
+    int,
+    int,
+    int,
+  )>();
   late final _spaceActiveMembersPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -16613,6 +16677,20 @@ class Api {
 
   late final _spaceSetTopicFuturePoll = _spaceSetTopicFuturePollPtr.asFunction<
       _SpaceSetTopicFuturePollReturn Function(
+    int,
+    int,
+    int,
+  )>();
+  late final _spaceSetNameFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _SpaceSetNameFuturePollReturn Function(
+    ffi.Int64,
+    ffi.Int64,
+    ffi.Int64,
+  )>>("__Space_set_name_future_poll");
+
+  late final _spaceSetNameFuturePoll = _spaceSetNameFuturePollPtr.asFunction<
+      _SpaceSetNameFuturePollReturn Function(
     int,
     int,
     int,
@@ -29241,6 +29319,47 @@ class Space {
     return tmp6;
   }
 
+  /// set name of the room
+  Future<EventId> setName(
+    String? name,
+  ) {
+    final tmp1 = name;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp4 = 0;
+    var tmp5 = 0;
+    var tmp6 = 0;
+    tmp0 = _box.borrow();
+    if (tmp1 == null) {
+      tmp2 = 0;
+    } else {
+      tmp2 = 1;
+      final tmp3 = tmp1;
+      final tmp3_0 = utf8.encode(tmp3);
+      tmp5 = tmp3_0.length;
+      debugAllocation("lower string", tmp4, tmp5);
+
+      final ffi.Pointer<ffi.Uint8> tmp4_0 = _api.__allocate(tmp5 * 1, 1);
+      final Uint8List tmp4_1 = tmp4_0.asTypedList(tmp5);
+      tmp4_1.setAll(0, tmp3_0);
+      tmp4 = tmp4_0.address;
+      tmp6 = tmp5;
+    }
+    final tmp7 = _api._spaceSetName(
+      tmp0,
+      tmp2,
+      tmp4,
+      tmp5,
+      tmp6,
+    );
+    final tmp9 = tmp7;
+    final ffi.Pointer<ffi.Void> tmp9_0 = ffi.Pointer.fromAddress(tmp9);
+    final tmp9_1 = _Box(_api, tmp9_0, "__Space_set_name_future_drop");
+    tmp9_1._finalizer = _api._registerFinalizer(tmp9_1);
+    final tmp8 = _nativeFuture(tmp9_1, _api.__spaceSetNameFuturePoll);
+    return tmp8;
+  }
+
   /// the members currently in the space
   Future<FfiListMember> activeMembers() {
     var tmp0 = 0;
@@ -35697,6 +35816,21 @@ class _SpaceRemoveAvatarFuturePollReturn extends ffi.Struct {
 }
 
 class _SpaceSetTopicFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+}
+
+class _SpaceSetNameFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1126,6 +1126,9 @@ object Space {
     /// set description / topic of the room
     fn set_topic(topic: string) -> Future<Result<EventId>>;
 
+    /// set name of the room
+    fn set_name(name: Option<string>) -> Future<Result<EventId>>;
+
     /// the members currently in the space
     fn active_members() -> Future<Result<Vec<Member>>>;
 

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -439,6 +439,7 @@ impl Client {
                             return Ok(LoopCtrl::Continue);
                         }
                     };
+                    trace!(target: "acter::sync_response::full", "sync response: {:#?}", response);
 
                     device_controller.process_device_lists(&client, &response);
                     trace!("post device controller");

--- a/native/test/src/tests/spaces.rs
+++ b/native/test/src/tests/spaces.rs
@@ -237,3 +237,182 @@ async fn create_subspace() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn update_name() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (user, _sync_state, _engine) = random_user_with_template("space-edit-", TMPL).await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 1 {
+                bail!("not all spaces found");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
+    let mut spaces = user.spaces().await?;
+
+    assert_eq!(spaces.len(), 1);
+
+    let space = spaces.pop().unwrap();
+    let listener = space.subscribe();
+    let space_id = space.room_id().to_string();
+
+    // set name
+
+    let _event_id = space.set_name(Some("New Name".to_owned())).await?;
+
+    let fetcher_client = user.clone();
+    let space_id_clone = space_id.clone();
+    let retry_strategy = FibonacciBackoff::from_millis(500).map(jitter).take(10);
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let space_id = space_id_clone.clone();
+        async move {
+            if client.get_space(space_id).await?.name() == Some("New Name".to_owned()) {
+                Ok(())
+            } else {
+                bail!("Name not set")
+            }
+        }
+    })
+    .await?;
+
+    // and we've seen the update
+
+    Retry::spawn(retry_strategy.clone(), move || {
+        let mut listener = listener.clone();
+        async move {
+            loop {
+                let res = listener.try_recv();
+                if matches!(res, Err(TryRecvError::Overflowed(_))) {
+                    // this was an overflow reporting, try again
+                    continue;
+                }
+                return res;
+            }
+        }
+    })
+    .await?;
+
+    // FIXME: name resetting seems to be broken on the synapse side. Getting a server error.
+
+    // // fresh listener
+    // let listener = space.subscribe();
+
+    // // reset name to None
+
+    // let _event_id = space.set_name(None).await?;
+
+    // let fetcher_client = user.clone();
+    // let space_id_clone = space_id.clone();
+    // let retry_strategy = FibonacciBackoff::from_millis(500).map(jitter).take(10);
+    // Retry::spawn(retry_strategy.clone(), move || {
+    //     let client = fetcher_client.clone();
+    //     let space_id = space_id_clone.clone();
+    //     async move {
+    //         if client.get_space(space_id).await?.name().is_none() {
+    //             Ok(())
+    //         } else {
+    //             bail!("Name not set")
+    //         }
+    //     }
+    // })
+    // .await?;
+
+    // // and we've seen the update
+
+    // Retry::spawn(retry_strategy.clone(), move || {
+    //     let mut listener = listener.clone();
+    //     async move {
+    //         loop {
+    //             let res = listener.try_recv();
+    //             if matches!(res, Err(TryRecvError::Overflowed(_))) {
+    //                 // this was an overflow reporting, try again
+    //                 continue;
+    //             }
+    //             return res;
+    //         }
+    //     }
+    // })
+    // .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "topic updating seems broken"]
+async fn update_topic() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (user, _sync_state, _engine) = random_user_with_template("space-edit-", TMPL).await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 1 {
+                bail!("not all spaces found");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
+    let mut spaces = user.spaces().await?;
+
+    assert_eq!(spaces.len(), 1);
+
+    let space = spaces.pop().unwrap();
+    let listener = space.subscribe();
+    let space_id = space.room_id().to_string();
+
+    // set name
+
+    let _event_id = space.set_topic("New topic".to_owned()).await?;
+
+    let fetcher_client = user.clone();
+    let space_id_clone = space_id.clone();
+    let retry_strategy = FibonacciBackoff::from_millis(500).map(jitter).take(10);
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let space_id = space_id_clone.clone();
+        async move {
+            if client.get_space(space_id).await?.topic() == Some("New topic".to_owned()) {
+                Ok(())
+            } else {
+                bail!("Topic not set")
+            }
+        }
+    })
+    .await?;
+
+    // and we've seen the update
+
+    Retry::spawn(retry_strategy.clone(), move || {
+        let mut listener = listener.clone();
+        async move {
+            loop {
+                let res = listener.try_recv();
+                if matches!(res, Err(TryRecvError::Overflowed(_))) {
+                    // this was an overflow reporting, try again
+                    continue;
+                }
+                return res;
+            }
+        }
+    })
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
fixes #703 .

- [x] API (and FFI) for `space.set_name`
- [x] tests for the API
- [x] disabled tests for `set_topic` - as there seems to be a bug.  

Extra: a new log level for sync response has been added. By setting `RUST_LOG=acter::sync_response::full=trace`, the response is now logged as a pretty-print, too.