### PR TITLE
Space members and power-level updates

### DIFF
--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -35,6 +35,7 @@ enum Routes {
   spaceInvite('/:spaceId([!#][^/]+)/invite'),
   space('/:spaceId([!#][^/]+)'), // !spaceId, #spaceName
   spaceRelatedSpaces('/:spaceId([!#][^/]+)/spaces'),
+  spaceMembers('/:spaceId([!#][^/]+)/members'),
   spacePins('/:spaceId([!#][^/]+)/pins'),
   spaceEvents('/:spaceId([!#][^/]+)/events'),
   spaceChats('/:spaceId([!#][^/]+)/chats'),

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -6,7 +6,6 @@ import 'package:acter/common/widgets/user_avatar.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/home/widgets/my_spaces_section.dart';
 import 'package:acter/features/home/widgets/my_events.dart';
-import 'package:acter/features/home/widgets/my_tasks.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/providers/space_providers.dart';

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -68,10 +68,6 @@ class _DashboardState extends ConsumerState<Dashboard> {
     bool isActive(f) => provider.isActive(f);
 
     List<Widget> children = [];
-    if (isActive(LabsFeature.tasks)) {
-      children.add(const MyTasksSection(limit: 5));
-    }
-
     if (isActive(LabsFeature.events)) {
       children.add(const MyEventsSection());
     }

--- a/app/lib/features/space/pages/members_page.dart
+++ b/app/lib/features/space/pages/members_page.dart
@@ -1,0 +1,93 @@
+import 'dart:core';
+import 'dart:math';
+
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/space/widgets/member_list_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:go_router/go_router.dart';
+
+class SpaceMembersPage extends ConsumerWidget {
+  final String spaceIdOrAlias;
+  const SpaceMembersPage({super.key, required this.spaceIdOrAlias});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final space = ref.watch(spaceProvider(spaceIdOrAlias)).requireValue;
+    final members = ref.watch(spaceMembersProvider(spaceIdOrAlias));
+    final myMembership = ref.watch(spaceMembershipProvider(spaceIdOrAlias));
+    // get platform of context.
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Members',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(
+                    Atlas.plus_circle_thin,
+                    color: Theme.of(context).colorScheme.neutral5,
+                  ),
+                  iconSize: 28,
+                  color: Theme.of(context).colorScheme.surface,
+                  onPressed: () => context.pushNamed(
+                    Routes.actionAddPin.name,
+                    queryParameters: {'spaceId': spaceIdOrAlias},
+                  ),
+                ),
+              ],
+            ),
+          ),
+          members.when(
+            data: (members) {
+              final widthCount =
+                  (MediaQuery.of(context).size.width ~/ 600).toInt();
+              const int minCount = 2;
+              if (members.isEmpty) {
+                return const SliverToBoxAdapter(
+                  child: Center(
+                    child: Text('there is nothing pinned yet'),
+                  ),
+                );
+              }
+              return SliverGrid.builder(
+                itemCount: members.length,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: max(1, min(widthCount, minCount)),
+                  childAspectRatio: 6,
+                ),
+                itemBuilder: (context, index) {
+                  final member = members[index];
+                  return MemberListEntry(
+                    member: member,
+                    myMembership: myMembership.valueOrNull,
+                  );
+                },
+              );
+            },
+            error: (error, stack) => SliverToBoxAdapter(
+              child: Center(
+                child: Text('Loading failed: $error'),
+              ),
+            ),
+            loading: () => const SliverToBoxAdapter(
+              child: Center(
+                child: Text('Loading'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/space/pages/members_page.dart
+++ b/app/lib/features/space/pages/members_page.dart
@@ -70,6 +70,7 @@ class SpaceMembersPage extends ConsumerWidget {
                   final member = members[index];
                   return MemberListEntry(
                     member: member,
+                    space: space,
                     myMembership: myMembership.valueOrNull,
                   );
                 },

--- a/app/lib/features/space/providers/space_navbar_provider.dart
+++ b/app/lib/features/space/providers/space_navbar_provider.dart
@@ -88,6 +88,15 @@ final tabsProvider =
       target: Routes.spaceRelatedSpaces.name,
     ),
   );
+
+  tabs.add(
+    TabEntry(
+      key: const Key('members'),
+      label: 'Members',
+      icon: const Icon(Atlas.group_team_collective_thin),
+      target: Routes.spaceMembers.name,
+    ),
+  );
   return tabs;
 });
 

