### PR TITLE
Enforce Platform Emojis

### DIFF
--- a/app/lib/common/themes/app_theme.dart
+++ b/app/lib/common/themes/app_theme.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io';
 
+@pragma('vm:platform-const')
 bool isDesktop = (Platform.isLinux || Platform.isWindows || Platform.isMacOS);
 
 const emojiFallbackFonts = [
-  'Apple Color Emoji', // we fallback to system fonts first
-  'Segoe UI Emoji',
   'NotoEmoji',
 ];
 const emojiFont = 'NotoEmoji';

--- a/app/lib/common/themes/app_theme.dart
+++ b/app/lib/common/themes/app_theme.dart
@@ -4,16 +4,33 @@ import 'dart:io';
 
 @pragma('vm:platform-const')
 bool isDesktop = (Platform.isLinux || Platform.isWindows || Platform.isMacOS);
+@pragma('vm:platform-const')
+final usesNotoEmoji = !(Platform.isWindows || Platform.isMacOS || Platform.isIOS || Platform.isAndroid);
 
-const emojiFallbackFonts = [
-  'NotoEmoji',
-];
-const emojiFont = 'NotoEmoji';
+const defaultEmojiFont = 'NotoEmoji';
+
+String? selectEmojiFont() {
+  switch(Platform.operatingSystem) {
+    case 'ios':
+    case 'macos':
+      return 'Apple Color Emoji';
+    case 'windows':
+      return 'Segoe UI Emoji';
+    case 'linux' :
+      return defaultEmojiFont;
+    // we fallback to system supported emoji otherwise
+    default: return null;
+  }
+}
+
+final emojiFont = selectEmojiFont();
+// non-noto-emoji we just fallback to the system fonts.
+final List<String>? emojiFallbackFonts = emojiFont != null ? [ emojiFont! ] : null;
 
 class EmojiConfig {
-  static const TextStyle emojiTextStyle =
-      TextStyle(fontFamily: emojiFont, fontFamilyFallback: emojiFallbackFonts);
-  static final checkPlatformCompatibility = !isDesktop;
+  static TextStyle? emojiTextStyle = emojiFont != null ?
+      TextStyle(fontFamily: emojiFont) : null;
+  static final checkPlatformCompatibility = emojiFont != defaultEmojiFont;
   static final emojiSizeMax = 32 * ((!kIsWeb && Platform.isIOS) ? 1.30 : 1.0);
 }
 

--- a/app/lib/common/themes/chat_theme.dart
+++ b/app/lib/common/themes/chat_theme.dart
@@ -52,8 +52,6 @@ class ActerChatTheme extends ChatTheme {
     Color primaryColor = const Color(0xffFF8E00),
     TextStyle receivedEmojiMessageTextStyle = const TextStyle(
       fontSize: 40,
-      fontFamily: emojiFont,
-      fontFamilyFallback: emojiFallbackFonts,
     ),
     TextStyle? receivedMessageBodyBoldTextStyle,
     TextStyle? receivedMessageBodyCodeTextStyle,
@@ -90,8 +88,6 @@ class ActerChatTheme extends ChatTheme {
     Widget? sendingIcon,
     TextStyle sentEmojiMessageTextStyle = const TextStyle(
       fontSize: 40,
-      fontFamily: emojiFont,
-      fontFamilyFallback: emojiFallbackFonts,
     ),
     TextStyle? sentMessageBodyBoldTextStyle,
     TextStyle? sentMessageBodyCodeTextStyle,

--- a/app/lib/common/themes/chat_theme.dart
+++ b/app/lib/common/themes/chat_theme.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 

--- a/app/lib/common/widgets/emoji_picker_widget.dart
+++ b/app/lib/common/widgets/emoji_picker_widget.dart
@@ -61,6 +61,7 @@ class EmojiPickerWidget extends StatelessWidget {
                 bgColor: Theme.of(context).colorScheme.background,
                 recentTabBehavior: RecentTabBehavior.RECENT,
                 recentsLimit: 28,
+                emojiTextStyle: EmojiConfig.emojiTextStyle,
               ),
             ),
           ),

--- a/app/lib/features/chat/widgets/emoji_row.dart
+++ b/app/lib/features/chat/widgets/emoji_row.dart
@@ -64,7 +64,7 @@ class EmojiRow extends StatelessWidget {
                 child: Text(
                   emoji,
                   style:
-                      EmojiConfig.emojiTextStyle.copyWith(fontSize: size ?? 18),
+                      (EmojiConfig.emojiTextStyle ?? const TextStyle()).copyWith(fontSize: size ?? 18),
                 ),
               ),
             InkWell(

--- a/app/lib/features/chat/widgets/text_message_builder.dart
+++ b/app/lib/features/chat/widgets/text_message_builder.dart
@@ -137,7 +137,7 @@ class _TextWidget extends ConsumerWidget {
               message.text,
               style: emojiTextStyle.copyWith(
                 overflow: isReply ? TextOverflow.ellipsis : null,
-                fontFamily: emojiFont
+                fontFamily: emojiFont,
               ),
               maxLines: isReply ? 3 : null,
             )

--- a/app/lib/features/chat/widgets/text_message_builder.dart
+++ b/app/lib/features/chat/widgets/text_message_builder.dart
@@ -137,6 +137,7 @@ class _TextWidget extends ConsumerWidget {
               message.text,
               style: emojiTextStyle.copyWith(
                 overflow: isReply ? TextOverflow.ellipsis : null,
+                fontFamily: emojiFont
               ),
               maxLines: isReply ? 3 : null,
             )


### PR DESCRIPTION
Looks like the font-fallback in #761 did not properly work on Windows, Mac and iOS, as reported in #891 .

For reasons unknown to the author, the included NotoEmoji-Font doesn't properly render on these platforms - maybe because it is an COLRv1 variable font - it is unclear. However, for the sake of support over consistency, this change fixes that by enforcing the usage of the system default emoji-font for these platforms, rather than first using NotoEmoji and only falling back to the system font if it isn't found (which was the previous pattern).

Because that makes the font non-`const` now (as checking Platform is - for some reason - not `const` either), this requires some trickery around the usage of the font setting in other places, too. 

Here you can see it working in all case: react-emoji, react-emoji-drawer, giant-sent-emoji, emoji-in-text-message and the emoji picker for both:

**MacOS**:
![emojis-on-macos](https://github.com/acterglobal/a3/assets/40496/70f8b8de-c4d8-4152-8a02-b20fb849e928)

and **Windows**:
![emojis-on-windows](https://github.com/acterglobal/a3/assets/40496/37d427d8-86ed-4dfa-880c-871d67b601a6)

