### PR TITLE
chat list ordering and timestamps

### DIFF
--- a/.changes/0847_chat-order-fixes.md
+++ b/.changes/0847_chat-order-fixes.md
@@ -1,0 +1,2 @@
+- Chat room latest message timestamps have been updated to be human readable format.
+- [fix] Chat rooms ordering will now happen correctly according to timestamps (both in realtime and initial load).

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -90,16 +90,22 @@ final relatedChatsProvider = FutureProvider.autoDispose
 
 // Member Providers
 final memberProfileProvider =
-    FutureProvider.family.autoDispose<ProfileData, String>((ref, userId) async {
-  final member = await ref.watch(memberProvider(userId).future);
-  UserProfile profile = member.getProfile();
-  OptionString displayName = await profile.getDisplayName();
-  final avatar = await profile.getThumbnail(62, 60);
-  return ProfileData(displayName.text(), avatar.data());
+    FutureProvider.family<ProfileData, String>((ref, userId) async {
+  final member = ref.watch(memberProvider(userId));
+  return member.when(
+    data: (data) async {
+      UserProfile profile = data!.getProfile();
+      OptionString displayName = await profile.getDisplayName();
+      final avatar = await profile.getThumbnail(62, 60);
+      return ProfileData(displayName.text(), avatar.data());
+    },
+    error: (error, st) => ProfileData('', null),
+    loading: () => ProfileData('', null),
+  );
 });
 
 final memberProvider =
-    FutureProvider.family<Member, String>((ref, userId) async {
-  final convo = ref.watch(currentConvoProvider)!;
-  return await convo.getMember(userId);
+    FutureProvider.family<Member?, String>((ref, userId) async {
+  final convo = ref.watch(currentConvoProvider);
+  return await convo!.getMember(userId);
 });

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -92,15 +92,14 @@ final relatedChatsProvider = FutureProvider.autoDispose
 final memberProfileProvider =
     FutureProvider.family<ProfileData, String>((ref, userId) async {
   final member = ref.watch(memberProvider(userId));
-  return member.when(
+  return member.maybeWhen(
     data: (data) async {
       UserProfile profile = data!.getProfile();
       OptionString displayName = await profile.getDisplayName();
       final avatar = await profile.getThumbnail(62, 60);
       return ProfileData(displayName.text(), avatar.data());
     },
-    error: (error, st) => ProfileData('', null),
-    loading: () => ProfileData('', null),
+    orElse: () => ProfileData('', null),
   );
 });
 

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:jiffy/jiffy.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -64,6 +65,25 @@ String formatDt(CalendarEvent e) {
     } else {
       final endFmt = DateFormat.yMMMd().format(end);
       return '$startFmt $startTimeFmt - $endFmt $endTimeFmt';
+    }
+  }
+}
+
+String jiffyTime(int timeInterval) {
+  final jiffyTime = Jiffy.parseFromMillisecondsSinceEpoch(timeInterval);
+  final now = Jiffy.now().startOf(Unit.day);
+  if (now.isSame(jiffyTime, unit: Unit.day)) {
+    // (00:00 AM/PM)
+    return jiffyTime.jm;
+  } else {
+    var yesterday = now.subtract(days: 1);
+    var week = now.subtract(weeks: 1);
+    if (jiffyTime.isBetween(yesterday, now)) {
+      return 'Yesterday';
+    } else if (jiffyTime.isBetween(week, now)) {
+      return jiffyTime.EEEE;
+    } else {
+      return jiffyTime.yMd;
     }
   }
 }

--- a/app/lib/common/widgets/chat/convo_card.dart
+++ b/app/lib/common/widgets/chat/convo_card.dart
@@ -10,7 +10,6 @@ import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_matrix_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 class ConvoCard extends ConsumerStatefulWidget {
   final Convo room;
@@ -376,14 +375,11 @@ class _TrailingWidget extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    int ts = eventItem.originServerTs();
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Text(
-          DateFormat.Hm().format(
-            DateTime.fromMillisecondsSinceEpoch(ts, isUtc: true),
-          ),
+          jiffyTime(latestMessage!.eventItem()!.originServerTs()),
           style: Theme.of(context).textTheme.labelMedium,
         ),
       ],

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -264,10 +264,18 @@ class _RoomPageConsumerState extends ConsumerState<RoomPage> {
                     ),
                   );
                 },
-                error: (e, st) => Text(
-                  'Error loading avatar due to ${e.toString()}',
-                  textScaleFactor: 0.2,
-                ),
+                error: (e, st) {
+                  debugPrint('ERROR loading avatar due to $e');
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 10),
+                    child: ActerAvatar(
+                      uniqueId: userId,
+                      displayName: userId,
+                      mode: DisplayMode.User,
+                      size: 28,
+                    ),
+                  );
+                },
                 loading: () => const CircularProgressIndicator(),
               );
             },

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -367,10 +367,15 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
                         size: profile.hasAvatar() ? 18 : 36,
                       );
                     },
