### PR TITLE
Forgot to persist sessions after deactivating an account

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -402,6 +402,7 @@ class ActerSdk {
       _index = clients.length - 1;
       rethrow;
     }
+    await _persistSessions();
     String appDocPath = await appDir();
 
     return await _api.destroyLocalData(appDocPath, userId, defaultServerName);


### PR DESCRIPTION
leads to the app reading a  dead session from the sessions pool and ending up in an unrecoverable state.

Minor fix on top of #895 .