### PR TITLE
Add cli to acter for non-ui state management

### DIFF
--- a/.changes/0882-cli.md
+++ b/.changes/0882-cli.md
@@ -1,0 +1,1 @@
+- New CLI interface added to allow for easier troubleshooting, see [it's docs for further information](https://docs.acter.global/user/getting-started/cli/)

--- a/app/lib/features/cli/commands/backup-and-reset.dart
+++ b/app/lib/features/cli/commands/backup-and-reset.dart
@@ -1,0 +1,54 @@
+import 'package:args/command_runner.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:acter/features/cli/util.dart';
+
+import 'dart:io';
+import 'dart:convert';
+import 'dart:core';
+// ignore_for_file: avoid_print
+
+class BackupAndResetCommand extends Command {
+  @override
+  final name = 'backup-and-reset';
+  @override
+  final description =
+      'Backup accounts and sessions and reset the state to fresh and clean';
+
+  BackupAndResetCommand();
+
+  @override
+  Future<void> run() async {
+    final now = DateTime.now();
+    final tzMinTotal = now.timeZoneOffset.inMinutes;
+    final separator = tzMinTotal.isNegative ? '-' : '+';
+    final tzHours = (tzMinTotal / 60).floor().abs().toString().padLeft(2, '0');
+    final tzRemainMins = (tzMinTotal % 60).abs().toString().padLeft(2, '0');
+    final date = now.toIso8601String().replaceAll(':', '_');
+    final String stamper = '$date$separator${tzHours}_$tzRemainMins';
+    print('Backup stamp will be: $stamper');
+    final appInfo = await AppInfo.make();
+    if (appInfo.sessions.isEmpty) {
+      print('⚠️ No active sessions found.');
+    } else {
+      final encoded = json.encode(appInfo.sessions);
+      final f = await File('${appInfo.appDocPath}/sessions_backup_$stamper')
+          .create(exclusive: true);
+      f.writeAsString(encoded);
+      print('✔️ Sessions backed up ');
+    }
+
+    if (appInfo.accounts.isEmpty) {
+      print('⚠️ No account data found.');
+    } else {
+      for (final a in appInfo.accounts) {
+        await Directory('${appInfo.appDocPath}/$a')
+            .rename('${appInfo.appDocPath}/${a}_backup_$stamper');
+        print('✔️ $a backed up ');
+      }
+    }
+
+    await appInfo.preferences.clear();
+    print('✔️ All reset');
+    exit(0);
+  }
+}

--- a/app/lib/features/cli/commands/backup-and-reset.dart
+++ b/app/lib/features/cli/commands/backup-and-reset.dart
@@ -1,5 +1,4 @@
 import 'package:args/command_runner.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter/features/cli/util.dart';
 
 import 'dart:io';

--- a/app/lib/features/cli/commands/info.dart
+++ b/app/lib/features/cli/commands/info.dart
@@ -1,11 +1,8 @@
-import 'dart:io';
-
 import 'package:args/command_runner.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:acter/features/cli/util.dart';
 
-final backupFormatFinder = RegExp(r'_backup_[0-9-_T.+]+$');
-
+import 'dart:io';
 // ignore_for_file: avoid_print
 
 class InfoCommand extends Command {
@@ -21,53 +18,18 @@ class InfoCommand extends Command {
     print('Acter $versionName');
     print(' - Default Homeserver: $defaultServerName');
     print(' - Default Homeserver URL: $defaultServerUrl');
-
-    String appDocPath = await appDir();
-    SharedPreferences prefs = await sharedPrefs();
-    List<String> sessions = (prefs.getStringList(defaultSessionKey) ?? []);
+    final appInfo = await AppInfo.make();
     print('Locally:');
-    print(' - App Folder: $appDocPath');
+    print(' - App Folder: ${appInfo.appDocPath}');
 
-    // directory
-    final dir = new Directory(appDocPath);
-    final dirEntries = await dir.list().toList();
-    final logFiles = dirEntries
-        .where(
-          (x) => x.path.endsWith('.log') && FileSystemEntity.isFileSync(x.path),
-        )
-        .toList();
-    final accounts = dirEntries
-        .where(
-          (x) => FileSystemEntity.isDirectorySync(x.path),
-        )
-        .map((a) {
-          if (a.isAbsolute) {
-            return a.path.substring(appDocPath.length + 1);
-          } else {
-            return a.path;
-          }
-        })
-        .where(
-          (f) =>
-              f.startsWith('@') &&
-              !backupFormatFinder
-                  .hasMatch(f), // only show the ones indicating a username
-        )
-        .toList();
-    logFiles.sort(
-      // latest first
-      (a, b) => FileStat.statSync(b.path)
-          .changed
-          .compareTo(FileStat.statSync(a.path).changed),
-    );
-    if (logFiles.isNotEmpty) {
-      print(' - Latest log file: ${logFiles[0].path}');
+    if (appInfo.logFiles.isNotEmpty) {
+      print(' - Latest log file: ${appInfo.logFiles[0].path}');
     }
 
-    print(' - Number of current sessions found: ${sessions.length}');
-    if (accounts.isNotEmpty) {
-      print(' - Data of sessions found: ${accounts.length}');
-      for (final a in accounts) {
+    print(' - Number of current sessions found: ${appInfo.sessions.length}');
+    if (appInfo.accounts.isNotEmpty) {
+      print(' - Data of sessions found: ${appInfo.accounts.length}');
+      for (final a in appInfo.accounts) {
         print('    * $a');
       }
     }

--- a/app/lib/features/cli/commands/info.dart
+++ b/app/lib/features/cli/commands/info.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ignore_for_file: avoid_print
+
+class InfoCommand extends Command {
+  @override
+  final name = 'info';
+  @override
+  final description = 'Local info about your acter';
+
+  InfoCommand();
+
+  @override
+  Future<void> run() async {
+    print('Acter $versionName');
+    print(' - Default Homeserver: $defaultServerName');
+    print(' - Default Homeserver URL: $defaultServerUrl');
+
+    String appDocPath = await appDir();
+    SharedPreferences prefs = await sharedPrefs();
+    List<String> sessions = (prefs.getStringList(defaultSessionKey) ?? []);
+    print('Locally:');
+    print(' - App Folder: $appDocPath');
+
+    // directory
+    final dir = new Directory(appDocPath);
+    final dirEntries = await dir.list().toList();
+    final logFiles = dirEntries
+        .where(
+          (x) => x.path.endsWith('.log') && FileSystemEntity.isFileSync(x.path),
+        )
+        .toList();
+    final accounts = dirEntries
+        .where(
+          (x) => FileSystemEntity.isDirectorySync(x.path),
+        )
+        .map((a) {
+          if (a.isAbsolute) {
+            return a.path.substring(appDocPath.length + 1);
+          } else {
+            return a.path;
+          }
+        })
+        .where(
+          (f) => f.startsWith('@'), // only show the ones indicating a username
+        )
+        .toList();
+    logFiles.sort(
+      // latest first
+      (a, b) => FileStat.statSync(b.path)
+          .changed
+          .compareTo(FileStat.statSync(a.path).changed),
+    );
+    if (logFiles.isNotEmpty) {
+      print(' - Latest log file: ${logFiles[0].path}');
+    }
+
+    print(' - Number of current sessions found: ${sessions.length}');
+    if (accounts.isNotEmpty) {
+      print(' - Data of sessions found: ${accounts.length}');
+      for (final a in accounts) {
+        print('    * $a');
+      }
+    }
+    exit(0);
+  }
+}

--- a/app/lib/features/cli/commands/info.dart
+++ b/app/lib/features/cli/commands/info.dart
@@ -4,6 +4,8 @@ import 'package:args/command_runner.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+final backupFormatFinder = RegExp(r'_backup_[0-9-_T.+]+$');
+
 // ignore_for_file: avoid_print
 
 class InfoCommand extends Command {
@@ -46,7 +48,10 @@ class InfoCommand extends Command {
           }
         })
         .where(
-          (f) => f.startsWith('@'), // only show the ones indicating a username
+          (f) =>
+              f.startsWith('@') &&
+              !backupFormatFinder
+                  .hasMatch(f), // only show the ones indicating a username
         )
         .toList();
     logFiles.sort(

--- a/app/lib/features/cli/main.dart
+++ b/app/lib/features/cli/main.dart
@@ -1,6 +1,7 @@
 import 'package:acter/features/cli/commands/backup-and-reset.dart';
 import 'package:acter/features/cli/commands/info.dart';
 import 'package:args/command_runner.dart';
+import 'dart:io';
 
 Future<void> cliMain(List<String> args) async {
   CommandRunner(
@@ -10,4 +11,5 @@ Future<void> cliMain(List<String> args) async {
     ..addCommand(InfoCommand())
     ..addCommand(BackupAndResetCommand())
     ..run(args);
+  exit(0);
 }

--- a/app/lib/features/cli/main.dart
+++ b/app/lib/features/cli/main.dart
@@ -1,0 +1,11 @@
+import 'package:acter/features/cli/commands/info.dart';
+import 'package:args/command_runner.dart';
+
+Future<void> cliMain(List<String> args) async {
+  await CommandRunner(
+    'acter',
+    'community communication and casual organizing platform',
+  )
+    ..addCommand(InfoCommand())
+    ..run(args);
+}

--- a/app/lib/features/cli/main.dart
+++ b/app/lib/features/cli/main.dart
@@ -1,11 +1,13 @@
+import 'package:acter/features/cli/commands/backup-and-reset.dart';
 import 'package:acter/features/cli/commands/info.dart';
 import 'package:args/command_runner.dart';
 
 Future<void> cliMain(List<String> args) async {
-  await CommandRunner(
+  CommandRunner(
     'acter',
     'community communication and casual organizing platform',
   )
     ..addCommand(InfoCommand())
+    ..addCommand(BackupAndResetCommand())
     ..run(args);
 }

--- a/app/lib/features/cli/util.dart
+++ b/app/lib/features/cli/util.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final backupFormatFinder = RegExp(r'_backup_[0-9-_T.+]+$');
+
+class AppInfo {
+  final String appDocPath;
+  final SharedPreferences preferences;
+  final List<String> sessions;
+  final List<FileSystemEntity> logFiles;
+  final List<String> accounts;
+
+  const AppInfo(
+    this.appDocPath,
+    this.preferences,
+    this.sessions,
+    this.logFiles,
+    this.accounts,
+  );
+
+  static Future<AppInfo> make() async {
+    String appDocPath = await appDir();
+    SharedPreferences pref = await sharedPrefs();
+    List<String> sessions = (pref.getStringList(defaultSessionKey) ?? []);
+
+    // directory
+    final dir = Directory(appDocPath);
+    final dirEntries = await dir.list().toList();
+    final logFiles = dirEntries
+        .where(
+          (x) => x.path.endsWith('.log') && FileSystemEntity.isFileSync(x.path),
+        )
+        .toList();
+    final accounts = dirEntries
+        .where(
+          (x) => FileSystemEntity.isDirectorySync(x.path),
+        )
+        .map((a) {
+          if (a.isAbsolute) {
+            return a.path.substring(appDocPath.length + 1);
+          } else {
+            return a.path;
+          }
+        })
+        .where(
+          (f) =>
+              f.startsWith('@') &&
+              !backupFormatFinder
+                  .hasMatch(f), // only show the ones indicating a username
+        )
+        .toList();
+    logFiles.sort(
+      // latest first
+      (a, b) => FileStat.statSync(b.path)
+          .changed
+          .compareTo(FileStat.statSync(a.path).changed),
+    );
+    return AppInfo(appDocPath, pref, sessions, logFiles, accounts);
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:acter/common/notifications/notifications.dart';
 import 'package:acter/common/utils/logging.dart';
 import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/features/cli/main.dart';
 import 'package:acter/l10n/l10n.dart';
 import 'package:acter/router/providers/router_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
@@ -16,8 +17,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:overlay_support/overlay_support.dart';
 
-void main() async {
-  await startApp();
+void main(List<String> args) async {
+  if (args.isNotEmpty) {
+    await cliMain(args);
+  } else {
+    await startApp();
+  }
 }
 
 Future<void> startFreshTestApp(String key) async {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "3.3.7"
   args:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: args
       sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -117,6 +117,7 @@ dependencies:
       url: https://github.com/acterglobal/awesome_notifications
       ref: acter-main
   logging: ^1.2.0
+  args: ^2.4.2
 
 dev_dependencies:
   flutter_test:

--- a/docs/content/user/getting-started/cli.md
+++ b/docs/content/user/getting-started/cli.md
@@ -1,0 +1,54 @@
++++
+title = "Command Line Interface"
+
+sort_by = "weight"
+weight = 20
+template = "docs/page.html"
++++
+
+In some situations, it might be useful to not start the full UI but use only a subset of the acter feature set. For this acter has a command line interface built in. This is only possible on desktop devices.
+
+## Starting acter from the terminal
+
+First you need to open a terminal. If you don't know how to do this, here are some step-by-step-guides for:
+
+- [Windows](https://www.wikihow.com/Open-Terminal-in-Windows)
+- [Mac](https://www.wikihow.com/Get-to-the-Command-Line-on-a-Mac)
+- [Linux](https://www.wikihow.com/Run-a-Program-from-the-Command-Line-on-Linux)
+
+Once you have a terminal, you can usually just drag and drop the acter-executable from whatever file explorer you are using into the terminal. It should add the path in the Terminal. On Mac this only shows the path to the package, you need to add `/Contents/MacOs/Acter` to get to the actual executable. To execute the command press `enter`. This should start the regular Acter App from the terminal giving you some helpful output that you can mark and copy-paste, for example to attach to issue reports.
+
+Additionally, before starting the program by pressing `enter`, you can add various commands after an additional space (` `), that make acter start in a different way:
+
+## Acter commands
+
+By default, with no extra arguments given (arguments are separated by a space), acter will just load the regular UI and run the proper client. But given a command after the executable will put it into cli mode and it will attempt to do what you are asking from it.
+
+### `--help` / `help [command]`
+
+You can always start by just adding `--help` to your `acter` command. Even though we try to keep this page accurate and up-to-date, this is always the most accurate information about what your specific acter executable supports. So always check that first. To learn more about the options, flags and features of a particular command listed, use `help [command]` (where you replace `[command]` with the specific command in question, for e.g. `help info`) to get more information.
+
+At the time of writing this is the output you'll see:
+
+```
+flutter: community communication and casual organizing platform
+
+Usage: acter <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+  backup-and-reset   Backup accounts and sessions and reset the state to fresh and clean
+  info               Local info about your acter
+
+Run "acter help <command>" for more information about a command.
+```
+
+### info
+
+This command shows you various information about the app and your local data.
+
+### backup-and-reset
+
+Issue this command, if you want to reset your local state. This can be necessary if you can't start the app anymore for unknown reasons. This will create a backup of your session and all internal data (including encryption keys) before resetting.


### PR DESCRIPTION
This adds cli-param parsing to the acter flutter app (only actually usable on Desktop), to manage state and debug info without loading the entire UI and - most importantly - starting the matrix-client infrastructure. From now on any params supplied to the executable will be passing the cli-command-infrastructure.

It currently comes with two commands: `info` and `backup-and-reset`. Allowing to introspect the current state and info of the system and backup the state and reset the sessions in case the app doesn't start anymore:

```
> $ ./acter --help

flutter: community communication and casual organizing platform

Usage: acter <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  backup-and-reset   Backup accounts and sessions and reset the state to fresh and clean
  info               Local info about your acter

Run "acter help <command>" for more information about a command.


> $ ./acter help info

flutter: Local info about your acter

Usage: acter info [arguments]
-h, --help    Print this usage information.

Run "acter help" to see global options.


$ ./acter help backup-and-reset

Usage: acter backup-and-reset [arguments]
-h, --help    Print this usage information.

Run "acter help" to see global options.
```

- [x] User-driven changelog
- [x] Docs how to use the cli args