### PR TITLE
switch default homeserver to staging environment

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -223,7 +223,9 @@ jobs:
             --dart-define VERSION_NAME="Nightly+${{ needs.tags.outputs.tag }}" \
             --dart-define RAGESHAKE_URL="${{ secrets.RAGESHAKE_URL }}" \
             --dart-define RAGESHAKE_APP_NAME="${{ secrets.RAGESHAKE_APP_NAME_NIGHTLY }}" \
-            --dart-define RAGESHAKE_APP_VERSION="Nightly-${{ needs.tags.outputs.tag }}/${{ matrix.name }}"
+            --dart-define RAGESHAKE_APP_VERSION="Nightly-${{ needs.tags.outputs.tag }}/${{ matrix.name }}" \
+            --dart-define DEFAULT_HOMESERVER_URL="${{vars.DEFAULT_HOMESERVER_URL}}" \
+            --dart-define DEFAULT_HOMESERVER_NAME="${{vars.DEFAULT_HOMESERVER_NAME}}"
         working-directory: ./app
 
       # Important! Cleanup: remove the certificate and provisioning profile from the runner!

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -18,12 +18,12 @@ const rustLogKey = 'RUST_LOG';
 
 const defaultServerUrl = String.fromEnvironment(
   'DEFAULT_HOMESERVER_URL',
-  defaultValue: 'https://matrix.acter.global',
+  defaultValue: 'https://m-1.acter.global',
 );
 
 const defaultServerName = String.fromEnvironment(
   'DEFAULT_HOMESERVER_NAME',
-  defaultValue: 'acter.global',
+  defaultValue: 'm-1.acter.global',
 );
 
 const defaultLogSetting = String.fromEnvironment(


### PR DESCRIPTION
We have a development/staging environment for testing. This PR switches the default development environment over to use them for registration and login. It does not effect already logged in accounts. However, when you login again next you have to use the full-user-id or register a new account with the staging server to use it.

Nightly builds are not effected - they will continue to use the production environment.