-                    error: (e, st) => Text(
-                      'Error loading avatar due to ${e.toString()}',
-                      textScaleFactor: 0.2,
-                    ),
+                    error: (e, st) {
+                      debugPrint('ERROR loading avatar due to $e');
+                      return ActerAvatar(
+                        mode: DisplayMode.User,
+                        uniqueId: roomMember['link'],
+                        displayName: title,
+                        size: 36,
+                      );
+                    },
                     loading: () => const CircularProgressIndicator(),
                   );
                 },

--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -16,6 +16,7 @@ import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:jiffy/jiffy.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:shake/shake.dart';
@@ -307,9 +308,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
   Future<void> handleBugReport() async {
     var appDocDir = await getApplicationDocumentsDirectory();
     // rage shake disallows dot in filename
-    var now = DateTime.now();
-    String timestamp =
-        "${now.year.toString()}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} ${now.hour.toString().padLeft(2, '0')}-${now.minute.toString().padLeft(2, '0')}";
+    String timestamp = Jiffy.now().toUtc().format();
     var imagePath = await screenshotController.captureAndSave(
       appDocDir.path,
       fileName: 'screenshot_$timestamp.png',

--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -10,7 +10,6 @@ import 'package:acter/features/home/widgets/sidebar_widget.dart';
 import 'package:acter/features/news/widgets/news_widget.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/router/providers/router_providers.dart';
-import 'package:date_format/date_format.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
@@ -308,10 +307,9 @@ class _HomeShellState extends ConsumerState<HomeShell> {
   Future<void> handleBugReport() async {
     var appDocDir = await getApplicationDocumentsDirectory();
     // rage shake disallows dot in filename
-    String timestamp = formatDate(
-      DateTime.now(),
-      [yyyy, '-', mm, '-', dd, '_', hh, '-', nn, '-', ss, '_', SSS],
-    );
+    var now = DateTime.now();
+    String timestamp =
+        "${now.year.toString()}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} ${now.hour.toString().padLeft(2, '0')}-${now.minute.toString().padLeft(2, '0')}";
     var imagePath = await screenshotController.captureAndSave(
       appDocDir.path,
       fileName: 'screenshot_$timestamp.png',

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -282,14 +282,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
-  date_format:
-    dependency: "direct main"
-    description:
-      name: date_format
-      sha256: "8e5154ca363411847220c8cbc43afcf69c08e8debe40ba09d57710c25711760c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.7"
   dbus:
     dependency: transitive
     description:
@@ -911,6 +903,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  jiffy:
+    dependency: "direct main"
+    description:
+      name: jiffy
+      sha256: cc1d4b75016a9156c29b5d61f0c9176c3e0fb0580cc5a0e0422b5d2cab3fbfff
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   js:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -101,7 +101,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   http_parser: ^4.0.2
   flutter_custom_selector: ^0.0.3
-  date_format: ^2.0.2
+  jiffy: ^6.2.1
   screenshot: ^2.1.0
   http: ^1.0.0
   string_validator: ^1.0.0


### PR DESCRIPTION
### Description
- Update timestamps to human readable formats for convo cards.
- Fix sorting order of chat with[ jiffy](https://pub.dev/packages/jiffy) extension.
- Fix [bug](https://github.com/rrousselGit/riverpod/issues/2041) where ```MemberProfileDataProvider``` sometimes listens bad future state.