### PR TITLE
New nightly section docs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,11 +23,17 @@ jobs:
       should_run: ${{ steps.check-new-commits.outputs.has-new-commits }}
     steps:
       - uses: actions/checkout@v2
-      - name: Check for new commits today
-        id: check-new-commits
-        uses: adriangl/check-new-commits-action@v1
         with:
-          seconds: 86400 # One day in seconds
+          fetch-depth: 0 # fetch all history and tags
+      - name: Check for new commits since last nightly
+        id: check-new-commits
+        shell: bash
+        run: |
+          if [ `git diff --name-only nightly-latest app native .changes | wc -l` -ne 0 ]; then
+            echo "has-new-commits=true"  >> $GITHUB_OUTPUT ;
+          else
+            echo "has-new-commits=false" >> $GITHUB_OUTPUT ;
+          fi
 
   tags:
     runs-on: ubuntu-latest
@@ -297,12 +303,22 @@ jobs:
           git fetch --prune --unshallow --tags
           cargo run -p mr_minutes -- --since nightly-latest --output nightly-changes.md
 
+      - name: "Generate docs"
+        run: |
+          echo "+++" > docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          echo "title = \" Nightly ${{ needs.tags.outputs.tag }}\"" >> docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          echo "template = \"nightlies/release.html\"" >> docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          echo "date = ${{ needs.tags.outputs.tag }}" >> docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          echo "+++" >>docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          echo "" >>docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+          cat nightly-changes.md >> docs/content/nightly/${{ needs.tags.outputs.tag }}.md
+
       - name: Tag for nightly release
         run: |
+          git cm "Add nightly ${{ needs.tags.outputs.tag }} to docs" docs/content/nightly/${{ needs.tags.outputs.tag }}.md
           git tag nightly-${{ needs.tags.outputs.tag }}
-          git push origin nightly-${{ needs.tags.outputs.tag }}
           git tag -f nightly-latest
-          git push -f origin nightly-latest
+          git push -f origin main nightly-${{ needs.tags.outputs.tag }} nightly-latest
       - name: Release
         id: create_release
         uses: softprops/action-gh-release@v1

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -28,10 +28,16 @@ twitter = "https://twitter.com/acterhq"
 email = "devs@acter.global"
 
 [[extra.menu.main]]
-name = "Getting Started"
+name = "Nightly builds"
+section = "nightly"
+url = "/nightly/"
+weight = 10
+
+[[extra.menu.main]]
+name = "Development"
 section = "docs"
 url = "/docs/getting-started/setup/"
-weight = 10
+weight = 15
 
 [[extra.menu.main]]
 name = "APIs"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,11 +1,10 @@
 +++
 title = "Acter Docs"
 
+template = "acter_index.html"
+
 # The homepage contents
 [extra]
-lead = '<b>Acter</b> the mobile-first <strong>community</strong> communication and <strong>casual organising</strong> plattform. The palm-pilot for your social groups.'
-url = "/docs/getting-started/setup/"
-url_button = "Getting started"
 repo_version = "GitHub v0.1.0"
 repo_license = "Acter Public Source License."
 repo_url = "https://github.com/acterglobal/a3"

--- a/docs/content/nightly/2023-07-20.md
+++ b/docs/content/nightly/2023-07-20.md
@@ -1,0 +1,8 @@
++++
+title = "Nightly 2023-07-20"
+template = "nightlies/release.html"
+date = 2023-07-20
+
++++
+
+- Bug reporting works now

--- a/docs/content/nightly/2023-07-21.md
+++ b/docs/content/nightly/2023-07-21.md
@@ -1,0 +1,10 @@
++++
+title = " Nightly 2023-07-21"
+template = "nightlies/release.html"
+date = 2023-07-21
++++
+
+- Renamed sidebar entry from Search to "Jump" and "Overview" to "Home" to align on the concept
+- Fix typos in onboarding pages
+- Special character limitation for username in registration form
+- Fix colors for registration buttons and defaults in the system

--- a/docs/content/nightly/_index.md
+++ b/docs/content/nightly/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Nightly builds"
+
+sort_by = "date"
+template = "nightlies/index.html"
+paginate_by = 10
++++
+
+We are providing demo builds (when changes have been merged) of the latest development version every day --- called 'nightlies', as they are build during the night.

