### PR TITLE
Refactor cargo toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,6 @@ dependencies = [
  "mime_guess",
  "oslog",
  "parse-env-filter",
- "proc-macro2 1.0.55",
  "ruma",
  "sanitize-filename-reader-friendly",
  "serde",

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -14,10 +14,12 @@ testing = ["dep:matrix-sdk-base"]
 cbindgen = []
 dart = []
 
+[patch.crates-io]
+proc-macro2 = "=1.0.55" # fix issue 'Your compiler does not support spans which is required by genco'
+
 [build-dependencies]
 ffi-gen = { git = "https://github.com/acterglobal/ffi-gen", branch = "leaking-no-drop"}
 cbindgen = "0.24.3"
-
 
 [dependencies]
 anyhow = "1.0.51"
@@ -67,9 +69,6 @@ features = [
 [dependencies.matrix-sdk-base]
 workspace = true
 optional = true
-
-[dependencies.proc-macro2]
-version = "=1.0.55" # fix issue 'Your compiler does not support spans which is required by genco'
 
 #   ----   WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Remove `proc-macro2` from `dependencies` of `acter`, because it is not direct dependency.
But its version should be `1.0.55` still.