### PR TITLE
fix fallback user avatar size

### DIFF
--- a/app/lib/common/widgets/user_avatar.dart
+++ b/app/lib/common/widgets/user_avatar.dart
@@ -23,7 +23,7 @@ class UserAvatarWidget extends ConsumerWidget {
             ActerAvatar(
               mode: DisplayMode.User,
               uniqueId: client.userId().toString(),
-              size: size,
+              size: data.profile.hasAvatar() ? size : size * 2,
               avatar: data.profile.getAvatarImage(),
               displayName: data.profile.displayName,
             ),

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -138,14 +138,17 @@ class _DashboardState extends ConsumerState<Dashboard> {
                         mode: DisplayMode.User,
                       ),
                     ),
-                    child: Container(
-                      key: Keys.avatar,
-                      margin: const EdgeInsets.all(8),
-                      child: InkWell(
-                        onTap: () => context.pushNamed(Routes.myProfile.name),
-                        child: const UserAvatarWidget(size: 20),
-                      ),
-                    ),
+                    child: !isDesktop
+                        ? Container(
+                            key: Keys.avatar,
+                            margin: const EdgeInsets.all(8),
+                            child: InkWell(
+                              onTap: () =>
+                                  context.pushNamed(Routes.myProfile.name),
+                              child: const UserAvatarWidget(size: 20),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
                   ),
                 ],
                 title: isDesktop

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -5,10 +5,10 @@ import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_dialog.dart';
+import 'package:acter/common/widgets/user_avatar.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -197,20 +197,7 @@ class MyProfile extends ConsumerWidget {
                           context,
                           ref,
                         ),
-                        child: Container(
-                          margin: const EdgeInsets.all(10),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(100),
-                            border: Border.all(width: 5),
-                          ),
-                          child: ActerAvatar(
-                            mode: DisplayMode.User,
-                            uniqueId: userId,
-                            avatar: data.profile.getAvatarImage(),
-                            displayName: data.profile.displayName,
-                            size: 100,
-                          ),
-                        ),
+                        child: const UserAvatarWidget(size: 100),
                       ),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
- fixes #930.
- hide user avatar in dashboard (desktop) since we have in navigation rail already.
<img width="1542" alt="Screenshot 2023-09-18 at 8 10 22 PM" src="https://github.com/acterglobal/a3/assets/68579938/e541472c-0c4c-4e5c-bd3a-96e0d9bbc44f">
<img width="1542" alt="Screenshot 2023-09-18 at 8 10 41 PM" src="https://github.com/acterglobal/a3/assets/68579938/db24c947-91b3-450e-9482-fc50c4ad2b31">
