### PR TITLE
Rename windows binary to acter

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/l10n/l10n.dart';
@@ -14,7 +13,6 @@ import 'package:flutter_mentions/flutter_mentions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:overlay_support/overlay_support.dart';
-import 'package:window_size/window_size.dart';
 
 void main() async {
   await startApp();
@@ -31,10 +29,6 @@ Future<void> startApp() async {
 }
 
 Future<void> startAppInner() async {
-  bool isDesktop = Platform.isWindows || Platform.isMacOS || Platform.isLinux;
-  if (isDesktop) {
-    setWindowTitle('Acter');
-  }
   GoogleFonts.config.allowRuntimeFetching = false;
   LicenseRegistry.addLicense(() async* {
     final license = await rootBundle.loadString('google_fonts/LICENSE.txt');

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1780,15 +1780,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  window_size:
-    dependency: "direct main"
-    description:
-      path: "plugins/window_size"
-      ref: HEAD
-      resolved-ref: "6c66ad23ee79749f30a8eece542cf54eaf157ed8"
-      url: "https://github.com/google/flutter-desktop-embedding.git"
-    source: git
-    version: "0.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -99,10 +99,6 @@ dependencies:
   mime: ^1.0.2
   permission_handler: ^10.2.0
   sprintf: ^6.0.0
-  window_size:
-    git:
-      url: https://github.com/google/flutter-desktop-embedding.git
-      path: plugins/window_size
   flutter_custom_selector: ^0.0.3
   date_format: ^2.0.2
   screenshot: ^1.3.0

--- a/app/windows/CMakeLists.txt
+++ b/app/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "app")
+set(BINARY_NAME "acter")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/app/windows/runner/main.cpp
+++ b/app/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.CreateAndShow(L"app", origin, size)) {
+  if (!window.CreateAndShow(L"Acter", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
- [Rename windows binary](https://github.com/acterglobal/a3/issues/758), fixes #758 
- Change window title from flutter level to cpp level for windows (like linux)