### PR TITLE
Add Noto Color Emoji font and use it in latest emoji_picker_widget

### DIFF
--- a/app/lib/common/widgets/emoji_picker_widget.dart
+++ b/app/lib/common/widgets/emoji_picker_widget.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:expandable_text/expandable_text.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
 
 class EmojiPickerWidget extends StatelessWidget {
@@ -37,10 +38,12 @@ class EmojiPickerWidget extends StatelessWidget {
                   onSelected(emoji.emoji),
               config: Config(
                 columns: 7,
+                emojiTextStyle: GoogleFonts.notoColorEmoji(),
+                checkPlatformCompatibility: false,
                 emojiSizeMax: 32 * ((!kIsWeb && Platform.isIOS) ? 1.30 : 1.0),
                 initCategory: Category.RECENT,
-                bgColor: Colors.white,
-                showRecentsTab: false,
+                bgColor: Theme.of(context).colorScheme.background,
+                recentTabBehavior: RecentTabBehavior.RECENT,
                 recentsLimit: 28,
               ),
             ),

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -10,8 +11,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mentions/flutter_mentions.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart' show toBeginningOfSentenceCase;
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 class CustomChatInput extends StatelessWidget {
   static const List<Icon> _attachmentIcons = [
@@ -534,8 +537,12 @@ class EmojiPickerWidget extends StatelessWidget {
               columns: 7,
               verticalSpacing: 0,
               horizontalSpacing: 0,
-              initCategory: Category.SMILEYS,
-              showRecentsTab: true,
+              checkPlatformCompatibility: false,
+              emojiTextStyle: GoogleFonts.notoColorEmoji(),
+              initCategory: Category.RECENT,
+              emojiSizeMax: 32 * ((!kIsWeb && Platform.isIOS) ? 1.30 : 1.0),
+              bgColor: Theme.of(context).colorScheme.background,
+              recentTabBehavior: RecentTabBehavior.RECENT,
               recentsLimit: 28,
               noRecents: Text(
                 AppLocalizations.of(context)!.noRecents,

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -68,7 +68,7 @@ class _DashboardState extends ConsumerState<Dashboard> {
     bool isActive(f) => provider.isActive(f);
 
     List<Widget> children = [];
-    if (isActive(LabsFeature.tasks)) {
+    if (false && isActive(LabsFeature.tasks)) {
       children.add(const MyTasksSection(limit: 5));
     }
 

--- a/app/lib/features/todo/widgets/comment_input.dart
+++ b/app/lib/features/todo/widgets/comment_input.dart
@@ -9,6 +9,7 @@ import 'package:atlas_icons/atlas_icons.dart';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:get/get.dart';
 
 class CommentInput extends ConsumerStatefulWidget {
@@ -168,8 +169,10 @@ class CommentInputState extends ConsumerState<CommentInput> {
                     backspaceColor: Colors.blue,
                     skinToneDialogBgColor: Colors.white,
                     skinToneIndicatorColor: Colors.grey,
+                    checkPlatformCompatibility: false,
+                    emojiTextStyle: GoogleFonts.notoColorEmoji(),
                     enableSkinTones: true,
-                    showRecentsTab: true,
+                    recentTabBehavior: RecentTabBehavior.RECENT,
                     recentsLimit: 28,
                     noRecents: const Text(
                       'No Recents',

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: emoji_picker_flutter
-      sha256: feb141b3ab9188e33c2ec35212136ecb3f79215d881aa5af3d3e0df28f84b725
+      sha256: "1ca31245cc1f7ab5304c68ccda8039f52b9f2372aa4d10803117160fad3faf12"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.1"
   equatable:
     dependency: transitive
     description:
@@ -749,10 +749,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: e70521755a6b08c6bde14ddae27dff5bf21010033888fc61da6c595f8a9f58c1
+      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "4.0.4"
   graphs:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   flutter_chat_types: ^3.3.2
   flutter_staggered_grid_view: ^0.6.2
   flutter_svg: ">=1.0.0"
-  google_fonts: ^2.3.1
+  google_fonts: ^4.0.0  # 5.0 not yet supported as it needs http 1.0, which in turn needs dart3, which is part of flutter 3.10 ...
   flutter_link_previewer: ^3.0.1
   bubble: ^1.2.1
   colorize_text_avatar: ^1.0.2
@@ -94,7 +94,7 @@ dependencies:
   file_picker: ^5.2.5
   filesystem_picker: ^2.0.1
   open_app_file: ^4.0.1
-  emoji_picker_flutter: ^1.5.2
+  emoji_picker_flutter: ^1.6.1
   connectivity_plus: ^3.0.3
   mime: ^1.0.2
   permission_handler: ^10.2.0


### PR DESCRIPTION
By adding Noto Color Emoji font and use that for emoji-picker we can render good emojis on platforms not having a good default emoji font. But this adds a whopping 10mb (I found a smaller version, the one from googlefonts is even 20mb) to our package _for all platforms_, even the ones with good support (like Android and iOS), so that sucks.

I am no sure we want to take this approach...


fixes #686 .

