### PR TITLE
Make sure we are awaiting the run for CLI

### DIFF
--- a/app/lib/features/cli/main.dart
+++ b/app/lib/features/cli/main.dart
@@ -4,12 +4,12 @@ import 'package:args/command_runner.dart';
 import 'dart:io';
 
 Future<void> cliMain(List<String> args) async {
-  CommandRunner(
+  final builder = CommandRunner(
     'acter',
     'community communication and casual organizing platform',
   )
     ..addCommand(InfoCommand())
-    ..addCommand(BackupAndResetCommand())
-    ..run(args);
+    ..addCommand(BackupAndResetCommand());
+  await builder.run(args);
   exit(0);
 }


### PR DESCRIPTION
Looks like the release build version is fast in quitting the cli, long before it has been run the command. Actually it stops at the very first await-point inside the execution. Seems like the debug version was just slower at stopping the process and thus the awaited tasks used to finish still...

With this fix, we are awaiting the execution of the actual inner commands and thus do actually work. 