### PR TITLE
Put alias resolving into a Runtime.

### DIFF
--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -285,12 +285,14 @@ final canonicalParentProvider = FutureProvider.autoDispose
     }
     final parent = relations.mainParent();
     if (parent == null) {
-      debugPrint('no parent');
       return null;
     }
 
     final parentSpace =
-        await ref.watch(spaceProvider(parent.roomId().toString()).future);
+        await ref.watch(maybeSpaceProvider(parent.roomId().toString()).future);
+    if (parentSpace == null) {
+      return null;
+    }
     final profile =
         await ref.watch(spaceProfileDataProvider(parentSpace).future);
     return SpaceWithProfileData(parentSpace, profile);

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -808,13 +808,18 @@ impl Client {
         }
         // if None, it is alias
         if let Ok(alias_id) = OwnedRoomAliasId::try_from(room_id_or_alias) {
-            let response = self.resolve_room_alias(&alias_id).await?;
-            for space in self.spaces().await?.into_iter() {
-                if space.inner.room.room_id() == response.room_id {
-                    return Ok(space);
-                }
-            }
-            bail!("Room with alias not found");
+            let me = self.clone();
+            RUNTIME
+                .spawn(async move {
+                    let response = me.resolve_room_alias(&alias_id).await?;
+                    for space in me.spaces().await?.into_iter() {
+                        if space.inner.room.room_id() == response.room_id {
+                            return Ok(space);
+                        }
+                    }
+                    bail!("Room with alias not found");
+                })
+                .await?
         } else {
             bail!("Neither roomId nor alias provided");
         }


### PR DESCRIPTION
Fixes the crash on the chats page if there is a chat with a roomAliasId.

And a run-by fix on the canonical parent provider to handle missing access nicer.