### PR TITLE
Revert getting of verification emojis from sas state to remote mode

### DIFF
--- a/app/lib/features/cross_signing/cross_signing.dart
+++ b/app/lib/features/cross_signing/cross_signing.dart
@@ -30,12 +30,12 @@ Widget elevatedButton(
 }
 
 class VerificationProcess {
-  bool wasTriggeredFromThisDevice;
+  bool verifiyingThisDevice;
   String stage;
   String? finishedMsg;
 
   VerificationProcess({
-    required this.wasTriggeredFromThisDevice,
+    required this.verifiyingThisDevice,
     required this.stage,
   });
 }
@@ -138,7 +138,7 @@ class CrossSigning {
     }
     // this case is bob side
     _processMap[flowId] = VerificationProcess(
-      wasTriggeredFromThisDevice: event.wasTriggeredFromThisDevice(),
+      verifiyingThisDevice: true, // this device is requested for verification
       stage: 'm.key.verification.request',
     );
     acceptingRequest = false;
@@ -258,7 +258,7 @@ class CrossSigning {
     } else {
       // this device is alice side
       _processMap[flowId] = VerificationProcess(
-        wasTriggeredFromThisDevice: event.wasTriggeredFromThisDevice(),
+        verifiyingThisDevice: false, // other device is ready for verification
         stage: 'm.key.verification.ready',
       );
     }
@@ -297,7 +297,7 @@ class CrossSigning {
                 ),
                 const SizedBox(width: 5),
                 Text(
-                  _processMap[flowId]!.wasTriggeredFromThisDevice
+                  _processMap[flowId]!.verifiyingThisDevice
                       ? AppLocalizations.of(context)!.verifyThisSession
                       : AppLocalizations.of(context)!.verifySession,
                 ),
@@ -441,7 +441,7 @@ class CrossSigning {
               ),
               const SizedBox(width: 5),
               Text(
-                _processMap[flowId]?.wasTriggeredFromThisDevice == true
+                _processMap[flowId]?.verifiyingThisDevice == true
                     ? AppLocalizations.of(context)!.verifyThisSession
                     : AppLocalizations.of(context)!.verifySession,
               ),
@@ -539,7 +539,7 @@ class CrossSigning {
                   ),
                   const SizedBox(width: 5),
                   Text(
-                    _processMap[flowId]?.wasTriggeredFromThisDevice == true
+                    _processMap[flowId]?.verifiyingThisDevice == true
                         ? AppLocalizations.of(context)!.verifyThisSession
                         : AppLocalizations.of(context)!.verifySession,
                   ),
@@ -603,7 +603,7 @@ class CrossSigning {
                   ),
                   const SizedBox(width: 5),
                   Text(
-                    _processMap[flowId]?.wasTriggeredFromThisDevice == true
+                    _processMap[flowId]?.verifiyingThisDevice == true
                         ? AppLocalizations.of(context)!.verifyThisSession
                         : AppLocalizations.of(context)!.verifySession,
                   ),
@@ -691,7 +691,7 @@ class CrossSigning {
                 ),
                 const SizedBox(width: 5),
                 Text(
-                  _processMap[flowId]?.wasTriggeredFromThisDevice == true
+                  _processMap[flowId]?.verifiyingThisDevice == true
                       ? AppLocalizations.of(context)!.verifyThisSession
                       : AppLocalizations.of(context)!.verifySession,
                 ),
@@ -775,7 +775,7 @@ class CrossSigning {
                 ),
                 const SizedBox(width: 5),
                 Text(
-                  _processMap[flowId]?.wasTriggeredFromThisDevice == true
+                  _processMap[flowId]?.verifiyingThisDevice == true
                       ? AppLocalizations.of(context)!.verifyThisSession
                       : AppLocalizations.of(context)!.verifySession,
                 ),
