### PR TITLE
Extend blocking feature

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -7325,6 +7325,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __spaceReportContentFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceReportContentFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   bool? __memberIgnoreFuturePoll(
     int boxed,
     int postCobject,
@@ -18288,6 +18332,34 @@ class Api {
             int,
             int,
           )>();
+  late final _spaceReportContentPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Uint8,
+            ffi.Int32,
+            ffi.Uint8,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__Space_report_content");
+
+  late final _spaceReportContent = _spaceReportContentPtr.asFunction<
+      int Function(
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+      )>();
   late final _memberGetProfilePtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -22247,6 +22319,21 @@ class Api {
   late final _spaceUpdateFeaturePowerLevelsFuturePoll =
       _spaceUpdateFeaturePowerLevelsFuturePollPtr.asFunction<
           _SpaceUpdateFeaturePowerLevelsFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _spaceReportContentFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _SpaceReportContentFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Space_report_content_future_poll");
+
+  late final _spaceReportContentFuturePoll =
+      _spaceReportContentFuturePollPtr.asFunction<
+          _SpaceReportContentFuturePollReturn Function(
             int,
             int,
             int,
@@ -39195,6 +39282,77 @@ class Space {
     return tmp10;
   }
 
+  /// report an event from this room
+  /// score - The score to rate this content as where -100 is most offensive and 0 is inoffensive (optional).
+  /// reason - The reason for the event being reported (optional).
+  Future<bool> reportContent(
+    String eventId,
+    int? score,
+    String? reason,
+  ) {
+    final tmp1 = eventId;
+    final tmp5 = score;
+    final tmp9 = reason;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    var tmp8 = 0;
+    var tmp10 = 0;
+    var tmp12 = 0;
+    var tmp13 = 0;
+    var tmp14 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    if (tmp5 == null) {
+      tmp6 = 0;
+    } else {
+      tmp6 = 1;
+      final tmp7 = tmp5;
+      tmp8 = tmp7;
+    }
+    if (tmp9 == null) {
+      tmp10 = 0;
+    } else {
+      tmp10 = 1;
+      final tmp11 = tmp9;
+      final tmp11_0 = utf8.encode(tmp11);
+      tmp13 = tmp11_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp12_0 = _api.__allocate(tmp13 * 1, 1);
+      final Uint8List tmp12_1 = tmp12_0.asTypedList(tmp13);
+      tmp12_1.setAll(0, tmp11_0);
+      tmp12 = tmp12_0.address;
+      tmp14 = tmp13;
+    }
+    final tmp15 = _api._spaceReportContent(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+      tmp8,
+      tmp10,
+      tmp12,
+      tmp13,
+      tmp14,
+    );
+    final tmp17 = tmp15;
+    final ffi.Pointer<ffi.Void> tmp17_0 = ffi.Pointer.fromAddress(tmp17);
+    final tmp17_1 = _Box(_api, tmp17_0, "__Space_report_content_future_drop");
+    tmp17_1._finalizer = _api._registerFinalizer(tmp17_1);
+    final tmp16 = _nativeFuture(tmp17_1, _api.__spaceReportContentFuturePoll);
+    return tmp16;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -47632,6 +47790,21 @@ class _SpaceUpdatePowerLevelFuturePollReturn extends ffi.Struct {
 }
 
 class _SpaceUpdateFeaturePowerLevelsFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
+class _SpaceReportContentFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -11770,6 +11770,16 @@ class Api {
       int Function(
         int,
       )>();
+  late final _newsEntrySenderPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__NewsEntry_sender");
+
+  late final _newsEntrySender = _newsEntrySenderPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _newsEntryDraftAddTextSlidePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -12306,6 +12316,16 @@ class Api {
       _ActerPinRoomIdStrReturn Function(
         int,
       )>();
+  late final _acterPinSenderPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__ActerPin_sender");
+
+  late final _acterPinSender = _acterPinSenderPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _acterPinUpdateBuilderPtr = _lookup<
       ffi.NativeFunction<
           _ActerPinUpdateBuilderReturn Function(
@@ -12578,6 +12598,16 @@ class Api {
 
   late final _calendarEventRoomIdStr = _calendarEventRoomIdStrPtr.asFunction<
       _CalendarEventRoomIdStrReturn Function(
+        int,
+      )>();
+  late final _calendarEventSenderPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__CalendarEvent_sender");
+
+  late final _calendarEventSender = _calendarEventSenderPtr.asFunction<
+      int Function(
         int,
       )>();
   late final _calendarEventUpdateBuilderPtr = _lookup<
@@ -25816,6 +25846,21 @@ class NewsEntry {
     return tmp2;
   }
 
+  /// get sender id
+  UserId sender() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._newsEntrySender(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_UserId");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = UserId._(_api, tmp3_1);
+    return tmp2;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -26941,6 +26986,21 @@ class ActerPin {
     return tmp2;
   }
 
+  /// sender id
+  UserId sender() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._acterPinSender(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_UserId");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = UserId._(_api, tmp3_1);
+    return tmp2;
+  }
+
   /// make a builder for updating the pin
   PinUpdateBuilder updateBuilder() {
     var tmp0 = 0;
@@ -27406,6 +27466,7 @@ class CalendarEvent {
     return tmp2;
   }
 
+  /// room id
   String roomIdStr() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
@@ -27432,6 +27493,21 @@ class CalendarEvent {
       tmp3_0 = ffi.Pointer.fromAddress(tmp3);
       _api.__deallocate(tmp3_0, tmp5 * 1, 1);
     }
+    return tmp2;
+  }
+
+  /// sender id
+  UserId sender() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._calendarEventSender(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_UserId");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = UserId._(_api, tmp3_1);
     return tmp2;
   }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -126,6 +126,9 @@ object NewsEntry {
 
     /// get room id
     fn room_id() -> RoomId;
+
+    /// get sender id
+    fn sender() -> UserId;
 }
 
 object NewsEntryDraft {
@@ -223,6 +226,9 @@ object ActerPin {
     /// the room/space this item belongs to
     fn room_id_str() -> string;
 
+    /// sender id
+    fn sender() -> UserId;
+
     /// make a builder for updating the pin
     fn update_builder() -> Result<PinUpdateBuilder>;
 
@@ -293,7 +299,10 @@ object CalendarEvent {
     // fn locations() -> Vec<Location>;
     /// event id
     fn event_id() -> EventId;
+    /// room id
     fn room_id_str() -> string;
+    /// sender id
+    fn sender() -> UserId;
     /// update builder
     fn update_builder() -> Result<CalendarEventUpdateBuilder>;
     /// get RSVP manager

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1501,6 +1501,11 @@ object Space {
     /// update the power level for a feature
     fn update_feature_power_levels(feature: string, level: Option<i32>) -> Future<Result<bool>>;
 
+    /// report an event from this room
+    /// score - The score to rate this content as where -100 is most offensive and 0 is inoffensive (optional).
+    /// reason - The reason for the event being reported (optional).
+    fn report_content(event_id: string, score: Option<i32>, reason: Option<string>) -> Future<Result<bool>>;
+
 }
 
 enum MembershipStatus {

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -12,7 +12,7 @@ use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
     room::{Joined, Room},
-    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId},
+    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId},
 };
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -156,8 +156,13 @@ impl CalendarEvent {
     pub fn event_id(&self) -> OwnedEventId {
         self.inner.event_id().to_owned()
     }
+
     pub fn room_id_str(&self) -> String {
         self.inner.room_id().to_string()
+    }
+
+    pub fn sender(&self) -> OwnedUserId {
+        self.inner.sender().to_owned()
     }
 }
 

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -12,7 +12,9 @@ use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
     room::{Joined, Room},
-    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId},
+    ruma::{
+        events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId,
+    },
 };
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -22,7 +22,7 @@ use matrix_sdk::{
             },
             ImageInfo,
         },
-        MxcUri, OwnedEventId, OwnedRoomId, UInt,
+        MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, UInt,
     },
 };
 use std::{
@@ -365,6 +365,10 @@ impl NewsEntry {
 
     pub fn room_id(&self) -> OwnedRoomId {
         self.room.room_id().to_owned()
+    }
+
+    pub fn sender(&self) -> OwnedUserId {
+        self.content.sender().to_owned()
     }
 }
 

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -11,7 +11,9 @@ use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
     room::{Joined, Room},
-    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId},
+    ruma::{
+        events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId,
+    },
 };
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -11,7 +11,7 @@ use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
     room::{Joined, Room},
-    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId},
+    ruma::{events::room::message::TextMessageEventContent, OwnedEventId, OwnedRoomId, OwnedUserId},
 };
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -256,6 +256,10 @@ impl Pin {
 
     pub fn room_id_str(&self) -> String {
         self.content.room_id().to_string()
+    }
+
+    pub fn sender(&self) -> OwnedUserId {
+        self.content.sender().to_owned()
     }
 }
 

--- a/native/core/src/models/calendar/event.rs
+++ b/native/core/src/models/calendar/event.rs
@@ -1,4 +1,4 @@
-use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId};
+use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId, UserId};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
@@ -42,6 +42,10 @@ impl CalendarEvent {
 
     pub fn room_id(&self) -> &RoomId {
         &self.meta.room_id
+    }
+
+    pub fn sender(&self) -> &UserId {
+        &self.meta.sender
     }
 
     pub fn updater(&self) -> CalendarEventUpdateBuilder {

--- a/native/core/src/models/news.rs
+++ b/native/core/src/models/news.rs
@@ -1,4 +1,4 @@
-use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId};
+use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId, UserId};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
@@ -27,6 +27,10 @@ impl Deref for NewsEntry {
 impl NewsEntry {
     pub fn room_id(&self) -> &RoomId {
         &self.meta.room_id
+    }
+
+    pub fn sender(&self) -> &UserId {
+        &self.meta.sender
     }
 
     pub fn key_from_event(event_id: &EventId) -> String {

--- a/native/core/src/models/pins.rs
+++ b/native/core/src/models/pins.rs
@@ -1,4 +1,4 @@
-use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId};
+use matrix_sdk::ruma::{events::OriginalMessageLikeEvent, EventId, RoomId, UserId};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
@@ -28,6 +28,10 @@ impl Pin {
 
     pub fn room_id(&self) -> &RoomId {
         &self.meta.room_id
+    }
+
+    pub fn sender(&self) -> &UserId {
+        &self.meta.sender
     }
 
     pub fn is_link(&self) -> bool {


### PR DESCRIPTION
We're currently missing sender info for Pins, News and Events. We actually need that for:
- Check `userId` to make reporting not appear if user is same.
- Optionally add the ignore user option which would require getting the member via `userId`.

Currently `report_content()` falls under only `Convo` hierarchy. We want to implement it in `Space` too.