### PR TITLE
activate chat reactions selection and improvements

### DIFF
--- a/.changes/0821-chat-fixes.md
+++ b/.changes/0821-chat-fixes.md
@@ -1,0 +1,4 @@
+- [fix] activate chat reactions.
+- [improvement] chat reactions ui.
+- [fix] reply content fixes.
+- [fix] chat list duplication bug.

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -106,70 +106,6 @@ class _RoomPageConsumerState extends ConsumerState<RoomPage> {
     );
   }
 
-  Widget customBottomWidget(BuildContext context) {
-    return Consumer(
-      builder: (context, ref, child) {
-        final client = ref.watch(clientProvider)!;
-        final messageId =
-            ref.watch(chatRoomProvider.notifier).repliedToMessage?.id;
-        final bool isAuthor = client.userId().toString() == messageId;
-        if (!ref.watch(chatInputProvider.select((ci) => ci.emojiRowVisible))) {
-          return const CustomChatInput();
-        }
-        return Container(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          color: Theme.of(context).colorScheme.onPrimary,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              InkWell(
-                onTap: () {
-                  ref.read(chatInputProvider.notifier).emojiRowVisible();
-                  ref.read(chatInputProvider.notifier).toggleReplyView();
-                },
-                child: const Text(
-                  'Reply',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              InkWell(
-                onTap: () {
-                  if (isAuthor) {
-                    ref
-                        .read(chatRoomProvider.notifier)
-                        .redactRoomMessage(messageId!);
-                    ref.read(chatInputProvider.notifier).toggleReplyView();
-                  } else {
-                    customMsgSnackbar(
-                      context,
-                      'Report message isn\'t implemented yet',
-                    );
-                  }
-                },
-                child: Text(
-                  isAuthor ? 'Unsend' : 'Report',
-                  style: const TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-              InkWell(
-                onTap: () => customMsgSnackbar(
-                  context,
-                  'More options not implemented yet',
-                ),
-                child: const Text(
-                  'More',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
   Widget textMessageBuilder(
     types.TextMessage p1, {
     required int messageWidth,
@@ -359,7 +295,7 @@ class _RoomPageConsumerState extends ConsumerState<RoomPage> {
           ),
           error: (e) => Text('Failed to load messages due to $e'),
           loaded: () => Chat(
-            customBottomWidget: customBottomWidget(context),
+            customBottomWidget: const CustomChatInput(),
             textMessageBuilder: textMessageBuilder,
             l10n: ChatL10nEn(
               emptyChatPlaceholder: '',
@@ -408,9 +344,8 @@ class _RoomPageConsumerState extends ConsumerState<RoomPage> {
               if (ref.watch(
                 chatInputProvider.select((ci) => ci.emojiRowVisible),
               )) {
-                ref.read(chatRoomProvider.notifier).repliedToMessage = null;
-                ref.read(chatInputProvider.notifier).emojiRowVisible();
-                ref.read(chatInputProvider.notifier).setReplyWidget(null);
+                ref.read(chatRoomProvider.notifier).currentMessageId = null;
+                ref.read(chatInputProvider.notifier).emojiRowVisible(false);
               }
             },
             //Custom Theme class, see lib/common/store/chatTheme.dart

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -27,7 +27,7 @@ final chatStreamProvider = StreamProvider<List<Convo>>((ref) async* {
     debugPrint('Acter Conversations Stream');
   });
   await for (var convoList in controller.stream) {
-    conversations.addAll(convoList);
+    conversations = convoList;
     //FIXME: how to check empty chats ?
     if (conversations.isNotEmpty) {
       yield conversations;
@@ -75,9 +75,6 @@ final chatProfilesProvider =
 // chat room mention list
 final mentionListProvider =
     StateProvider<List<Map<String, dynamic>>>((ref) => []);
-
-// emoji row preview toggler
-final toggleEmojiRowProvider = StateProvider<bool>((ref) => false);
 
 final messageMarkDownProvider = StateProvider<Map<String, String>>((ref) => {});
 

--- a/app/lib/features/chat/providers/notifiers/chat_input_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_input_notifier.dart
@@ -5,17 +5,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class ChatInputNotifier extends StateNotifier<ChatInputState> {
   ChatInputNotifier() : super(const ChatInputState());
 
-  void setReplyView(bool value) {
-    state = state.copyWith(showReplyView: value);
-  }
+  void toggleReplyView(bool value) =>
+      state = state.copyWith(showReplyView: value);
 
-  void showSendBtn(bool value) {
-    state = state.copyWith(sendBtnVisible: value);
-  }
+  void showSendBtn(bool value) => state = state.copyWith(sendBtnVisible: value);
 
-  void toggleAttachment() {
-    state = state.copyWith(attachmentVisible: !state.attachmentVisible);
-  }
+  void toggleAttachment(bool value) =>
+      state = state.copyWith(attachmentVisible: value);
 
   void emojiRowVisible(bool value) =>
       state = state.copyWith(emojiRowVisible: value);

--- a/app/lib/features/chat/providers/notifiers/chat_input_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_input_notifier.dart
@@ -5,8 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class ChatInputNotifier extends StateNotifier<ChatInputState> {
   ChatInputNotifier() : super(const ChatInputState());
 
-  void toggleReplyView() {
-    state = state.copyWith(showReplyView: !state.showReplyView);
+  void setReplyView(bool value) {
+    state = state.copyWith(showReplyView: value);
   }
 
   void showSendBtn(bool value) {
@@ -17,11 +17,11 @@ class ChatInputNotifier extends StateNotifier<ChatInputState> {
     state = state.copyWith(attachmentVisible: !state.attachmentVisible);
   }
 
-  void emojiRowVisible() =>
-      state = state.copyWith(emojiRowVisible: !state.emojiRowVisible);
+  void emojiRowVisible(bool value) =>
+      state = state.copyWith(emojiRowVisible: value);
 
-  void emojiPickerVisible() =>
-      state = state.copyWith(emojiPickerVisible: !state.emojiPickerVisible);
+  void emojiPickerVisible(bool value) =>
+      state = state.copyWith(emojiPickerVisible: value);
 
   void setReplyWidget(Widget? child) {
     state = state.copyWith(replyWidget: child);

--- a/app/lib/features/chat/providers/notifiers/messages_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/messages_notifier.dart
@@ -6,9 +6,7 @@ class MessagesNotifier extends StateNotifier<List<types.Message>> {
   MessagesNotifier() : super([]);
 
   // Messages CRUD
-  void addMessage(types.Message m) {
-    state = [...state, m];
-  }
+  void addMessage(types.Message m) => state = [...state, m];
 
   void insertMessage(int to, types.Message m) {
     try {
@@ -51,7 +49,5 @@ class MessagesNotifier extends StateNotifier<List<types.Message>> {
     }
   }
 
-  void reset() {
-    state.clear();
-  }
+  void reset() => state.clear();
 }

--- a/app/lib/features/chat/widgets/text_message_builder.dart
+++ b/app/lib/features/chat/widgets/text_message_builder.dart
@@ -16,11 +16,13 @@ class TextMessageBuilder extends ConsumerStatefulWidget {
   final void Function(types.TextMessage, types.PreviewData)?
       onPreviewDataFetched;
   final int messageWidth;
+  final bool isReply;
 
   const TextMessageBuilder({
     Key? key,
     required this.message,
     this.onPreviewDataFetched,
+    this.isReply = false,
     required this.messageWidth,
   }) : super(key: key);
 
@@ -84,6 +86,7 @@ class _TextMessageBuilderConsumerState
           enlargeEmoji:
               widget.message.metadata!['enlargeEmoji'] ?? enlargeEmoji,
           isNotice: isNotice,
+          isReply: widget.isReply,
         ),
         width: widget.messageWidth.toDouble(),
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -93,6 +96,7 @@ class _TextMessageBuilderConsumerState
       message: widget.message,
       enlargeEmoji: enlargeEmoji,
       isNotice: isNotice,
+      isReply: widget.isReply,
     );
   }
 
@@ -110,11 +114,13 @@ class _TextWidget extends ConsumerWidget {
   final types.TextMessage message;
   final bool enlargeEmoji;
   final bool isNotice;
+  final bool isReply;
 
   const _TextWidget({
     required this.message,
     required this.enlargeEmoji,
     required this.isNotice,
+    required this.isReply,
   });
 
   @override
@@ -133,14 +139,21 @@ class _TextWidget extends ConsumerWidget {
       child: enlargeEmoji
           ? Text(
               message.text,
-              style: emojiTextStyle,
+              style: emojiTextStyle.copyWith(
+                overflow: isReply ? TextOverflow.ellipsis : null,
+              ),
+              maxLines: isReply ? 3 : null,
             )
           : Html(
               // ignore: prefer_single_quotes, unnecessary_string_interpolations
               data: """${message.text}""",
               shrinkToFit: true,
               padding: const EdgeInsets.all(5),
-              defaultTextStyle: Theme.of(context).textTheme.bodySmall,
+              defaultTextStyle: Theme.of(context)
+                  .textTheme
+                  .bodySmall!
+                  .copyWith(overflow: isReply ? TextOverflow.ellipsis : null),
+              maxLines: isReply ? 3 : null,
             ),
     );
   }


### PR DESCRIPTION
- [x] Activate chat reactions and visual improvements. Message tap to show message actions
- [x] Reply fixes: earlier wasn't showing encrypted events as part of reply content.
- [x] Chat list fixes: minor duplication bug.

### Bug: Redacted Events cannot be rendered as part of reply, as it couldn't fetch event id.

<img width="1360" alt="Screenshot 2023-08-03 at 12 45 42 AM" src="https://github.com/acterglobal/a3/assets/68579938/1023ac79-d11a-4163-a91d-05a84f98f4a8">
<img width="1360" alt="Screenshot 2023-08-03 at 12 46 02 AM" src="https://github.com/acterglobal/a3/assets/68579938/c6ee9a6d-0f33-40f4-84dc-7d7465d750e8">
<img width="1360" alt="Screenshot 2023-08-03 at 12 46 22 AM" src="https://github.com/acterglobal/a3/assets/68579938/25cad6da-14f5-4e01-9d11-2277f98ea204">
