### PR TITLE
User deactivation

### DIFF
--- a/.changes/0895-user-deactivation.md
+++ b/.changes/0895-user-deactivation.md
@@ -1,0 +1,1 @@
+- Ability to trigger a GDPR-compliant user deactivation from the user profile added

--- a/app/lib/common/dialogs/deactivation_confirmation.dart
+++ b/app/lib/common/dialogs/deactivation_confirmation.dart
@@ -1,0 +1,124 @@
+import 'package:acter/common/dialogs/pop_up_dialog.dart';
+import 'package:acter/common/providers/sdk_provider.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+// Can be extended to be reusable dialog as riverpod states get added.
+// Ref can be used to read any provider which are declared.
+void deactivationConfirmationDialog(BuildContext context, WidgetRef ref) {
+  TextEditingController passwordController = TextEditingController();
+  showDialog(
+    context: context,
+    builder: (BuildContext ctx) {
+      return AlertDialog(
+        title: Text('Deactivate Account',
+            style: TextStyle(
+                color: AppTheme.brandColorScheme.error, fontSize: 32,),),
+        content: SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 650),
+            child: Wrap(
+              children: [
+                Text(
+                  'Careful: You are about to permanently deactivate your account ',
+                  style: TextStyle(
+                    color: AppTheme.brandColorScheme.error,
+                    fontSize: 24,
+                  ),
+                ),
+                const Text('If you proceed: \n  \n'
+                    '- All your personal data will be removed from your homeserver, including display name and avatar \n'
+                    '- All your sessions will be closed immediately, no other device will be able to continue their sessions \n'
+                    '- You will leave all rooms, chats, spaces and DMs that you are in \n'
+                    '- You will not be able to reactivate your account \n'
+                    '- You will no longer be able to log in \n'
+                    '- No one will be able to reuse your username (MXID), including you: this username will remain unavailable indefinitely \n'
+                    '- You will be removed from the identity server, if you provided any information to be found through that (e.g. email or phone number) \n'
+                    '- All local data, including any encryption keys, will be permanently deleted from this device \n'
+                    '- Your old messages will still be visible to people who received them, just like emails you sent in the past. \n'
+                    '\n You will not be able to reverse any of this. This is a permanent and irrevocable action.'),
+                Padding(
+                  padding: const EdgeInsets.only(top: 10, bottom: 10),
+                  child: Text(
+                    'Please provide your user password to confirm you want to deactivate your account.',
+                    style: TextStyle(
+                      color: AppTheme.brandColorScheme.error,
+                      fontSize: 24,
+                    ),
+                  ),
+                ),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 250),
+                  child: TextField(
+                    controller: passwordController,
+                    obscureText: true,
+                    decoration: const InputDecoration(hintText: 'Password'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => ctx.pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () async {
+              popUpDialog(
+                context: context,
+                title: Text(
+                  'Deactivating your account',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                isLoader: true,
+              );
+              final sdk = await ref.read(sdkProvider.future);
+              try {
+                if (!await sdk.deactivateAndDestroyCurrentClient(
+                  passwordController.text,
+                )) {
+                  throw 'Deactivation and removing all local data failed';
+                }
+                // ignore: use_build_context_synchronously
+                if (!context.mounted) {
+                  return;
+                }
+                // remove pop up
+                Navigator.of(context, rootNavigator: true).pop();
+                // remove ourselves
+                Navigator.of(context, rootNavigator: true).pop();
+                context.goNamed(Routes.main.name);
+              } catch (err) {
+                // We are doing as expected, but the lints triggers.
+                // ignore: use_build_context_synchronously
+                if (!context.mounted) {
+                  return;
+                }
+                Navigator.of(context, rootNavigator: true).pop();
+
+                popUpDialog(
+                  context: context,
+                  title: Text(
+                    'Deactivating failed: \n $err"',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  isLoader: false,
+                  btnText: 'Close',
+                  onPressedBtn: () {
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                );
+              }
+            },
+            child: const Text('Deactivate'),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/app/lib/common/themes/app_theme.dart
+++ b/app/lib/common/themes/app_theme.dart
@@ -81,6 +81,8 @@ class AppTheme {
     ],
   );
 
+  static MaterialStateProperty<Color?> dangerState =
+      MaterialStateProperty.all(brandColorScheme.error);
   static ThemeData get theme {
     return ThemeData(
       fontFamily: 'Inter',

--- a/app/lib/features/activities/widgets/session_card.dart
+++ b/app/lib/features/activities/widgets/session_card.dart
@@ -97,12 +97,14 @@ class SessionCard extends ConsumerWidget {
       context: context,
       builder: (BuildContext ctx) {
         return AlertDialog(
-          title: const Text('Auth data needed'),
+          title: const Text('Authentication required'),
           content: Wrap(
             children: [
-              const Text('Please input password of your account.'),
+              const Text(
+                  'Please provide your user password to confirm you want to end that session.',),
               TextField(
                 controller: passwordController,
+                obscureText: true,
                 decoration: const InputDecoration(hintText: 'Password'),
               ),
             ],

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -1,6 +1,8 @@
+import 'package:acter/common/dialogs/deactivation_confirmation.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/dialogs/logout_confirmation.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
+import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
@@ -144,10 +146,6 @@ class MyProfile extends ConsumerWidget {
           appBar: AppBar(
             title: const Text('My profile'),
             actions: [
-              IconButton(
-                icon: const Icon(Atlas.construction_tools_thin),
-                onPressed: () => context.pushNamed(Routes.settings.name),
-              ),
               PopupMenuButton(
                 itemBuilder: (BuildContext context) => <PopupMenuEntry>[
                   PopupMenuItem(
@@ -247,6 +245,41 @@ class MyProfile extends ConsumerWidget {
                             },
                           ),
                         ],
+                      ),
+                      const SizedBox(height: 30),
+                      OutlinedButton.icon(
+                        icon: const Icon(Atlas.construction_tools_thin),
+                        onPressed: () =>
+                            context.pushNamed(Routes.settings.name),
+                        label: const Text('App Settings'),
+                      ),
+                      const SizedBox(height: 10),
+                      OutlinedButton.icon(
+                        icon: const Icon(Atlas.laptop_screen_thin),
+                        onPressed: () =>
+                            context.pushNamed(Routes.settingSessions.name),
+                        label: const Text('Sessions'),
+                      ),
+                      const SizedBox(height: 30),
+                      OutlinedButton.icon(
+                        icon: const Icon(Atlas.exit_thin),
+                        onPressed: () => logoutConfirmationDialog(context, ref),
+                        label: const Text('Logout'),
+                      ),
+                      const SizedBox(height: 45),
+                      OutlinedButton.icon(
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: AppTheme.brandColorScheme.error,
+                          backgroundColor: AppTheme.brandColorScheme.onError,
+                          side: BorderSide(
+                            width: 1,
+                            color: AppTheme.brandColorScheme.error,
+                          ),
+                        ),
+                        icon: const Icon(Atlas.trash_can_thin),
+                        onPressed: () =>
+                            deactivationConfirmationDialog(context, ref),
+                        label: const Text('Deactivate account'),
                       ),
                     ],
                   ),

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -377,6 +377,36 @@ class ActerSdk {
     return _clients;
   }
 
+  Future<bool> deactivateAndDestroyCurrentClient(
+    String password,
+  ) async {
+    final client = currentClient;
+    if (client == null) {
+      return false;
+    }
+
+    final userId = client.userId().toString();
+
+    // take it out of the loop
+    if (_index >= 0 && _index < _clients.length) {
+      _clients.removeAt(_index);
+      _index = _index > 0 ? _index - 1 : 0;
+    }
+    try {
+      if (!await client.deactivate(password)) {
+        throw 'Deactivating the client failed';
+      }
+    } catch (e) {
+      // reset the client locally
+      _clients.add(client);
+      _index = clients.length - 1;
+      rethrow;
+    }
+    String appDocPath = await appDir();
+
+    return await _api.destroyLocalData(appDocPath, userId, defaultServerName);
+  }
+
   ffi.CreateConvoSettingsBuilder newConvoSettingsBuilder() {
     return _api.newConvoSettingsBuilder();
   }

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1062,6 +1062,67 @@ class Api {
     return tmp29;
   }
 
+  /// destroy the local data of a session
+  Future<bool> destroyLocalData(
+    String basepath,
+    String userId,
+    String defaultHomeserverName,
+  ) {
+    final tmp0 = basepath;
+    final tmp4 = userId;
+    final tmp8 = defaultHomeserverName;
+    var tmp1 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp9 = 0;
+    var tmp10 = 0;
+    var tmp11 = 0;
+    final tmp0_0 = utf8.encode(tmp0);
+    tmp2 = tmp0_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp1_0 = this.__allocate(tmp2 * 1, 1);
+    final Uint8List tmp1_1 = tmp1_0.asTypedList(tmp2);
+    tmp1_1.setAll(0, tmp0_0);
+    tmp1 = tmp1_0.address;
+    tmp3 = tmp2;
+    final tmp4_0 = utf8.encode(tmp4);
+    tmp6 = tmp4_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp5_0 = this.__allocate(tmp6 * 1, 1);
+    final Uint8List tmp5_1 = tmp5_0.asTypedList(tmp6);
+    tmp5_1.setAll(0, tmp4_0);
+    tmp5 = tmp5_0.address;
+    tmp7 = tmp6;
+    final tmp8_0 = utf8.encode(tmp8);
+    tmp10 = tmp8_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp9_0 = this.__allocate(tmp10 * 1, 1);
+    final Uint8List tmp9_1 = tmp9_0.asTypedList(tmp10);
+    tmp9_1.setAll(0, tmp8_0);
+    tmp9 = tmp9_0.address;
+    tmp11 = tmp10;
+    final tmp12 = _destroyLocalData(
+      tmp1,
+      tmp2,
+      tmp3,
+      tmp5,
+      tmp6,
+      tmp7,
+      tmp9,
+      tmp10,
+      tmp11,
+    );
+    final tmp14 = tmp12;
+    final ffi.Pointer<ffi.Void> tmp14_0 = ffi.Pointer.fromAddress(tmp14);
+    final tmp14_1 = _Box(this, tmp14_0, "__destroy_local_data_future_drop");
+    tmp14_1._finalizer = this._registerFinalizer(tmp14_1);
+    final tmp13 = _nativeFuture(tmp14_1, this.__destroyLocalDataFuturePoll);
+    return tmp13;
+  }
+
   EfkDuration durationFromSecs(
     int secs,
   ) {
@@ -1368,6 +1429,50 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_Client");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = Client._(this, tmp13_1);
+    return tmp7;
+  }
+
+  bool? __destroyLocalDataFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _destroyLocalDataFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -7033,6 +7138,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __clientDeactivateFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _clientDeactivateFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   String? __clientRestoreTokenFuturePoll(
     int boxed,
     int postCobject,
@@ -10642,6 +10791,32 @@ class Api {
         int,
         int,
         int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+      )>();
+  late final _destroyLocalDataPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__destroy_local_data");
+
+  late final _destroyLocalData = _destroyLocalDataPtr.asFunction<
+      int Function(
         int,
         int,
         int,
@@ -17880,6 +18055,22 @@ class Api {
           int Function(
             int,
           )>();
+  late final _clientDeactivatePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__Client_deactivate");
+
+  late final _clientDeactivate = _clientDeactivatePtr.asFunction<
+      int Function(
+        int,
+        int,
+        int,
+        int,
+      )>();
   late final _clientStartSyncPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -19294,6 +19485,21 @@ class Api {
   late final _registerWithTokenFuturePoll =
       _registerWithTokenFuturePollPtr.asFunction<
           _RegisterWithTokenFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _destroyLocalDataFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _DestroyLocalDataFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__destroy_local_data_future_poll");
+
+  late final _destroyLocalDataFuturePoll =
+      _destroyLocalDataFuturePollPtr.asFunction<
+          _DestroyLocalDataFuturePollReturn Function(
             int,
             int,
             int,
@@ -21078,6 +21284,21 @@ class Api {
   late final _notificationListResultNotificationsFuturePoll =
       _notificationListResultNotificationsFuturePollPtr.asFunction<
           _NotificationListResultNotificationsFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _clientDeactivateFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientDeactivateFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Client_deactivate_future_poll");
+
+  late final _clientDeactivateFuturePoll =
+      _clientDeactivateFuturePollPtr.asFunction<
+          _ClientDeactivateFuturePollReturn Function(
             int,
             int,
             int,
@@ -38337,6 +38558,37 @@ class Client {
 
   Client._(this._api, this._box);
 
+  Future<bool> deactivate(
+    String password,
+  ) {
+    final tmp1 = password;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._clientDeactivate(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+    );
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "__Client_deactivate_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeFuture(tmp7_1, _api.__clientDeactivateFuturePoll);
+    return tmp6;
+  }
+
   /// start the sync
   SyncState startSync() {
     var tmp0 = 0;
@@ -43451,6 +43703,21 @@ class _RegisterWithTokenFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _DestroyLocalDataFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _NewsSlideImageBinaryFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -45256,6 +45523,21 @@ class _NotificationListResultNotificationsFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _ClientDeactivateFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -19,6 +19,9 @@ fn guest_client(basepath: string, default_homeserver_name: string, default_homes
 /// Create a new client from the registration token
 fn register_with_token(basepath: string, username: string, password: string, registration_token: string, default_homeserver_name: string, default_homeserver_url: string, device_name: string) -> Future<Result<Client>>;
 
+/// destroy the local data of a session 
+fn destroy_local_data(basepath: string, userId: string, default_homeserver_name: string) -> Future<Result<bool>>;
+
 /// Representing a time frame
 object EfkDuration {}
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1633,6 +1633,11 @@ object CreateSpaceSettings {}
 
 /// Main entry point for `acter`.
 object Client {
+
+    // deactivate the account. This can not be reversed. The username will 
+    // be blocked from any future usage, all personal data will be removed.
+    fn deactivate(password: string) -> Future<Result<bool>>;
+
     // Special
 
     /// start the sync

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -52,9 +52,9 @@ pub use acter_core::{
 };
 pub use attachments::{Attachment, AttachmentDraft, AttachmentsManager};
 pub use auth::{
-    guest_client, login_new_client, login_new_client_under_config, login_with_token,
-    login_with_token_under_config, make_client_config, register_under_config, register_with_token,
-    register_with_token_under_config, sanitize_user,
+    destroy_local_data, guest_client, login_new_client, login_new_client_under_config,
+    login_with_token, login_with_token_under_config, make_client_config, register_under_config,
+    register_with_token, register_with_token_under_config, sanitize_user,
 };
 pub use calendar_events::{CalendarEvent, CalendarEventDraft, CalendarEventUpdateBuilder};
 pub use client::{Client, ClientStateBuilder, HistoryLoadState, SyncState};

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -42,6 +42,15 @@ pub async fn sanitize_user(
     Ok((user_id, true))
 }
 
+pub async fn destroy_local_data(
+    base_path: String,
+    username: String,
+    default_homeserver_name: String,
+) -> Result<bool> {
+    let (user_id, fallback) = sanitize_user(&username, &default_homeserver_name).await?;
+    platform::destroy_local_data(base_path, user_id.to_string()).await
+}
+
 // public for only integration test, not api.rsh
 pub async fn make_client_config(
     base_path: String,

--- a/native/acter/src/platform/android.rs
+++ b/native/acter/src/platform/android.rs
@@ -6,6 +6,10 @@ use std::sync::{Arc, Mutex};
 
 use super::native;
 
+pub async fn destroy_local_data(base_path: String, home_dir: String) -> Result<bool> {
+    native::destroy_local_data(base_path, home_dir).await
+}
+
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,

--- a/native/acter/src/platform/desktop.rs
+++ b/native/acter/src/platform/desktop.rs
@@ -3,6 +3,10 @@ use matrix_sdk::ClientBuilder;
 
 use super::native;
 
+pub async fn destroy_local_data(base_path: String, home_dir: String) -> Result<bool> {
+    native::destroy_local_data(base_path, home_dir).await
+}
+
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,

--- a/native/acter/src/platform/ios.rs
+++ b/native/acter/src/platform/ios.rs
@@ -6,6 +6,9 @@ use std::sync::{Arc, Mutex};
 
 use super::native;
 
+pub async fn destroy_local_data(base_path: String, home_dir: String) -> Result<bool> {
+    native::destroy_local_data(base_path, home_dir).await
+}
 // this includes macos, because macos and ios is very much alike in logging
 
 #[cfg(target_os = "ios")]

--- a/native/acter/src/platform/native.rs
+++ b/native/acter/src/platform/native.rs
@@ -12,6 +12,15 @@ use std::{
 
 use crate::RUNTIME;
 
+pub async fn destroy_local_data(base_path: String, home_dir: String) -> Result<bool> {
+    let data_path = sanitize(&base_path, &home_dir);
+    if Path::new(&data_path).try_exists()? {
+        std::fs::remove_dir_all(&data_path)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,

--- a/native/test/src/utils.rs
+++ b/native/test/src/utils.rs
@@ -39,6 +39,22 @@ pub fn default_user_password(username: &str) -> String {
     }
 }
 
+pub async fn login_test_user(username: String) -> Result<Client> {
+    ensure_user(
+        option_env!("DEFAULT_HOMESERVER_URL")
+            .unwrap_or("http://localhost:8118")
+            .to_string(),
+        option_env!("DEFAULT_HOMESERVER_NAME")
+            .unwrap_or("localhost")
+            .to_string(),
+        username,
+        option_env!("REGISTRATION_TOKEN").map(ToString::to_string),
+        "acter-integration-tests".to_owned(),
+        StoreConfig::default(),
+    )
+    .await
+}
+
 pub async fn random_user_with_template(
     prefix: &str,
     template: &str,


### PR DESCRIPTION
This PR adds the ability to deactivate ones account, of course with the big red text and password-confirmation before the user actually does it, as that the most permanent, GDPR compliant implementation of right-of-erasure you can implement on Matrix.

This comes with a rust-backend end-to-end-test and code to also remove the locally stored data right at the same time.

See it in action:
![deactivate-and-destroy](https://github.com/acterglobal/a3/assets/40496/3ae9596c-2924-40d5-8d4e-bdb2cb548605)
And then if you tried log in again:
![and-gone](https://github.com/acterglobal/a3/assets/40496/7b3029b4-e87b-43ea-ac5a-c2d04cf65830)


fixes #892 .