### PR TITLE
space members avatar fix

### DIFF
--- a/.changes/0911-space-fixes.md
+++ b/.changes/0911-space-fixes.md
@@ -1,0 +1,1 @@
+- [fix] Some space members avatars failed to load due to internal wrong references. This has been fixed.

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -4,7 +4,6 @@ import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/providers/notifiers/network_notifier.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/utils.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart'
     show Account, Convo, Member, OptionString, UserProfile;
@@ -89,22 +88,11 @@ final relatedChatsProvider = FutureProvider.autoDispose
 });
 
 // Member Providers
+// TODO: improve this to be reusable for space and chat members alike.
 final memberProfileProvider =
-    FutureProvider.family<ProfileData, String>((ref, userId) async {
-  final member = ref.watch(memberProvider(userId));
-  return member.maybeWhen(
-    data: (data) async {
-      UserProfile profile = data!.getProfile();
-      OptionString displayName = await profile.getDisplayName();
-      final avatar = await profile.getThumbnail(62, 60);
-      return ProfileData(displayName.text(), avatar.data());
-    },
-    orElse: () => ProfileData('', null),
-  );
-});
-
-final memberProvider =
-    FutureProvider.family<Member?, String>((ref, userId) async {
-  final convo = ref.watch(currentConvoProvider);
-  return await convo!.getMember(userId);
+    FutureProvider.family<ProfileData, Member>((ref, member) async {
+  UserProfile profile = member.getProfile();
+  OptionString displayName = await profile.getDisplayName();
+  final avatar = await profile.getThumbnail(62, 60);
+  return ProfileData(displayName.text(), avatar.data());
 });

--- a/app/lib/common/widgets/member_list_entry.dart
+++ b/app/lib/common/widgets/member_list_entry.dart
@@ -290,7 +290,7 @@ class MemberListEntry extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userId = member.userId().toString();
-    final profile = ref.watch(memberProfileProvider(userId));
+    final profile = ref.watch(memberProfileProvider(member));
     final memberStatus = member.membershipStatusStr();
     final List<Widget> trailing = [];
     if (memberStatus == 'Admin') {

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'package:acter/common/models/profile_data.dart';
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/features/chat/models/chat_list_state/chat_list_state.dart';
 import 'package:acter/features/chat/models/chat_input_state/chat_input_state.dart';
 import 'package:acter/features/chat/models/chat_room_state/chat_room_state.dart';
@@ -96,5 +98,13 @@ final currentConvoProvider = StateProvider<Convo?>((ref) => null);
 
 final paginationProvider = StateProvider.autoDispose<bool>((ref) => true);
 
+final chatMemberProfileProvider =
+    FutureProvider.family<ProfileData, String>((ref, userId) async {
+  // Eventually we need to figure out a way to track room as this can fail.
+  final convo = ref.watch(currentConvoProvider)!;
+  final member = await convo.getMember(userId);
+  final profile = await ref.watch(memberProfileProvider(member).future);
+  return profile;
+});
 // for desktop only
 final showFullSplitView = StateProvider<bool>((ref) => false);

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -100,7 +100,7 @@ final paginationProvider = StateProvider.autoDispose<bool>((ref) => true);
 
 final chatMemberProfileProvider =
     FutureProvider.family<ProfileData, String>((ref, userId) async {
-  // Eventually we need to figure out a way to track room as this can fail.
+  // Eventually we need to figure keeping this reference in a safe way as this can fail.
   final convo = ref.watch(currentConvoProvider)!;
   final member = await convo.getMember(userId);
   final profile = await ref.watch(memberProfileProvider(member).future);

--- a/app/lib/features/chat/widgets/avatar_builder.dart
+++ b/app/lib/features/chat/widgets/avatar_builder.dart
@@ -1,4 +1,4 @@
-import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,7 +13,7 @@ class AvatarBuilder extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final memberProfile = ref.watch(memberProfileProvider(userId));
+    final memberProfile = ref.watch(chatMemberProfileProvider(userId));
     return memberProfile.when(
       data: (profile) {
         return Padding(

--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
@@ -187,7 +186,7 @@ class _ChatBubble extends ConsumerWidget {
     Widget? child,
   ) {
     final authorId = message.repliedMessage!.author.id;
-    final replyProfile = ref.watch(memberProfileProvider(authorId));
+    final replyProfile = ref.watch(chatMemberProfileProvider(authorId));
     return Row(
       children: [
         replyProfile.when(

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -276,7 +276,7 @@ class CustomChatInput extends ConsumerWidget {
   Widget replyBuilder(BuildContext context, WidgetRef ref, Widget? child) {
     final roomNotifier = ref.watch(chatRoomProvider.notifier);
     final authorId = roomNotifier.repliedToMessage!.author.id;
-    final replyProfile = ref.watch(memberProfileProvider(authorId));
+    final replyProfile = ref.watch(chatMemberProfileProvider(authorId));
     final inputNotifier = ref.watch(chatInputProvider.notifier);
     return Row(
       children: [

--- a/app/lib/features/chat/widgets/emoji_reaction_item.dart
+++ b/app/lib/features/chat/widgets/emoji_reaction_item.dart
@@ -1,5 +1,5 @@
-import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,7 +15,7 @@ class EmojiReactionItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profile = ref.watch(memberProfileProvider(userId));
+    final profile = ref.watch(chatMemberProfileProvider(userId));
 
     return ListTile(
       leading: profile.when(

--- a/app/lib/features/chat/widgets/mention_profile_builder.dart
+++ b/app/lib/features/chat/widgets/mention_profile_builder.dart
@@ -1,4 +1,4 @@
-import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,7 +15,7 @@ class MentionProfileBuilder extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final mentionProfile = ref.watch(memberProfileProvider(authorId));
+    final mentionProfile = ref.watch(chatMemberProfileProvider(authorId));
     return mentionProfile.when(
       data: (profile) => ActerAvatar(
         mode: DisplayMode.User,

--- a/app/lib/features/space/widgets/member_avatar.dart
+++ b/app/lib/features/space/widgets/member_avatar.dart
@@ -13,7 +13,7 @@ class MemberAvatar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userId = member.userId().toString();
-    final profile = ref.watch(memberProfileProvider(userId));
+    final profile = ref.watch(memberProfileProvider(member));
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR acts as derivative from the changes done in #907 and attempts to correct few things:
- Space Members Avatars were previously fetched from the reference of ```Convo``` which is corrected to now be not depending on that while only consider ```Member```.
- Because of that ```memberProfileProvider``` being used simultaneously in other places like ```Chat```, ```chatMemberProfileProvider``` has taken place of it which will fetch profile keeping in mind of ```Convo``` object reference. This is not to be considered viable solution as I've already commented out possible refactoring once chat room state logic is more elegant and safe.