### PR TITLE
fix missing type association problem

### DIFF
--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -7,8 +7,6 @@ import 'package:acter_avatar/acter_avatar.dart';
 import 'package:bubble/bubble.dart';
 import 'package:acter/features/chat/widgets/emoji_reaction_item.dart';
 import 'package:acter/features/chat/widgets/emoji_row.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart'
-    show ReactionRecord;
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -290,7 +288,7 @@ class _EmojiContainerState extends State<_EmojiContainer>
               String key = keys[index];
               Map<String, dynamic> reactions =
                   widget.message.metadata!['reactions'];
-              List<ReactionRecord>? reactionRecords = reactions[key];
+              final recordsCount = reactions[key]?.length;
               return GestureDetector(
                 onTap: () {
                   showEmojiReactionsSheet(reactions);
@@ -300,7 +298,7 @@ class _EmojiContainerState extends State<_EmojiContainer>
                   children: [
                     Text(key),
                     const SizedBox(width: 2),
-                    Text(reactionRecords!.length.toString()),
+                    Text(recordsCount!.toString()),
                   ],
                 ),
               );
@@ -318,9 +316,9 @@ class _EmojiContainerState extends State<_EmojiContainer>
     if (mounted) {
       setState(() {
         reactions.forEach((key, value) {
-          count += value.count();
+          count += value.length;
           reactionTabs.add(
-            Tab(text: '$key+${value.count()}'),
+            Tab(text: '$key+${value.length}'),
           );
         });
         reactionTabs.insert(0, (Tab(text: 'All $count')));


### PR DESCRIPTION
Drive by fix for a missing types update when rendering chat reactions:
```
════════ Exception caught by widgets library ═══════════════════════════════════
type 'FfiListReactionRecord' is not a subtype of type 'List<ReactionRecord>?'
The relevant error-causing widget was
LayoutBuilder
bubble_builder.dart:258
════════════════════════════════════════════════════════════════════════════════
```

![grafik](https://github.com/acterglobal/a3/assets/40496/2ba558b6-b5ea-4ff0-b287-4e788d61c015)