@@ -954,7 +954,7 @@ class CrossSigning {
     if (process.finishedMsg != null) {
       return process.finishedMsg!;
     }
-    if (process.wasTriggeredFromThisDevice) {
+    if (process.verifiyingThisDevice) {
       return AppLocalizations.of(context)!.verificationConclusionOkSelfNotice;
     }
     return AppLocalizations.of(context)!.verificationConclusionOkDone;

--- a/app/lib/features/cross_signing/cross_signing.dart
+++ b/app/lib/features/cross_signing/cross_signing.dart
@@ -735,16 +735,18 @@ class CrossSigning {
       return;
     }
     _processMap[flowId]?.stage = 'm.key.verification.key';
-    showModalBottomSheet(
-      context: rootNavKey.currentContext!,
-      builder: (BuildContext context) => Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(15),
+    event.getEmojis().then((emojis) {
+      showModalBottomSheet(
+        context: rootNavKey.currentContext!,
+        builder: (BuildContext context) => Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(15),
+          ),
+          child: _buildOnKey(context, event, flowId, emojis),
         ),
-        child: _buildOnKey(context, event, flowId, event.getEmojis()),
-      ),
-      isDismissible: false,
-    );
+        isDismissible: false,
+      );
+    });
   }
 
   Widget _buildOnKey(

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -18253,17 +18253,6 @@ class Api {
           int Function(
             int,
           )>();
-  late final _verificationEventWasTriggeredFromThisDevicePtr = _lookup<
-      ffi.NativeFunction<
-          _VerificationEventWasTriggeredFromThisDeviceReturn Function(
-            ffi.Int64,
-          )>>("__VerificationEvent_was_triggered_from_this_device");
-
-  late final _verificationEventWasTriggeredFromThisDevice =
-      _verificationEventWasTriggeredFromThisDevicePtr.asFunction<
-          _VerificationEventWasTriggeredFromThisDeviceReturn Function(
-            int,
-          )>();
   late final _verificationEventAcceptSasVerificationPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -39040,34 +39029,6 @@ class VerificationEvent {
     return tmp2;
   }
 
-  /// Whether verification request was launched from this device
-  bool wasTriggeredFromThisDevice() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._verificationEventWasTriggeredFromThisDevice(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    final tmp6 = tmp1.arg3;
-    final tmp7 = tmp1.arg4;
-    if (tmp3 == 0) {
-      debugAllocation("handle error", tmp4, tmp5);
-      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-      final tmp3_0 =
-          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
-      if (tmp5 > 0) {
-        final ffi.Pointer<ffi.Void> tmp4_0;
-        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-        _api.__deallocate(tmp4_0, tmp6, 1);
-      }
-      throw tmp3_0;
-    }
-    final tmp2 = tmp7 > 0;
-    return tmp2;
-  }
-
   /// Bob accepts the SAS verification
   Future<bool> acceptSasVerification() {
     var tmp0 = 0;
@@ -41902,19 +41863,6 @@ class _VerificationEventGetContentReturn extends ffi.Struct {
   external int arg2;
   @ffi.Uint64()
   external int arg3;
-}
-
-class _VerificationEventWasTriggeredFromThisDeviceReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint8()
-  external int arg4;
 }
 
 class _VerificationEmojiDescriptionReturn extends ffi.Struct {

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -8737,6 +8737,54 @@ class Api {
     return tmp7;
   }
 
+  FfiListVerificationEmoji? __verificationEventGetEmojisFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _verificationEventGetEmojisFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListVerificationEmoji");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp14 = FfiListVerificationEmoji._(this, tmp13_1);
+    final tmp7 = tmp14;
+    return tmp7;
+  }
+
   bool? __verificationEventAcceptVerificationRequestFuturePoll(
     int boxed,
     int postCobject,
@@ -9043,54 +9091,6 @@ class Api {
       throw tmp9_0;
     }
     final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
-  FfiListVerificationEmoji? __verificationEventGetVerificationEmojiFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _verificationEventGetVerificationEmojiFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListVerificationEmoji");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp14 = FfiListVerificationEmoji._(this, tmp13_1);
-    final tmp7 = tmp14;
     return tmp7;
   }
 
@@ -18184,6 +18184,16 @@ class Api {
             int,
             int,
           )>();
+  late final _verificationEventEmojisPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__VerificationEvent_emojis");
+
+  late final _verificationEventEmojis = _verificationEventEmojisPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _verificationEventGetEmojisPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -18284,17 +18294,6 @@ class Api {
 
   late final _verificationEventSendVerificationKey =
       _verificationEventSendVerificationKeyPtr.asFunction<
-          int Function(
-            int,
-          )>();
-  late final _verificationEventGetVerificationEmojiPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-          )>>("__VerificationEvent_get_verification_emoji");
-
-  late final _verificationEventGetVerificationEmoji =
-      _verificationEventGetVerificationEmojiPtr.asFunction<
           int Function(
             int,
           )>();
@@ -21018,6 +21017,21 @@ class Api {
             int,
             int,
           )>();
+  late final _verificationEventGetEmojisFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _VerificationEventGetEmojisFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__VerificationEvent_get_emojis_future_poll");
+
+  late final _verificationEventGetEmojisFuturePoll =
+      _verificationEventGetEmojisFuturePollPtr.asFunction<
+          _VerificationEventGetEmojisFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _verificationEventAcceptVerificationRequestFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _VerificationEventAcceptVerificationRequestFuturePollReturn Function(
@@ -21124,21 +21138,6 @@ class Api {
   late final _verificationEventSendVerificationKeyFuturePoll =
       _verificationEventSendVerificationKeyFuturePollPtr.asFunction<
           _VerificationEventSendVerificationKeyFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
-  late final _verificationEventGetVerificationEmojiFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _VerificationEventGetVerificationEmojiFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__VerificationEvent_get_verification_emoji_future_poll");
-
-  late final _verificationEventGetVerificationEmojiFuturePoll =
-      _verificationEventGetVerificationEmojiFuturePollPtr.asFunction<
-          _VerificationEventGetVerificationEmojiFuturePollReturn Function(
             int,
             int,
             int,
@@ -38935,10 +38934,10 @@ class VerificationEvent {
   }
 
   /// Get emoji array
-  FfiListVerificationEmoji getEmojis() {
+  FfiListVerificationEmoji emojis() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._verificationEventGetEmojis(
+    final tmp1 = _api._verificationEventEmojis(
       tmp0,
     );
     final tmp3 = tmp1;
@@ -38947,6 +38946,23 @@ class VerificationEvent {
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp4 = FfiListVerificationEmoji._(_api, tmp3_1);
     final tmp2 = tmp4;
+    return tmp2;
+  }
+
+  /// Get emoji array
+  Future<FfiListVerificationEmoji> getEmojis() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._verificationEventGetEmojis(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 =
+        _Box(_api, tmp3_0, "__VerificationEvent_get_emojis_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 =
+        _nativeFuture(tmp3_1, _api.__verificationEventGetEmojisFuturePoll);
     return tmp2;
   }
 
@@ -39100,23 +39116,6 @@ class VerificationEvent {
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp2 = _nativeFuture(
         tmp3_1, _api.__verificationEventSendVerificationKeyFuturePoll);
-    return tmp2;
-  }
-
-  /// Alice gets the verification emoji from Bob and vice versa
-  Future<FfiListVerificationEmoji> getVerificationEmoji() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._verificationEventGetVerificationEmoji(
-      tmp0,
-    );
-    final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(
-        _api, tmp3_0, "__VerificationEvent_get_verification_emoji_future_drop");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = _nativeFuture(
-        tmp3_1, _api.__verificationEventGetVerificationEmojiFuturePoll);
     return tmp2;
   }
 
@@ -44408,6 +44407,21 @@ class _InvitationRejectFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _VerificationEventGetEmojisFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+}
+
 class _VerificationEventAcceptVerificationRequestFuturePollReturn
     extends ffi.Struct {
   @ffi.Uint8()
@@ -44516,22 +44530,6 @@ class _VerificationEventSendVerificationKeyFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Uint8()
-  external int arg5;
-}
-
-class _VerificationEventGetVerificationEmojiFuturePollReturn
-    extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Int64()
   external int arg5;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1807,9 +1807,6 @@ object VerificationEvent {
     /// Alice starts the SAS verification
     fn start_sas_verification() -> Future<Result<bool>>;
 
-    /// Whether verification request was launched from this device
-    fn was_triggered_from_this_device() -> Result<bool>;
-
     /// Bob accepts the SAS verification
     fn accept_sas_verification() -> Future<Result<bool>>;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1790,7 +1790,10 @@ object VerificationEvent {
     fn get_content(key: string) -> Option<string>;
 
     /// Get emoji array
-    fn get_emojis() -> Vec<VerificationEmoji>;
+    fn emojis() -> Vec<VerificationEmoji>;
+
+    /// Get emoji array
+    fn get_emojis() -> Future<Result<Vec<VerificationEmoji>>>;
 
     /// Bob accepts the verification request from Alice
     fn accept_verification_request() -> Future<Result<bool>>;

--- a/native/acter/src/api/verification.rs
+++ b/native/acter/src/api/verification.rs
@@ -331,24 +331,6 @@ impl VerificationEvent {
             .await?
     }
 
-    pub fn was_triggered_from_this_device(&self) -> Result<bool> {
-        let device_id = self
-            .client
-            .device_id()
-            .context("guest user cannot get device id")?;
-        warn!("was_triggered_from_this_device device_id: {}", device_id.to_string());
-        if let Some(other_device_id) = self.content.get("other_device_id") {
-            warn!("was_triggered_from_this_device other_device_id: {}", *other_device_id);
-            Ok(*other_device_id == *device_id)
-        } else if let Some(from_device) = self.content.get("from_device") {
-            warn!("was_triggered_from_this_device from_device: {}", *from_device);
-            Ok(*from_device == *device_id)
-        } else {
-            warn!("neither other_device_id nor from_device");
-            Ok(false)
-        }
-    }
-
     pub async fn accept_sas_verification(&self) -> Result<bool> {
         let client = self.client.clone();
         let controller = self.controller.clone();

--- a/native/test/src/tests/verification.rs
+++ b/native/test/src/tests/verification.rs
@@ -152,7 +152,7 @@ async fn interactive_verification_started_from_request() -> Result<()> {
     let bob_event = wait_for_verification_event(&mut bob_rx, "m.key.verification.key");
 
     // Bob gets the verification key from event
-    let emojis_from_alice = bob_event.get_emojis();
+    let emojis_from_alice = bob_event.get_emojis().await?;
     info!("emojis from alice: {:?}", emojis_from_alice);
 
     // Bob sends a key
@@ -165,7 +165,7 @@ async fn interactive_verification_started_from_request() -> Result<()> {
     let alice_event = wait_for_verification_event(&mut alice_rx, "m.key.verification.key");
 
     // Alice gets the verification key from event
-    let emojis_from_bob = alice_event.get_emojis();
+    let emojis_from_bob = alice_event.get_emojis().await?;
     info!("emojis from bob: {:?}", emojis_from_bob);
 
     // ----------------------------------------------------------------------------


### PR DESCRIPTION
When other device verifies this device, getting emojis from SAS state works well.
When this device verifies other device, getting emojis from SAS state doesn't work.
So I will reactivate getting of emojis from remote server.