--- a/docs/templates/acter_index.html
+++ b/docs/templates/acter_index.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block seo %}
+  {{ super() }}
+
+  {% if config.title %}
+    {% set title = config.title %}
+  {% else %}
+    {% set title = "" %}
+  {% endif %}
+  
+  {% if config.extra.title_addition and title %}
+    {% set title_addition = title_separator ~ config.extra.title_addition %}
+  {% elif config.extra.title_addition %}
+    {% set title_addition = config.extra.title_addition %}
+  {% else %}
+    {% set title_addition = "" %}
+  {% endif %}
+  
+  {% set description = config.description %}
+  
+  {{ macros_head::seo(title=title, title_addition=title_addition, description=description, is_home=true) }}
+{% endblock seo %}
+
+{% block content %}
+<div class="wrap container" role="document">
+  <div class="content">
+    <section class="section container-fluid mt-n3 pb-3">
+      <div class="row justify-content-center">
+        <div class="col-lg-12 text-center">
+          <h1 class="mt-0">{{ section.title | default(value="Modern Documentation Theme") }}</h1>
+        </div>
+        <div class="col-lg-9 col-xl-8 text-center">
+          <p class="lead">
+            <b>Acter</b> the mobile-first <strong>community</strong> communication and <strong>casual organising</strong> plattform. The palm-pilot for your social groups.'
+
+          </p>
+          <a class="btn btn-primary btn-lg px-4 mb-2" href="/nightly" role="button">Nightly builds</a> <a class="btn btn-outline-secondary btn-lg px-4 mb-2" href="/docs/getting-started/setup/" role="button">Dev setup</a>
+          <p class="meta">{{ section.extra.repo_license | default(value="MIT")}} <a href="{{ section.extra.repo_url | default(value="https://github.com/aaranxu/adidoks") | safe }}">{{ section.extra.repo_version | default(value="0.1.0") }}</a></p>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+
+<section class="section section-sm">
+  <div class="container">
+    <div class="row justify-content-center text-center">
+      {% if section.extra.list %}
+        {% for val in section.extra.list %}
+        <div class="col-lg-5">
+          <h2 class="h4">{{ val.title }}</h2>
+          <p>{{ val.content | safe }}</p>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="col-lg-5">
+          <h2 class="h4">Security aware</h2>
+          <p>Get A+ scores on <a href="https://observatory.mozilla.org/analyze/doks.netlify.app">Mozilla Observatory</a> out of the box. Easily change the default Security Headers to suit your needs.</p>
+        </div>      
+        <div class="col-lg-5">
+          <h2 class="h4">Fast by default ⚡️</h2>
+          <p>Get 100 scores on <a href="https://googlechrome.github.io/lighthouse/viewer/?gist=7731347bb8ce999eff7428a8e763b637">Google Lighthouse</a> by default. Doks removes unused css, prefetches links, and lazy loads images.</p>
+        </div>
+        <div class="col-lg-5">
+          <h2 class="h4">SEO-ready</h2>
+          <p>Use sensible defaults for structured data, open graph, and Twitter cards. Or easily change the SEO settings to your liking.</p>
+        </div>
+        <div class="col-lg-5">
+          <h2 class="h4">Full text search</h2>
+          <p>Search your Doks site with FlexSearch. Easily customize index settings and search options to your liking.</p>
+        </div>
+        <div class="col-lg-5">
+          <h2 class="h4">Page layouts</h2>
+          <p>Build pages with a landing page, blog, or documentation layout. Add custom sections and components to suit your needs.</p>
+        </div>
+        <div class="col-lg-5">
+          <h2 class="h4">Dark mode</h2>
+          <p>Switch to a low-light UI with the click of a button. Change colors with variables to match your branding.</p>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+<section class="section section-sm container-fluid">
+  <div class="row justify-content-center text-center">
+    <div class="col-lg-9"></div>
+  </div>
+</section>
+{% endblock content %}

--- a/docs/templates/macros/nightly-macros.html
+++ b/docs/templates/macros/nightly-macros.html
@@ -1,0 +1,46 @@
+
+{% macro nightly_desktop_install_buttons(tag_date) %}
+<a
+    class="btn btn-outline-secondary btn-lg px-4 mb-2"
+    href="https://github.com/acterglobal/a3/releases/download/nightly-{{tag_date}}/acter-nightly-windows-{{tag_date}}.zip"
+    role="button"
+>
+Windows (x64)
+</a>
+<a
+    class="btn btn-outline-secondary btn-lg px-4 mb-2"
+    href="https://github.com/acterglobal/a3/releases/download/nightly-{{tag_date}}/acter-nightly-macosx-{{tag_date}}.tar.bz2 "
+    role="button"
+>
+MacOS (intel & silicon)
+</a>
+<a
+    class="btn btn-outline-secondary btn-lg px-4 mb-2"
+    href="https://github.com/acterglobal/a3/releases/download/nightly-{{tag_date}}/acter-nightly-linux-x64-{{tag_date}}.tar.bz2 "
+    role="button"
+>
+Linux (x64)
+</a>
+
+{% endmacro %}
+
+{% macro nightly_mobile_install_buttons(tag_date) %}
+<a
+    class="btn btn-outline-primary btn-lg px-4 mb-2"
+    href="https://github.com/acterglobal/a3/releases/download/nightly-{{tag_date}}/acter-nightly-android-arm64-{{tag_date}}.apk"
+    role="button"
+>
+Android (arm64)
+</a>
+
+<a
+    class="btn btn-outline-primary btn-lg px-4 mb-2"
+    href="itms-services://?action=download-manifest&amp;url=https://github.com/acterglobal/a3/releases/download/nightly-{{tag_date}}/ios-manifest.plist"
+    role="button"
+>
+iPhone / iOS*
+</a>
+<br/>
+<small>* for ad-hoc registered devices only</small>
+
+{% endmacro %}