--- a/app/lib/features/space/widgets/member_list_entry.dart
+++ b/app/lib/features/space/widgets/member_list_entry.dart
@@ -1,0 +1,163 @@
+import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:go_router/go_router.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:acter_avatar/acter_avatar.dart';
+import 'package:flutter/services.dart';
+
+class MemberListEntry extends ConsumerWidget {
+  final Member member;
+  final Member? myMembership;
+
+  const MemberListEntry({
+    super.key,
+    required this.member,
+    this.myMembership,
+  });
+
+  Widget submenu(BuildContext context, WidgetRef ref) {
+    final List<PopupMenuEntry> submenu = [];
+
+    submenu.add(
+      PopupMenuItem(
+        onTap: () {
+          Clipboard.setData(
+            ClipboardData(
+              text: member.userId().toString(),
+            ),
+          );
+          customMsgSnackbar(
+            context,
+            'Username copied to clipboard',
+          );
+        },
+        child: const Text('Copy username'),
+      ),
+    );
+
+    if (myMembership != null) {
+      submenu.add(const PopupMenuDivider());
+      if (myMembership!.canString('CanUpdatePowerLevels')) {
+        submenu.add(
+          PopupMenuItem(
+            onTap: () => customMsgSnackbar(
+              context,
+              'Power Level change is not implemented yet',
+            ),
+            child: const Text('Change Power Level'),
+          ),
+        );
+      }
+
+      if (myMembership!.canString('CanKick')) {
+        submenu.add(
+          PopupMenuItem(
+            onTap: () => customMsgSnackbar(
+              context,
+              'Kicking not yet implemented yet',
+            ),
+            child: const Text('Kick User'),
+          ),
+        );
+
+        if (myMembership!.canString('CanBan')) {
+          submenu.add(
+            PopupMenuItem(
+              onTap: () => customMsgSnackbar(
+                context,
+                'Kicking not yet implemented yet',
+              ),
+              child: const Text('Kick & Ban User'),
+            ),
+          );
+        }
+      }
+
+      // if (submenu.isNotEmpty) {
+      //   // add divider
+      //   submenu.add(const PopupMenuDivider());
+      // }
+      // submenu.add(
+      //   PopupMenuItem(
+      //     onTap: () => _handleLeaveSpace(context, space, ref),
+      //     child: const Text('Leave Space'),
+      //   ),
+      // );
+    }
+
+    return PopupMenuButton(
+      icon: Icon(
+        Icons.more_vert,
+        color: Theme.of(context).colorScheme.neutral5,
+      ),
+      iconSize: 28,
+      color: Theme.of(context).colorScheme.surface,
+      itemBuilder: (BuildContext context) => submenu,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(memberProfileProvider(member));
+    final userId = member.userId().toString();
+    final memberStatus = member.membershipStatusStr();
+    final List<Widget> trailing = [];
+    debugPrint(memberStatus);
+    if (memberStatus == 'Admin') {
+      trailing.add(
+        const Tooltip(
+          message: 'Space Admin',
+          child: Icon(Atlas.crown_winner_thin),
+        ),
+      );
+    } else if (memberStatus == 'Mod') {
+      trailing.add(
+        const Tooltip(
+          message: 'Space Moderator',
+          child: Icon(Atlas.shield_star_win_thin),
+        ),
+      );
+    } else if (memberStatus == 'Custom') {
+      trailing.add(
+        Tooltip(
+          message: 'Custom Power Level (${member.powerLevel()})',
+          child: const Icon(Atlas.star_medal_award_thin),
+        ),
+      );
+    }
+    if (myMembership != null) {
+      trailing.add(submenu(context, ref));
+    }
+    return Card(
+      child: ListTile(
+        leading: profile.when(
+          data: (data) => ActerAvatar(
+            mode: DisplayMode.User,
+            uniqueId: member.userId().toString(),
+            size: 18,
+            avatar: data.getAvatarImage(),
+            displayName: data.displayName,
+          ),
+          loading: () => const Text('loading'),
+          error: (e, t) => Text('loading avatar failed: $e'),
+        ),
+        title: profile.when(
+          data: (data) => Text(data.displayName ?? userId),
+          loading: () => Text(userId),
+          error: (e, s) => Text('loading profile failed: $e'),
+        ),
+        subtitle: Text(userId),
+        trailing: Row(
+          children: trailing,
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.end,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -19,6 +19,7 @@ import 'package:acter/features/pins/pages/pins_page.dart';
 import 'package:acter/features/pins/pages/pin_page.dart';
 import 'package:acter/features/space/pages/chats_page.dart';
 import 'package:acter/features/space/dialogs/invite_to_space_dialog.dart';
+import 'package:acter/features/space/pages/members_page.dart';
 import 'package:acter/features/spaces/dialogs/create_space_sheet.dart';
 import 'package:acter/features/news/pages/simple_post.dart';
 import 'package:acter/features/news/pages/news_page.dart';
@@ -579,6 +580,22 @@ List<RouteBase> makeRoutes(Ref ref) => [
                   return NoTransitionPage(
                     key: state.pageKey,
                     child: RelatedSpacesPage(
+                      spaceIdOrAlias: state.pathParameters['spaceId']!,
+                    ),
+                  );
+                },
+              ),
+              GoRoute(
+                name: Routes.spaceMembers.name,
+                path: Routes.spaceMembers.route,
+                redirect: authGuardRedirect,
+                pageBuilder: (context, state) {
+                  ref
+                      .read(selectedTabKeyProvider.notifier)
+                      .switchTo(const Key('members'));
+                  return NoTransitionPage(
+                    key: state.pageKey,
+                    child: SpaceMembersPage(
                       spaceIdOrAlias: state.pathParameters['spaceId']!,
                     ),
                   );

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -5893,6 +5893,52 @@ class Api {
     return tmp7;
   }
 
+  EventId? __spaceUpdatePowerLevelFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceUpdatePowerLevelFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(tmp10_0.asTypedList(tmp11));
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
   OptionText? __accountDisplayNameFuturePoll(
     int boxed,
     int postCobject,
@@ -15205,6 +15251,24 @@ class Api {
       int Function(
     int,
   )>();
+  late final _spaceUpdatePowerLevelPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+    ffi.Int64,
+    ffi.Int64,
+    ffi.Uint64,
+    ffi.Uint64,
+    ffi.Int32,
+  )>>("__Space_update_power_level");
+
+  late final _spaceUpdatePowerLevel = _spaceUpdatePowerLevelPtr.asFunction<
+      int Function(
+    int,
+    int,
+    int,
+    int,
+    int,
+  )>();
   late final _memberGetProfilePtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -18568,6 +18632,21 @@ class Api {
 
   late final _spaceLeaveFuturePoll = _spaceLeaveFuturePollPtr.asFunction<
       _SpaceLeaveFuturePollReturn Function(
+    int,
+    int,
+    int,
+  )>();
+  late final _spaceUpdatePowerLevelFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _SpaceUpdatePowerLevelFuturePollReturn Function(
+    ffi.Int64,
+    ffi.Int64,
+    ffi.Int64,
+  )>>("__Space_update_power_level_future_poll");
+
+  late final _spaceUpdatePowerLevelFuturePoll =
+      _spaceUpdatePowerLevelFuturePollPtr.asFunction<
+          _SpaceUpdatePowerLevelFuturePollReturn Function(
     int,
     int,
     int,
@@ -32780,6 +32859,43 @@ class Space {
     return tmp2;
   }
 
+  /// update the power levels of specified member
+  Future<EventId> updatePowerLevel(
+    String userId,
+    int level,
+  ) {
+    final tmp1 = userId;
+    final tmp5 = level;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    tmp6 = tmp5;
+    final tmp7 = _api._spaceUpdatePowerLevel(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+    );
+    final tmp9 = tmp7;
+    final ffi.Pointer<ffi.Void> tmp9_0 = ffi.Pointer.fromAddress(tmp9);
+    final tmp9_1 = _Box(_api, tmp9_0, "__Space_update_power_level_future_drop");
+    tmp9_1._finalizer = _api._registerFinalizer(tmp9_1);
+    final tmp8 = _nativeFuture(tmp9_1, _api.__spaceUpdatePowerLevelFuturePoll);
+    return tmp8;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -40180,6 +40296,21 @@ class _SpaceLeaveFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Uint8()
+  external int arg5;
+}
+
+class _SpaceUpdatePowerLevelFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
   external int arg5;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -15225,6 +15225,27 @@ class Api {
       int Function(
     int,
   )>();
+  late final _memberMembershipStatusStrPtr = _lookup<
+      ffi.NativeFunction<
+          _MemberMembershipStatusStrReturn Function(
+    ffi.Int64,
+  )>>("__Member_membership_status_str");
+
+  late final _memberMembershipStatusStr =
+      _memberMembershipStatusStrPtr.asFunction<
+          _MemberMembershipStatusStrReturn Function(
+    int,
+  )>();
+  late final _memberPowerLevelPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint64 Function(
+    ffi.Int64,
+  )>>("__Member_power_level");
+
+  late final _memberPowerLevel = _memberPowerLevelPtr.asFunction<
+      int Function(
+    int,
+  )>();
   late final _memberCanStringPtr = _lookup<
       ffi.NativeFunction<
           ffi.Uint8 Function(
@@ -20823,6 +20844,12 @@ class Api {
 
   late final _destructureRelationTargetType = _destructureRelationTargetTypePtr
       .asFunction<_EnumWrapper Function(int)>();
+  late final _destructureMembershipStatusPtr =
+      _lookup<ffi.NativeFunction<_EnumWrapper Function(ffi.IntPtr)>>(
+          "destructure_enum_MembershipStatus");
+
+  late final _destructureMembershipStatus =
+      _destructureMembershipStatusPtr.asFunction<_EnumWrapper Function(int)>();
   late final _destructureMemberPermissionPtr =
       _lookup<ffi.NativeFunction<_EnumWrapper Function(ffi.IntPtr)>>(
           "destructure_enum_MemberPermission");
@@ -32795,6 +32822,49 @@ class Member {
     return tmp2;
   }
 
+  /// The status of this member.
+  String membershipStatusStr() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._memberMembershipStatusStr(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final utf8Decoder = utf8.decoder;
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8Decoder.convert(tmp3_buf);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// the power level this user has
+  int powerLevel() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._memberPowerLevel(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3;
+    return tmp2;
+  }
+
   /// Whether this user is allowed to perform the given action
   bool canString(
     String permission,
@@ -36630,6 +36700,65 @@ class RelationTargetType {
   RelationTargetType._(this._api, this._box);
 }
 
+enum MembershipStatusTag {
+  Admin,
+  Mod,
+  Custom,
+  Regular,
+}
+
+class MembershipStatus {
+  final Api _api;
+  final _Box _box;
+
+  MembershipStatusTag? _tag;
+  Object? _inner;
+
+  void destructureSelf() {
+    final parts = this._api._destructureMembershipStatus(this._box.borrow());
+    switch (parts.tag) {
+      case 0:
+        this._tag = MembershipStatusTag.Admin;
+
+        break;
+      case 1:
+        this._tag = MembershipStatusTag.Mod;
+
+        break;
+      case 2:
+        this._tag = MembershipStatusTag.Custom;
+
+        break;
+      case 3:
+        this._tag = MembershipStatusTag.Regular;
+
+        break;
+      default:
+        throw new StateError(
+            "Destructuring enum gave back an invalid tag: ${parts.tag}");
+    }
+  }
+
+  /// The tag of this enum object
+  MembershipStatusTag get tag {
+    if (_tag == null) {
+      destructureSelf();
+    }
+    return _tag!;
+  }
+
+  /// The data contained inside this enum object. You will need
+  /// to cast it to the correct type based on the value of tag
+  Object? get inner {
+    if (_inner == null) {
+      destructureSelf();
+    }
+    return _inner;
+  }
+
+  MembershipStatus._(this._api, this._box);
+}
+
 enum MemberPermissionTag {
   CanSendChatMessages,
   CanSendReaction,
@@ -36645,6 +36774,7 @@ enum MemberPermissionTag {
   CanUpdateAvatar,
   CanSetTopic,
   CanLinkSpaces,
+  CanUpdatePowerLevels,
   CanSetParentSpace,
 }
 
@@ -36715,6 +36845,10 @@ class MemberPermission {
 
         break;
       case 14:
+        this._tag = MemberPermissionTag.CanUpdatePowerLevels;
+
+        break;
+      case 15:
         this._tag = MemberPermissionTag.CanSetParentSpace;
 
         break;
@@ -38108,6 +38242,15 @@ class _SpacePinDraftReturn extends ffi.Struct {
   external int arg3;
   @ffi.Int64()
   external int arg4;
+}
+
+class _MemberMembershipStatusStrReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
 }
 
 class _PublicSearchResultItemNameReturn extends ffi.Struct {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1273,6 +1273,10 @@ object Space {
 
     /// leave this room
     fn leave() -> Future<Result<bool>>;
+    
+       /// update the power levels of specified member
+    fn update_power_level(user_id: string, level: i32) -> Future<Result<EventId>>;
+
 }
 
 enum MembershipStatus {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1275,6 +1275,13 @@ object Space {
     fn leave() -> Future<Result<bool>>;
 }
 
+enum MembershipStatus {
+    Admin,
+    Mod,
+    Custom,
+    Regular
+}
+
 enum MemberPermission {
     CanSendChatMessages,
     CanSendReaction,
@@ -1290,6 +1297,7 @@ enum MemberPermission {
     CanUpdateAvatar,
     CanSetTopic,
     CanLinkSpaces,
+    CanUpdatePowerLevels,
     CanSetParentSpace
 }
 
@@ -1299,6 +1307,12 @@ object Member {
 
     /// Full user_id
     fn user_id() -> UserId;
+
+    /// The status of this member.
+    fn membership_status_str() -> string;
+
+    /// the power level this user has
+    fn power_level() -> u64;
 
     /// Whether this user is allowed to perform the given action
     //fn can(permission: MemberPermission) -> bool;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -71,7 +71,7 @@ pub use news::{NewsEntry, NewsEntryDraft, NewsEntryUpdateBuilder, NewsSlide};
 pub use pins::{Pin as ActerPin, PinDraft, PinUpdateBuilder};
 pub use profile::{RoomProfile, UserProfile};
 pub use receipt::{ReceiptEvent, ReceiptRecord};
-pub use room::{Member, MemberPermission, Room};
+pub use room::{Member, MemberPermission, MembershipStatus, Room};
 pub use search::{PublicSearchResult, PublicSearchResultItem};
 pub use spaces::{
     new_space_settings_builder, CreateSpaceSettings, CreateSpaceSettingsBuilder,


### PR DESCRIPTION
Adds support for another tab in the space to see the current list of members and their respective power-level status. And as an admin, you can update said status as well:

![space-admin](https://github.com/acterglobal/a3/assets/40496/b3cf4778-7cf7-45a5-a254-3d495856f91b)
