### PR TITLE
push chat to unbreak switching

### DIFF
--- a/.changes/1026-chat-unbreak.md
+++ b/.changes/1026-chat-unbreak.md
@@ -1,0 +1,1 @@
+- Fix: do not render space-chat under space but switch to chat-section

--- a/app/lib/features/space/pages/chats_page.dart
+++ b/app/lib/features/space/pages/chats_page.dart
@@ -66,7 +66,11 @@ class SpaceChatsPage extends ConsumerWidget {
                     child: ConvoCard(
                       room: rooms[index],
                       showParent: false,
-                      onTap: () => context.pushNamed(
+
+                      /// FIXME: push is broken for switching from subshell to subshell
+                      /// hence we are using `go` here.
+                      /// https://github.com/flutter/flutter/issues/125752
+                      onTap: () => context.goNamed(
                         Routes.chatroom.name,
                         pathParameters: {'roomId': rooms[index].getRoomIdStr()},
                       ),

--- a/app/lib/features/space/widgets/chats_card.dart
+++ b/app/lib/features/space/widgets/chats_card.dart
@@ -45,7 +45,11 @@ class ChatsCard extends ConsumerWidget {
                     itemBuilder: (context, index) => ConvoCard(
                       room: chats[index],
                       showParent: false,
-                      onTap: () => context.pushNamed(
+
+                      /// FIXME: push is broken for switching from subshell to subshell
+                      /// hence we are using `go` here.
+                      /// https://github.com/flutter/flutter/issues/125752
+                      onTap: () => context.goNamed(
                         Routes.chatroom.name,
                         pathParameters: {
                           'roomId': chats[index].getRoomIdStr(),
@@ -58,7 +62,7 @@ class ChatsCard extends ConsumerWidget {
                           padding: const EdgeInsets.only(left: 30, top: 8),
                           child: OutlinedButton(
                             onPressed: () {
-                              context.pushNamed(
+                              context.goNamed(
                                 Routes.spaceChats.name,
                                 pathParameters: {'spaceId': spaceId},
                               );


### PR DESCRIPTION
refs #955 , #935 

Actually a [bug in flutter go_router](https://github.com/acterglobal/a3/pull/new/ben-fix-chat-subrouting) with `push`. Therefore using `go` here for now.


![chat-from-space](https://github.com/acterglobal/a3/assets/40496/1b517848-2a79-4ba4-987d-6667114df066)