--- a/docs/templates/nightlies/index.html
+++ b/docs/templates/nightlies/index.html
@@ -1,0 +1,52 @@
+{% extends "section.html" %}
+
+{% import 'macros/nightly-macros.html' as nightly_macros -%}
+
+{% block body %}
+{% set page_class = "blog list" %}
+{% endblock body %}
+
+{% block header %}
+  {# This value is matched by the config.extra.menu.main~section #}
+  {% set current_section = "blog" %}
+  {{ macros_header::header(current_section=current_section)}}
+{% endblock header %}
+
+{% block content %}
+<div class="wrap container" role="document">
+  <div class="content">
+    <div class="row justify-content-center">
+      <div class="col-md-12 col-lg-10 col-xxl-8">
+        <article>
+          <h1 class="text-center">{{ section.title }}</h1>
+          <div class="text-center">{{ section.content | safe }}</div>
+            {% if not paginator.previous %}
+                <div class="content">
+                {% set latest_page = paginator.pages | first %} 
+                <h3>Install Latest</h3>
+                <h4>Desktop:</h4>
+                {{ nightly_macros::nightly_desktop_install_buttons(tag_date=latest_page.date) }}
+                <h4>On mobile:</h4>
+                {{ nightly_macros::nightly_mobile_install_buttons(tag_date=latest_page.date) }}
+                </div>
+            <h2>Changes</h2>
+            {% endif %}
+            <div class="card-list">
+            {% for page in paginator.pages %}
+                <div class="card">
+                <div class="card-body">
+                    <h3><a class="stretched-link text-body" href="{{ page.permalink }}">{{ page.title }}</a></h3>
+                    <p class="lead">{{ page.content | safe }}</p>
+                </div>
+                </div>
+            {% endfor %}
+            {% if paginator.previous or paginator.next %}
+              {{ macros_section_nav::navigation(paginator=paginator) }}
+            {% endif %}
+          </div>
+        </article>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/docs/templates/nightlies/release.html
+++ b/docs/templates/nightlies/release.html
@@ -1,0 +1,42 @@
+{# Default page template used for blog contents #}
+
+{% extends "page.html" %}
+{% import 'macros/nightly-macros.html' as nightly_macros -%}
+
+{% block seo %}
+  {# This value is matched by the config.extra.menu.main->section #}
+  {% set_global current_section = 'blog' %}
+  {{ super() }}
+{% endblock seo %}
+
+{% block body %}
+  {% set page_class = "blog single" %}
+{% endblock body %}
+
+{% block header %}
+  {{ macros_header::header(current_section=current_section)}}
+{% endblock header %}
+
+{% block content %}
+<div class="wrap container" role="document">
+  <div class="content">
+    <div class="row justify-content-center">
+      <div class="col-md-12 col-lg-10 col-xxl-8">
+        <article>
+          <div class="blog-header">
+            <h1>{{ page.title }}</h1>
+          </div>
+          <h2>Changes</h2>
+          {{ page.content | safe }}
+
+          <h3>Install</h3>
+          <h4>Desktop:</h4>
+          {{ nightly_macros::nightly_desktop_install_buttons(tag_date=page.date) }}
+          <h4>On mobile:</h4>
+          {{ nightly_macros::nightly_mobile_install_buttons(tag_date=page.date) }}
+        </article>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
With this change, we are replacing the getting-started section of docs.acter.global with a nightly-process, with direct links to click:
![grafik](https://github.com/acterglobal/a3/assets/40496/0ad8e3ec-87d3-4629-9fd3-2d7dd375767e)

![grafik](https://github.com/acterglobal/a3/assets/40496/3308c0ad-d989-4080-957d-2e8cc7bbd987)


Additionally, this contains changes to create the latest entry in docs automagically in the nightly-workflow and attach it to the docs. The docs will always link to the install section of the latest, but each sub-page also contains the corresponding links.