### PR TITLE
Remove unnecessary helper functions from calendar event and tasklist

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -28378,7 +28378,7 @@ class Task {
     return tmp2;
   }
 
-  /// the name of this task
+  /// the description of this task
   String? descriptionText() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
@@ -29955,7 +29955,7 @@ class TaskList {
     return tmp2;
   }
 
-  /// the name of this task list
+  /// the description of this task list
   String? descriptionText() {
     var tmp0 = 0;
     tmp0 = _box.borrow();

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -288,7 +288,7 @@ object CalendarEvent {
     fn update_builder() -> Result<CalendarEventUpdateBuilder>;
 }
 
-object CalendarEventUpdateBuilder{
+object CalendarEventUpdateBuilder {
     /// set title of the event>
     fn title(title: string);
     /// set description text
@@ -822,7 +822,7 @@ object Task {
     /// the name of this task
     fn title() -> string;
 
-    /// the name of this task
+    /// the description of this task
     fn description_text() -> Option<string>;
 
     /// the users assigned
@@ -1014,7 +1014,7 @@ object TaskList {
     /// the name of this task list
     fn name() -> string;
 
-    /// the name of this task list
+    /// the description of this task list
     fn description_text() -> Option<string>;
 
     /// who wants to be informed on updates about this?

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -151,32 +151,8 @@ impl Deref for CalendarEvent {
 
 /// helpers for inner
 impl CalendarEvent {
-    pub fn title(&self) -> String {
-        self.inner.title.clone()
-    }
-
-    pub fn description_text(&self) -> Option<String> {
-        self.inner.description.as_ref().map(|t| t.body.clone())
-    }
-
-    pub fn color(&self) -> Option<Color> {
-        self.inner.color.clone()
-    }
-
-    pub fn icon(&self) -> Option<Icon> {
-        self.inner.icon.clone()
-    }
-
     pub fn event_id(&self) -> OwnedEventId {
         self.inner.event_id().to_owned()
-    }
-
-    pub fn utc_start(&self) -> UtcDateTime {
-        self.inner.utc_start
-    }
-
-    pub fn utc_end(&self) -> UtcDateTime {
-        self.inner.utc_end
     }
 }
 

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -280,17 +280,10 @@ impl Deref for TaskList {
     }
 }
 
+/// helpers for content
 impl TaskList {
-    pub fn name(&self) -> String {
-        self.content.name.clone()
-    }
-
     pub fn description_text(&self) -> Option<String> {
-        self.description.as_ref().map(|t| t.body.clone())
-    }
-
-    pub fn subscribers(&self) -> Vec<OwnedUserId> {
-        self.content.subscribers.clone()
+        self.content.description.as_ref().map(|t| t.body.clone())
     }
 
     pub fn role(&self) -> Option<String> {
@@ -302,10 +295,6 @@ impl TaskList {
 
     pub fn sort_order(&self) -> u32 {
         self.content.sort_order
-    }
-
-    pub fn color(&self) -> Option<Color> {
-        self.content.color.clone()
     }
 
     pub fn time_zone(&self) -> Option<String> {
@@ -344,6 +333,7 @@ impl TaskList {
     }
 }
 
+// custom functions
 impl TaskList {
     pub fn client(&self) -> &Client {
         &self.client
@@ -465,20 +455,8 @@ impl Deref for Task {
 
 /// helpers for content
 impl Task {
-    pub fn title(&self) -> String {
-        self.content.title.clone()
-    }
-
     pub fn description_text(&self) -> Option<String> {
         self.content.description.as_ref().map(|t| t.body.clone())
-    }
-
-    pub fn assignees(&self) -> Vec<OwnedUserId> {
-        self.content.assignees.clone()
-    }
-
-    pub fn subscribers(&self) -> Vec<OwnedUserId> {
-        self.content.subscribers.clone()
     }
 
     pub fn sort_order(&self) -> u32 {
@@ -498,18 +476,6 @@ impl Task {
             Priority::SecondLowest => 8,
             Priority::Lowest => 9,
         })
-    }
-
-    pub fn utc_due(&self) -> Option<UtcDateTime> {
-        self.content.utc_due
-    }
-
-    pub fn utc_start(&self) -> Option<UtcDateTime> {
-        self.content.utc_start
-    }
-
-    pub fn color(&self) -> Option<Color> {
-        self.content.color.clone()
     }
 
     pub fn is_done(&self) -> bool {

--- a/native/core/src/events/tasks.rs
+++ b/native/core/src/events/tasks.rs
@@ -94,12 +94,6 @@ pub struct TaskListEventContent {
     pub subscribers: Vec<OwnedUserId>,
 }
 
-impl TaskListBuilder {
-    pub fn description_text(&mut self, text: String) -> &mut Self {
-        self.description(Some(TextMessageEventContent::plain(text)))
-    }
-}
-
 /// The TaskList Event
 ///
 /// modeled after [JMAP TaskList](https://jmap.io/spec-tasks.html#tasklists)

--- a/native/test/src/tests/tasks.rs
+++ b/native/test/src/tests/tasks.rs
@@ -30,7 +30,7 @@ async fn odos_tasks() -> Result<()> {
     state_sync.await_has_synced_history().await?;
 
     let task_lists = odo.task_lists().await?;
-    let Some(mut task_list) = task_lists.into_iter().find(|t| t.name() == list_name) else {
+    let Some(mut task_list) = task_lists.into_iter().find(|t| t.name() == list_name.as_str()) else {
         bail!("TaskList not found");
     };
 
@@ -61,7 +61,7 @@ async fn odos_tasks() -> Result<()> {
                 .task_lists()
                 .await?
                 .into_iter()
-                .find(|t| t.name() == list_name)
+                .find(|t| t.name() == list_name.as_str())
                 .expect("TaskList not found again");
             if let Some(task) = task_list
                 .tasks()
@@ -150,7 +150,7 @@ async fn task_smoketests() -> Result<()> {
         bail!("freshly created Task List couldn't be found");
     };
 
-    assert_eq!(task_list.name(), "Starting up".to_owned());
+    assert_eq!(task_list.name(), "Starting up");
     assert_eq!(task_list.tasks().await?.len(), 0);
 
     let task_list_listener = task_list.subscribe();
@@ -183,7 +183,7 @@ async fn task_smoketests() -> Result<()> {
     assert_eq!(tasks[0].event_id(), task_1_id);
 
     let task_1 = tasks[0].clone();
-    assert_eq!(task_1.title(), "Testing 1".to_owned());
+    assert_eq!(task_1.title(), "Testing 1");
     assert!(!task_1.is_done());
 
     let task_list_listener = task_list.subscribe();
@@ -216,7 +216,7 @@ async fn task_smoketests() -> Result<()> {
     assert_eq!(tasks[1].event_id(), task_2_id);
 
     let task_2 = tasks[1].clone();
-    assert_eq!(task_2.title(), "Testing 2".to_owned());
+    assert_eq!(task_2.title(), "Testing 2");
     assert!(!task_2.is_done());
 
     let task_1_updater = task_1.subscribe();
@@ -246,7 +246,7 @@ async fn task_smoketests() -> Result<()> {
 
     let task_1 = task_1.refresh().await?;
     // Update has been applied properly
-    assert_eq!(task_1.title(), "Replacement Name".to_owned());
+    assert_eq!(task_1.title(), "Replacement Name");
     assert!(task_1.is_done());
 
     let task_list_listener = task_list.subscribe();
@@ -276,9 +276,9 @@ async fn task_smoketests() -> Result<()> {
 
     let task_list = task_list.refresh().await?;
 
-    assert_eq!(task_list.name(), "Setup".to_owned());
+    assert_eq!(task_list.name(), "Setup");
     assert_eq!(
-        task_list.description().as_ref().unwrap().body,
+        task_list.description_text().unwrap(),
         "All done now".to_owned()
     );
 
@@ -320,7 +320,7 @@ async fn task_lists_comments_smoketests() -> Result<()> {
 
     let comments_manager = task_list.comments().await?;
 
-    assert_eq!(task_list.name(), "Comments test".to_owned());
+    assert_eq!(task_list.name(), "Comments test");
     assert_eq!(task_list.tasks().await?.len(), 0);
     assert!(!comments_manager.stats().has_comments());
 
@@ -393,7 +393,7 @@ async fn task_comment_smoketests() -> Result<()> {
         bail!("freshly created Task List couldn't be found");
     };
 
-    assert_eq!(task_list.name(), "Starting up".to_owned());
+    assert_eq!(task_list.name(), "Starting up");
     assert_eq!(task_list.tasks().await?.len(), 0);
 
     let task_list_listener = task_list.subscribe();

--- a/native/tui/src/ui.rs
+++ b/native/tui/src/ui.rs
@@ -268,7 +268,7 @@ impl TasksState {
             let ls = List::new(
                 self.task_lists
                     .iter()
-                    .map(|l| ListItem::new(Text::from(l.name())))
+                    .map(|l| ListItem::new(Text::from(l.name().as_str())))
                     .collect::<Vec<_>>(),
             )
             .highlight_style(Style::default().add_modifier(Modifier::BOLD).fg(PRIMARY))


### PR DESCRIPTION
I will remove some duplications from `api/calendar_events.rs` and `api/tasks.rs`, because they are implemented in `models/calendar/event.rs` and `models/tasks.rs`.