### PR TITLE
HotFix: #805, #804

### DIFF
--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -44,14 +44,6 @@ class _RoomPageConsumerState extends ConsumerState<RoomPage> {
     });
   }
 
-  @override
-  void dispose() {
-    debugPrint('Disposing message stream');
-    // making sure we dispose stream before loading next room.
-    ref.invalidate(chatRoomProvider);
-    super.dispose();
-  }
-
   void onAttach(BuildContext context) {
     showModalBottomSheet(
       backgroundColor: Colors.transparent,

--- a/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_list_notifier.dart
@@ -12,7 +12,7 @@ class ChatListNotifier extends StateNotifier<ChatListState> {
 
   void _loadUp() async {
     state = asyncChats.when(
-      data: (rooms) => ChatListState.data(chats: rooms),
+      data: (rooms) => ChatListState.data(chats: [...rooms]),
       error: (e, s) => ChatListState.error(e.toString()),
       loading: () => const ChatListState.loading(),
     );

--- a/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
@@ -38,7 +38,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
     roomId = id;
     room = await ref.read(chatProvider(roomId).future);
     timeline = await room.timelineStream();
-    StreamSubscription<TimelineDiff?>? subscription;
+    StreamSubscription<TimelineDiff>? subscription;
     subscription = timeline.diffRx().listen((event) async {
       await _parseEvent(event);
     });

--- a/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
@@ -414,11 +414,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
           author: author,
           createdAt: createdAt,
           id: eventId,
-          metadata: {
-            'itemType': 'event',
-            'eventType': eventType,
-            'repliedTo': inReplyTo,
-          },
+          metadata: metadata,
         );
       case 'm.room.member':
         TextDesc? description = eventItem.textDesc();

--- a/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
@@ -38,13 +38,11 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
     roomId = id;
     room = await ref.read(chatProvider(roomId).future);
     timeline = await room.timelineStream();
-    StreamSubscription<TimelineDiff>? subscription;
+    StreamSubscription<TimelineDiff?>? subscription;
     subscription = timeline.diffRx().listen((event) async {
       await _parseEvent(event);
     });
-    while (ref.read(messagesProvider).length < 10) {
-      await timeline.paginateBackwards(10);
-    }
+    await timeline.paginateBackwards(10);
     ref.onDispose(() async {
       debugPrint('disposing message stream');
       await subscription?.cancel();
@@ -171,6 +169,8 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
         ref.read(messagesProvider.notifier).reset();
         break;
       case 'Reset':
+        break;
+      default:
         break;
     }
   }
@@ -395,17 +395,21 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
         break;
       case 'm.reaction':
       case 'm.room.encrypted':
+        var metadata = {'itemType': 'event', 'eventType': eventType};
+        if (inReplyTo != null) {
+          metadata['repliedTo'] = inReplyTo;
+        }
         return types.CustomMessage(
           author: author,
           createdAt: createdAt,
           id: eventId,
-          metadata: {
-            'itemType': 'event',
-            'eventType': eventType,
-            'repliedTo': inReplyTo,
-          },
+          metadata: metadata,
         );
       case 'm.room.redaction':
+        var metadata = {'itemType': 'event', 'eventType': eventType};
+        if (inReplyTo != null) {
+          metadata['repliedTo'] = inReplyTo;
+        }
         return types.CustomMessage(
           author: author,
           createdAt: createdAt,
@@ -701,15 +705,17 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
   ) {
     var messages = ref.read(messagesProvider);
     final index = messages.indexWhere((x) => x.id == message.id);
-    final updatedMessage = (messages[index] as types.TextMessage).copyWith(
-      previewData: previewData,
-    );
+    if (index != -1) {
+      final updatedMessage = (messages[index] as types.TextMessage).copyWith(
+        previewData: previewData,
+      );
 
-    WidgetsBinding.instance.addPostFrameCallback(
-      (Duration duration) => ref
-          .read(messagesProvider.notifier)
-          .replaceMessage(index, updatedMessage),
-    );
+      WidgetsBinding.instance.addPostFrameCallback(
+        (Duration duration) => ref
+            .read(messagesProvider.notifier)
+            .replaceMessage(index, updatedMessage),
+      );
+    }
   }
 
   // image selection

--- a/app/lib/features/chat/widgets/convo_card.dart
+++ b/app/lib/features/chat/widgets/convo_card.dart
@@ -26,7 +26,6 @@ class ConvoCard extends ConsumerStatefulWidget {
 }
 
 class _ConvoCardState extends ConsumerState<ConvoCard> {
-  // final ReceiptController recieptController = Get.find<ReceiptController>();
   List<Member> activeMembers = [];
 
   @override
@@ -123,7 +122,6 @@ class _SubtitleWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final typingEvent = ref.watch(typingProvider);
-    debugPrint('$typingEvent');
     if (typingEvent.isNotEmpty) {
       debugPrint('$typingEvent');
       if (typingEvent['roomId'] == room.getRoomIdStr()) {

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -253,7 +253,6 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
   @override
   Widget build(BuildContext context) {
     final mentionList = ref.watch(mentionListProvider);
-    debugPrint('$mentionList');
     return FlutterMentions(
       key: ref.watch(mentionKeyProvider),
       suggestionPosition: SuggestionPosition.Top,

--- a/app/lib/features/home/providers/notifiers/sync_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/sync_notifier.dart
@@ -21,7 +21,6 @@ class SyncNotifier extends StateNotifier<LocalSyncState> {
   }
 
   Future<void> startSync(Client client, Ref ref) async {
-    // Get.put(ReceiptController(client: state!));
     // on release we have a really weird behavior, where, if we schedule
     // any async call in rust too early, they just pend forever. this
     // hack unfortunately means we have two wait a bit but that means


### PR DESCRIPTION
- [x] Fixed chat initial loading preview, whereby it should constantly show 'Loading Conversations' until sync process is finished.
- [x] Fixed issue where ```m.encryption``` and ```m.redacted``` events throw ```TypeError()``` exception in some scenarios .i.e when they have ```replyId``` as ```NULL``` and tries to fetch reply content.