### PR TITLE
Configure pushers

### DIFF
--- a/app/lib/common/notifications/notifications.dart
+++ b/app/lib/common/notifications/notifications.dart
@@ -102,7 +102,7 @@ void notificationTapBackground(NotificationResponse notificationResponse) {
 String makeForward(
     {required String roomId,
     required String deviceId,
-    required String eventId}) {
+    required String eventId,}) {
   return '/forward?roomId=${Uri.encodeComponent(roomId)}&eventId=${Uri.encodeComponent(eventId)}&deviceId=${Uri.encodeComponent(deviceId)}';
 }
 
@@ -246,7 +246,7 @@ Future<void> initializeNotifications() async {
       return;
     }
     rootNavKey.currentContext!.push(
-        makeForward(roomId: roomId, deviceId: deviceId, eventId: eventId));
+        makeForward(roomId: roomId, deviceId: deviceId, eventId: eventId),);
   });
 
   // Handle push notifications
@@ -431,7 +431,7 @@ Future<bool> onNewToken(Client client, String token) async {
   }
 
   await client.addPusher(
-      appId, token, name, appName, pushServerUrl, Platform.isIOS, null);
+      appId, token, name, appName, pushServerUrl, Platform.isIOS, null,);
 
   debugPrint(
     ' ---- notification pusher sent: $appName ($appId) on $name ($token) to $pushServerUrl',

--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -66,6 +66,7 @@ enum Routes {
   settings('/settings'),
   settingsLabs('/settings/labs'),
   settingSessions('/settings/sessions'),
+  settingNotifications('/settings/notifications'),
   blockedUsers('/settings/blockedUsers'),
   info('/info'),
   licenses('/info/licenses'),

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -13,14 +13,6 @@ class SettingsLabsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(featuresProvider);
-    bool isActive(f) => provider.isActive(f);
-    bool updateFeatureState(f, value) {
-      debugPrint('setting $f to $value');
-      ref.read(featuresProvider.notifier).setActive(f, value);
-      return value;
-    }
-
     return WithSidebar(
       sidebar: const SettingsMenu(),
       child: Scaffold(
@@ -33,15 +25,27 @@ class SettingsLabsPage extends ConsumerWidget {
                 SettingsTile.switchTile(
                   title: const Text('Push Notifications'),
                   description: Text(
-                    !supportedPlatforms ? 'Only supported on mobile (iOS & Android) right now': 'Needs App restart to activate',
+                    !supportedPlatforms
+                        ? 'Only supported on mobile (iOS & Android) right now'
+                        : 'Needs App restart to activate',
                   ),
-                  initialValue: supportedPlatforms && isActive(LabsFeature.showNotifications),
+                  initialValue: supportedPlatforms &&
+                      ref.watch(
+                        isActiveProvider(LabsFeature.showNotifications),
+                      ),
                   enabled: supportedPlatforms,
                   onToggle: (newVal) {
-                      updateFeatureState(LabsFeature.showNotifications, newVal);
-                      if (newVal) {
-                        customMsgSnackbar(context, 'Push enabled. Please restart to activate');
-                      }
+                    updateFeatureState(
+                      ref,
+                      LabsFeature.showNotifications,
+                      newVal,
+                    );
+                    if (newVal) {
+                      customMsgSnackbar(
+                        context,
+                        'Push enabled. Please restart to activate',
+                      );
+                    }
                   },
                 ),
               ],
@@ -64,9 +68,9 @@ class SettingsLabsPage extends ConsumerWidget {
                 SettingsTile.switchTile(
                   title: const Text('Events'),
                   description: const Text('Shared Calendar and events'),
-                  initialValue: isActive(LabsFeature.events),
+                  initialValue: ref.watch(isActiveProvider(LabsFeature.events)),
                   onToggle: (newVal) =>
-                      updateFeatureState(LabsFeature.events, newVal),
+                      updateFeatureState(ref, LabsFeature.events, newVal),
                 ),
                 SettingsTile.switchTile(
                   title: const Text('Tasks'),
@@ -74,22 +78,24 @@ class SettingsLabsPage extends ConsumerWidget {
                       const Text('Manage Tasks lists and ToDos together'),
                   initialValue: false,
                   onToggle: (newVal) =>
-                      updateFeatureState(LabsFeature.tasks, newVal),
+                      updateFeatureState(ref, LabsFeature.tasks, newVal),
                 ),
                 SettingsTile.switchTile(
                   title: const Text('Polls'),
                   description: const Text('Polls and Surveys'),
-                  initialValue: isActive(LabsFeature.polls),
+                  initialValue: ref.watch(isActiveProvider(LabsFeature.polls)),
                   onToggle: (newVal) =>
-                      updateFeatureState(LabsFeature.polls, newVal),
+                      updateFeatureState(ref, LabsFeature.polls, newVal),
                   enabled: false,
                 ),
                 SettingsTile.switchTile(
                   title: const Text('CoBudget'),
                   description: const Text('Manage budgets cooperatively'),
-                  initialValue: isActive(LabsFeature.cobudget),
+                  initialValue: ref.watch(
+                    isActiveProvider(LabsFeature.cobudget),
+                  ),
                   onToggle: (newVal) =>
-                      updateFeatureState(LabsFeature.cobudget, newVal),
+                      updateFeatureState(ref, LabsFeature.cobudget, newVal),
                   enabled: false,
                 ),
               ],

--- a/app/lib/features/settings/pages/notifications_page.dart
+++ b/app/lib/features/settings/pages/notifications_page.dart
@@ -1,0 +1,197 @@
+import 'package:acter/common/notifications/notifications.dart';
+import 'package:acter/features/settings/widgets/settings_section_with_title_actions.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/utils/utils.dart';
+import 'package:acter/common/widgets/with_sidebar.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter/features/settings/providers/settings_providers.dart';
+import 'package:acter/features/settings/widgets/settings_menu.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class AddEmail extends StatefulWidget {
+  const AddEmail({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<AddEmail> createState() => _AddEmailState();
+}
+
+class _AddEmailState extends State<AddEmail> {
+  final TextEditingController emailAddr = TextEditingController();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Email address to add'),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(5),
+              child: TextFormField(
+                controller: emailAddr,
+                validator: (value) => value != null &&
+                        value.startsWith('@') &&
+                        value.contains(':')
+                    ? null
+                    : 'Format must be @user:server.tld',
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context, null),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () {
+            if (_formKey.currentState!.validate()) {
+              Navigator.pop(context, emailAddr.text);
+            }
+          },
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}
+
+class NotificationsSettingsPage extends ConsumerWidget {
+  const NotificationsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return WithSidebar(
+      sidebar: const SettingsMenu(),
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: const AppBarTheme().backgroundColor,
+          elevation: 0.0,
+          title: const Text('Notifications'),
+        ),
+        body: Column(
+          children: [
+            SettingsList(
+              shrinkWrap: true,
+              sections: [
+                SettingsSection(
+                  title: const Text('Notifications'),
+                  tiles: [
+                    SettingsTile.switchTile(
+                      title: const Text('Push to this device'),
+                      description: Text(
+                        !supportedPlatforms
+                            ? 'Only supported on mobile (iOS & Android) right now'
+                            : 'Needs App restart to activate',
+                      ),
+                      initialValue: supportedPlatforms &&
+                          ref.watch(
+                            isActiveProvider(LabsFeature.showNotifications),
+                          ),
+                      enabled: supportedPlatforms,
+                      onToggle: (newVal) {
+                        updateFeatureState(
+                          ref,
+                          LabsFeature.showNotifications,
+                          newVal,
+                        );
+                        if (newVal) {
+                          customMsgSnackbar(
+                            context,
+                            'Push enabled. Please restart to activate',
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                ),
+                _pushTargets(context, ref),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  SettingsSectionWithTitleActions _pushTargets(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    return SettingsSectionWithTitleActions(
+      title: const Text('Notification Targets'),
+      actions: [
+        IconButton(
+          icon: Icon(
+            Atlas.plus_circle_thin,
+            color: Theme.of(context).colorScheme.neutral5,
+          ),
+          iconSize: 20,
+          color: Theme.of(context).colorScheme.surface,
+          onPressed: () async {
+            final emailToAdd = await showDialog<String?>(
+              context: context,
+              builder: (BuildContext context) => const AddEmail(),
+            );
+            if (emailToAdd != null) {
+              final client = ref.read(
+                  clientProvider,); // is guaranteed because of the ignoredUsersProvider using it
+
+              // await client.addEmailPusher(emailToAdd);
+              if (context.mounted) {
+                customMsgSnackbar(
+                  context,
+                  '$emailToAdd added to block list. UI might take a bit too update',
+                );
+              }
+            }
+          },
+        ),
+      ],
+      tiles: ref.watch(pushersProvider).when(
+            data: (items) {
+              if (items.isEmpty) {
+                return [
+                  SettingsTile(
+                    title: const Text('no push targets added yet'),
+                  ),
+                ];
+              }
+              return items
+                  .map(
+                    (item) => _pusherTile(context, ref, item),
+                  )
+                  .toList();
+            },
+            error: (e, s) => [
+              SettingsTile(
+                title: Text('failed to load push targets: $e'),
+              ),
+            ],
+            loading: () => [
+              SettingsTile(
+                title: const Text('loading targets'),
+              ),
+            ],
+          ),
+    );
+  }
+
+  SettingsTile _pusherTile(BuildContext context, WidgetRef ref, Pusher item) {
+    return SettingsTile(
+      title: Text(item.deviceDisplayName()),
+      description: Text(item.appDisplayName()),
+    );
+  }
+}

--- a/app/lib/features/settings/pages/notifications_page.dart
+++ b/app/lib/features/settings/pages/notifications_page.dart
@@ -2,10 +2,8 @@ import 'package:acter/common/notifications/notifications.dart';
 import 'package:acter/features/settings/widgets/settings_section_with_title_actions.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -210,40 +208,67 @@ class NotificationsSettingsPage extends ConsumerWidget {
 
   SettingsTile _pusherTile(BuildContext context, WidgetRef ref, Pusher item) {
     return SettingsTile(
+      leading: item.isEmailPusher()
+          ? const Icon(Atlas.email_thin)
+          : const Icon(Atlas.mobile_portrait_thin),
       title: Text(item.deviceDisplayName()),
       description: Text(item.appDisplayName()),
-      trailing: MenuAnchor(
-        builder:
-            (BuildContext context, MenuController controller, Widget? child) {
-          return IconButton(
-            onPressed: () {
-              if (controller.isOpen) {
-                controller.close();
-              } else {
-                controller.open();
-              }
-            },
-            icon: const Icon(Icons.more_vert),
-            tooltip: 'Show menu',
-          );
-        },
-        menuChildren: [
-          MenuItemButton(
-            onPressed: () {
-              // alert dialog with details;
-            },
-            child: const Text('Details'),
+      trailing: const Icon(Atlas.dots_vertical_thin),
+      onPressed: (context) => showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Target Details'),
+          content: SizedBox(
+            width: 300,
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                ListTile(
+                  title: const Text('AppId'),
+                  subtitle: Text(item.appId()),
+                ),
+                ListTile(
+                  title: const Text('App Name'),
+                  subtitle: Text(item.appDisplayName()),
+                ),
+                ListTile(
+                  title: const Text('Device Name'),
+                  subtitle: Text(item.deviceDisplayName()),
+                ),
+                ListTile(
+                  title: const Text('Language'),
+                  subtitle: Text(item.lang()),
+                ),
+              ],
+            ),
+            // alert dialog with details;
           ),
-          MenuItemButton(
-            onPressed: () async {
-              EasyLoading.show();
-              await item.delete();
-              EasyLoading.dismiss();
-              ref.invalidate(pushersProvider);
-            },
-            child: const Text('Delete Pusher'),
-          ),
-        ],
+          actions: <Widget>[
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.red,
+                border: Border.all(color: Colors.red),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: TextButton(
+                onPressed: () async {
+                  EasyLoading.show();
+                  await item.delete();
+                  EasyLoading.dismiss();
+                  ref.invalidate(pushersProvider);
+                },
+                child: const Text(
+                  'Delete Target',
+                  style: TextStyle(color: Colors.white, fontSize: 17),
+                ),
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, null),
+              child: const Text('Close Dialog'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/settings/providers/settings_providers.dart
+++ b/app/lib/features/settings/providers/settings_providers.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/utils/feature_flagger.dart';
 import 'package:acter/common/utils/utils.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/providers/notifiers/labs_features.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final featuresProvider =
@@ -21,3 +23,22 @@ final ignoredUsersProvider = FutureProvider<List<UserId>>((ref) async {
   final account = await ref.watch(accountProvider.future);
   return (await account.ignoredUsers()).toList();
 });
+
+final pushersProvider = FutureProvider<List<Pusher>>((ref) async {
+  final client = ref.watch(clientProvider);
+  if (client == null) {
+    throw 'No client';
+  }
+  return (await client.pushers()).toList();
+});
+
+final isActiveProvider = StateProvider.family<bool, LabsFeature>(
+  (ref, feature) => ref.watch(featuresProvider).isActive(feature),
+);
+
+// helper
+bool updateFeatureState(ref, f, value) {
+  debugPrint('setting $f to $value');
+  ref.read(featuresProvider.notifier).setActive(f, value);
+  return value;
+}

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -71,7 +71,7 @@ class SettingsMenu extends ConsumerWidget {
                   style: titleStylesSelected(Routes.settingNotifications),
                 ),
                 leading: Icon(
-                  Atlas.key_monitor_thin,
+                  Atlas.bell_mobile_thin,
                   color: colorSelected(Routes.settingNotifications),
                 ),
                 onPressed: (context) {

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -63,6 +63,25 @@ class SettingsMenu extends ConsumerWidget {
               ),
               SettingsTile.navigation(
                 title: Text(
+                  'Notifications',
+                  style: titleStylesSelected(Routes.settingNotifications),
+                ),
+                description: Text(
+                  'Notifications settings and targets',
+                  style: titleStylesSelected(Routes.settingNotifications),
+                ),
+                leading: Icon(
+                  Atlas.key_monitor_thin,
+                  color: colorSelected(Routes.settingNotifications),
+                ),
+                onPressed: (context) {
+                  shouldGoNotNamed
+                      ? context.goNamed(Routes.settingNotifications.name)
+                      : context.pushNamed(Routes.settingNotifications.name);
+                },
+              ),
+              SettingsTile.navigation(
+                title: Text(
                   'Blocked Users',
                   style: titleStylesSelected(Routes.blockedUsers),
                 ),

--- a/app/lib/features/settings/widgets/settings_section_with_title_actions.dart
+++ b/app/lib/features/settings/widgets/settings_section_with_title_actions.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class SettingsSectionWithTitleActions extends AbstractSettingsSection {
+  /// The actual title widget
+  final Widget title;
+  final List<Widget> actions;
+  final List<AbstractSettingsTile> tiles;
+  const SettingsSectionWithTitleActions({
+    super.key,
+    required this.title,
+    required this.actions,
+    required this.tiles,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SettingsTheme.of(context);
+    final tileList = buildTileList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            _platformPaddingTitle(context),
+            const Spacer(),
+            ...actions,
+          ],
+        ),
+        Container(
+          color: theme.themeData.settingsSectionBackground,
+          child: tileList,
+        ),
+      ],
+    );
+  }
+
+  Widget buildTileList() {
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: tiles.length,
+      padding: EdgeInsets.zero,
+      physics: const NeverScrollableScrollPhysics(),
+      itemBuilder: (BuildContext context, int index) {
+        return tiles[index];
+      },
+    );
+  }
+
+  Padding _platformPaddingTitle(BuildContext context) {
+    final theme = SettingsTheme.of(context);
+    final scaleFactor = MediaQuery.of(context).textScaleFactor;
+
+    switch (theme.platform) {
+      case DevicePlatform.android:
+      case DevicePlatform.fuchsia:
+      case DevicePlatform.linux:
+        return Padding(
+          padding: EdgeInsetsDirectional.only(
+            top: 24 * scaleFactor,
+            bottom: 10 * scaleFactor,
+            start: 24,
+            end: 24,
+          ),
+          child: DefaultTextStyle(
+            style: TextStyle(
+              color: theme.themeData.titleTextColor,
+            ),
+            child: title,
+          ),
+        );
+      case DevicePlatform.iOS:
+      case DevicePlatform.macOS:
+      case DevicePlatform.windows:
+        return Padding(
+          padding: EdgeInsetsDirectional.only(
+            start: 18,
+            bottom: 5 * scaleFactor,
+          ),
+          child: DefaultTextStyle(
+            style: TextStyle(
+              color: theme.themeData.titleTextColor,
+              fontSize: 13,
+            ),
+            child: title,
+          ),
+        );
+
+      case DevicePlatform.web:
+      case DevicePlatform.device:
+        throw Exception(
+          'You can\'t use the DevicePlatform.device/web in this context. '
+          'Incorrect platform: SettingsSection.build',
+        );
+    }
+  }
+}

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -13,6 +13,7 @@ import 'package:acter/features/events/sheets/edit_event_sheet.dart';
 import 'package:acter/features/pins/sheets/create_pin_sheet.dart';
 import 'package:acter/features/pins/sheets/edit_pin_sheet.dart';
 import 'package:acter/features/settings/pages/blocked_users.dart';
+import 'package:acter/features/settings/pages/notifications_page.dart';
 import 'package:acter/features/settings/pages/sessions_page.dart';
 import 'package:acter/features/bug_report/pages/bug_report_page.dart';
 import 'package:acter/features/chat/pages/chat_select_page.dart';
@@ -104,7 +105,7 @@ Future<String?> forwardRedirect(
   try {
     final acterSdk = await ActerSdk.instance;
     if (!acterSdk.hasClients) {
-      // we are not logged in. 
+      // we are not logged in.
       return null;
     }
     final deviceId = state.uri.queryParameters['deviceId'];
@@ -112,11 +113,13 @@ Future<String?> forwardRedirect(
     final client = await acterSdk.getClientWithDeviceId(deviceId!);
     if (await client.hasConvo(roomId!)) {
       // this is a chat
-      return state.namedLocation(Routes.chatroom.name, pathParameters: {'roomId': roomId});
-    } else  {
+      return state.namedLocation(Routes.chatroom.name,
+          pathParameters: {'roomId': roomId},);
+    } else {
       // final eventId = state.uri.queryParameters['eventId'];
-      // with the event ID or further information we could figure out the specific action 
-      return state.namedLocation(Routes.space.name, pathParameters: {'roomId': roomId});
+      // with the event ID or further information we could figure out the specific action
+      return state
+          .namedLocation(Routes.space.name, pathParameters: {'roomId': roomId});
     }
   } catch (error, trace) {
     // ignore: deprecated_member_use
@@ -152,7 +155,7 @@ List<RouteBase> makeRoutes(Ref ref) {
       path: Routes.forward.route,
       redirect: forwardRedirect,
     ),
-    
+
     GoRoute(
       name: Routes.intro.name,
       path: Routes.intro.route,
@@ -192,7 +195,9 @@ List<RouteBase> makeRoutes(Ref ref) {
       parentNavigatorKey: rootNavKey,
       name: Routes.fatalFail.name,
       path: Routes.fatalFail.route,
-      builder: (context, state) => FatalFailPage(error: state.uri.queryParameters['error']!, trace: state.uri.queryParameters['trace']!),
+      builder: (context, state) => FatalFailPage(
+          error: state.uri.queryParameters['error']!,
+          trace: state.uri.queryParameters['trace']!,),
     ),
     GoRoute(
       parentNavigatorKey: rootNavKey,
@@ -690,6 +695,17 @@ List<RouteBase> makeRoutes(Ref ref) {
             return NoTransitionPage(
               key: state.pageKey,
               child: const SettingsLabsPage(),
+            );
+          },
+        ),
+        GoRoute(
+          name: Routes.settingNotifications.name,
+          path: Routes.settingNotifications.route,
+          redirect: authGuardRedirect,
+          pageBuilder: (context, state) {
+            return NoTransitionPage(
+              key: state.pageKey,
+              child: const NotificationsSettingsPage(),
             );
           },
         ),

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -8454,6 +8454,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __pusherDeleteFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _pusherDeleteFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   bool? __clientDeactivateFuturePoll(
     int boxed,
     int postCobject,
@@ -10000,50 +10044,6 @@ class Api {
     return tmp7;
   }
 
-  bool? __clientAddPusherFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _clientAddPusherFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
   FfiListPusher? __clientPushersFuturePoll(
     int boxed,
     int postCobject,
@@ -10089,6 +10089,94 @@ class Api {
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp14 = FfiListPusher._(this, tmp13_1);
     final tmp7 = tmp14;
+    return tmp7;
+  }
+
+  bool? __clientAddPusherFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _clientAddPusherFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
+  bool? __clientAddEmailPusherFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _clientAddEmailPusherFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -20713,6 +20801,16 @@ class Api {
       _PusherProfileTagReturn Function(
         int,
       )>();
+  late final _pusherDeletePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Pusher_delete");
+
+  late final _pusherDelete = _pusherDeletePtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _createConvoSettingsBuilderSetNamePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -21711,6 +21809,16 @@ class Api {
           int Function(
             int,
           )>();
+  late final _clientPushersPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Client_pushers");
+
+  late final _clientPushers = _clientPushersPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _clientAddPusherPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -21761,14 +21869,40 @@ class Api {
         int,
         int,
       )>();
-  late final _clientPushersPtr = _lookup<
+  late final _clientAddEmailPusherPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
-          )>>("__Client_pushers");
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Uint8,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__Client_add_email_pusher");
 
-  late final _clientPushers = _clientPushersPtr.asFunction<
+  late final _clientAddEmailPusher = _clientAddEmailPusherPtr.asFunction<
       int Function(
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
         int,
       )>();
   late final _clientGetNotificationItemPtr = _lookup<
@@ -24799,6 +24933,20 @@ class Api {
             int,
             int,
           )>();
+  late final _pusherDeleteFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _PusherDeleteFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Pusher_delete_future_poll");
+
+  late final _pusherDeleteFuturePoll = _pusherDeleteFuturePollPtr.asFunction<
+      _PusherDeleteFuturePollReturn Function(
+        int,
+        int,
+        int,
+      )>();
   late final _clientDeactivateFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _ClientDeactivateFuturePollReturn Function(
@@ -25287,6 +25435,20 @@ class Api {
             int,
             int,
           )>();
+  late final _clientPushersFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientPushersFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Client_pushers_future_poll");
+
+  late final _clientPushersFuturePoll = _clientPushersFuturePollPtr.asFunction<
+      _ClientPushersFuturePollReturn Function(
+        int,
+        int,
+        int,
+      )>();
   late final _clientAddPusherFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _ClientAddPusherFuturePollReturn Function(
@@ -25302,20 +25464,21 @@ class Api {
             int,
             int,
           )>();
-  late final _clientPushersFuturePollPtr = _lookup<
+  late final _clientAddEmailPusherFuturePollPtr = _lookup<
       ffi.NativeFunction<
-          _ClientPushersFuturePollReturn Function(
+          _ClientAddEmailPusherFuturePollReturn Function(
             ffi.Int64,
             ffi.Int64,
             ffi.Int64,
-          )>>("__Client_pushers_future_poll");
+          )>>("__Client_add_email_pusher_future_poll");
 
-  late final _clientPushersFuturePoll = _clientPushersFuturePollPtr.asFunction<
-      _ClientPushersFuturePollReturn Function(
-        int,
-        int,
-        int,
-      )>();
+  late final _clientAddEmailPusherFuturePoll =
+      _clientAddEmailPusherFuturePollPtr.asFunction<
+          _ClientAddEmailPusherFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _clientGetNotificationItemFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _ClientGetNotificationItemFuturePollReturn Function(
@@ -44489,6 +44652,20 @@ class Pusher {
     return tmp2;
   }
 
+  Future<bool> delete() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherDelete(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Pusher_delete_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__pusherDeleteFuturePoll);
+    return tmp2;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -46496,6 +46673,21 @@ class Client {
     return tmp2;
   }
 
+  /// list of pushers
+  Future<FfiListPusher> pushers() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._clientPushers(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Client_pushers_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__clientPushersFuturePoll);
+    return tmp2;
+  }
+
   /// add another http pusher to the notification system
   Future<bool> addPusher(
     String appId,
@@ -46621,19 +46813,93 @@ class Client {
     return tmp30;
   }
 
-  /// list of pushers
-  Future<FfiListPusher> pushers() {
+  /// add another http pusher to the notification system
+  Future<bool> addEmailPusher(
+    String deviceName,
+    String appName,
+    String email,
+    String? lang,
+  ) {
+    final tmp1 = deviceName;
+    final tmp5 = appName;
+    final tmp9 = email;
+    final tmp13 = lang;
     var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp8 = 0;
+    var tmp10 = 0;
+    var tmp11 = 0;
+    var tmp12 = 0;
+    var tmp14 = 0;
+    var tmp16 = 0;
+    var tmp17 = 0;
+    var tmp18 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._clientPushers(
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5_0 = utf8.encode(tmp5);
+    tmp7 = tmp5_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp6_0 = _api.__allocate(tmp7 * 1, 1);
+    final Uint8List tmp6_1 = tmp6_0.asTypedList(tmp7);
+    tmp6_1.setAll(0, tmp5_0);
+    tmp6 = tmp6_0.address;
+    tmp8 = tmp7;
+    final tmp9_0 = utf8.encode(tmp9);
+    tmp11 = tmp9_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp10_0 = _api.__allocate(tmp11 * 1, 1);
+    final Uint8List tmp10_1 = tmp10_0.asTypedList(tmp11);
+    tmp10_1.setAll(0, tmp9_0);
+    tmp10 = tmp10_0.address;
+    tmp12 = tmp11;
+    if (tmp13 == null) {
+      tmp14 = 0;
+    } else {
+      tmp14 = 1;
+      final tmp15 = tmp13;
+      final tmp15_0 = utf8.encode(tmp15);
+      tmp17 = tmp15_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp16_0 = _api.__allocate(tmp17 * 1, 1);
+      final Uint8List tmp16_1 = tmp16_0.asTypedList(tmp17);
+      tmp16_1.setAll(0, tmp15_0);
+      tmp16 = tmp16_0.address;
+      tmp18 = tmp17;
+    }
+    final tmp19 = _api._clientAddEmailPusher(
       tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+      tmp7,
+      tmp8,
+      tmp10,
+      tmp11,
+      tmp12,
+      tmp14,
+      tmp16,
+      tmp17,
+      tmp18,
     );
-    final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(_api, tmp3_0, "__Client_pushers_future_drop");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = _nativeFuture(tmp3_1, _api.__clientPushersFuturePoll);
-    return tmp2;
+    final tmp21 = tmp19;
+    final ffi.Pointer<ffi.Void> tmp21_0 = ffi.Pointer.fromAddress(tmp21);
+    final tmp21_1 =
+        _Box(_api, tmp21_0, "__Client_add_email_pusher_future_drop");
+    tmp21_1._finalizer = _api._registerFinalizer(tmp21_1);
+    final tmp20 = _nativeFuture(tmp21_1, _api.__clientAddEmailPusherFuturePoll);
+    return tmp20;
   }
 
   /// getting a notification item from the notification data;
@@ -53146,6 +53412,21 @@ class _NotificationListResultNotificationsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _PusherDeleteFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _ClientDeactivateFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -53637,6 +53918,21 @@ class _ClientListNotificationsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ClientPushersFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+}
+
 class _ClientAddPusherFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -53652,7 +53948,7 @@ class _ClientAddPusherFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _ClientPushersFuturePollReturn extends ffi.Struct {
+class _ClientAddEmailPusherFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()
@@ -53663,7 +53959,7 @@ class _ClientPushersFuturePollReturn extends ffi.Struct {
   external int arg3;
   @ffi.Uint64()
   external int arg4;
-  @ffi.Int64()
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -10044,6 +10044,54 @@ class Api {
     return tmp7;
   }
 
+  FfiListPusher? __clientPushersFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _clientPushersFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListPusher");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp14 = FfiListPusher._(this, tmp13_1);
+    final tmp7 = tmp14;
+    return tmp7;
+  }
+
   NotificationItem? __clientGetNotificationItemFuturePoll(
     int boxed,
     int postCobject,
@@ -20595,6 +20643,76 @@ class Api {
           int Function(
             int,
           )>();
+  late final _pusherIsEmailPusherPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.Int64,
+          )>>("__Pusher_is_email_pusher");
+
+  late final _pusherIsEmailPusher = _pusherIsEmailPusherPtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _pusherPushkeyPtr = _lookup<
+      ffi.NativeFunction<
+          _PusherPushkeyReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_pushkey");
+
+  late final _pusherPushkey = _pusherPushkeyPtr.asFunction<
+      _PusherPushkeyReturn Function(
+        int,
+      )>();
+  late final _pusherAppIdPtr = _lookup<
+      ffi.NativeFunction<
+          _PusherAppIdReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_app_id");
+
+  late final _pusherAppId = _pusherAppIdPtr.asFunction<
+      _PusherAppIdReturn Function(
+        int,
+      )>();
+  late final _pusherAppDisplayNamePtr = _lookup<
+      ffi.NativeFunction<
+          _PusherAppDisplayNameReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_app_display_name");
+
+  late final _pusherAppDisplayName = _pusherAppDisplayNamePtr.asFunction<
+      _PusherAppDisplayNameReturn Function(
+        int,
+      )>();
+  late final _pusherDeviceDisplayNamePtr = _lookup<
+      ffi.NativeFunction<
+          _PusherDeviceDisplayNameReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_device_display_name");
+
+  late final _pusherDeviceDisplayName = _pusherDeviceDisplayNamePtr.asFunction<
+      _PusherDeviceDisplayNameReturn Function(
+        int,
+      )>();
+  late final _pusherLangPtr = _lookup<
+      ffi.NativeFunction<
+          _PusherLangReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_lang");
+
+  late final _pusherLang = _pusherLangPtr.asFunction<
+      _PusherLangReturn Function(
+        int,
+      )>();
+  late final _pusherProfileTagPtr = _lookup<
+      ffi.NativeFunction<
+          _PusherProfileTagReturn Function(
+            ffi.Int64,
+          )>>("__Pusher_profile_tag");
+
+  late final _pusherProfileTag = _pusherProfileTagPtr.asFunction<
+      _PusherProfileTagReturn Function(
+        int,
+      )>();
   late final _createConvoSettingsBuilderSetNamePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -21641,6 +21759,16 @@ class Api {
         int,
         int,
         int,
+        int,
+      )>();
+  late final _clientPushersPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Client_pushers");
+
+  late final _clientPushers = _clientPushersPtr.asFunction<
+      int Function(
         int,
       )>();
   late final _clientGetNotificationItemPtr = _lookup<
@@ -25174,6 +25302,20 @@ class Api {
             int,
             int,
           )>();
+  late final _clientPushersFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientPushersFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Client_pushers_future_poll");
+
+  late final _clientPushersFuturePoll = _clientPushersFuturePollPtr.asFunction<
+      _ClientPushersFuturePollReturn Function(
+        int,
+        int,
+        int,
+      )>();
   late final _clientGetNotificationItemFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _ClientGetNotificationItemFuturePollReturn Function(
@@ -26694,6 +26836,55 @@ class Api {
   late final _ffiListPublicSearchResultItemInsert =
       _ffiListPublicSearchResultItemInsertPtr
           .asFunction<void Function(int, int, int)>();
+  FfiListPusher createFfiListPusher() {
+    final ffi.Pointer<ffi.Void> list_ptr =
+        ffi.Pointer.fromAddress(_ffiListPusherCreate());
+    final list_box = _Box(this, list_ptr, "drop_box_FfiListPusher");
+    return FfiListPusher._(this, list_box);
+  }
+
+  late final _ffiListPusherCreatePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
+          "__FfiListPusherCreate");
+
+  late final _ffiListPusherCreate =
+      _ffiListPusherCreatePtr.asFunction<int Function()>();
+
+  late final _ffiListPusherLenPtr =
+      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.IntPtr)>>(
+          "__FfiListPusherLen");
+
+  late final _ffiListPusherLen =
+      _ffiListPusherLenPtr.asFunction<int Function(int)>();
+
+  late final _ffiListPusherElementAtPtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListPusherElementAt");
+
+  late final _ffiListPusherElementAt =
+      _ffiListPusherElementAtPtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListPusherRemovePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListPusherRemove");
+
+  late final _ffiListPusherRemove =
+      _ffiListPusherRemovePtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListPusherAddPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
+          "__FfiListPusherAdd");
+
+  late final _ffiListPusherAdd =
+      _ffiListPusherAddPtr.asFunction<void Function(int, int)>();
+
+  late final _ffiListPusherInsertPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.IntPtr, ffi.Uint32, ffi.IntPtr)>>("__FfiListPusherInsert");
+
+  late final _ffiListPusherInsert =
+      _ffiListPusherInsertPtr.asFunction<void Function(int, int, int)>();
   FfiListReactionRecord createFfiListReactionRecord() {
     final ffi.Pointer<ffi.Void> list_ptr =
         ffi.Pointer.fromAddress(_ffiListReactionRecordCreate());
@@ -44102,6 +44293,208 @@ class NotificationItem {
   }
 }
 
+/// The pusher we sent notifications via to the user
+class Pusher {
+  final Api _api;
+  final _Box _box;
+
+  Pusher._(this._api, this._box);
+
+  bool isEmailPusher() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherIsEmailPusher(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  String pushkey() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherPushkey(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String appId() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherAppId(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String appDisplayName() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherAppDisplayName(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String deviceDisplayName() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherDeviceDisplayName(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String lang() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherLang(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? profileTag() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._pusherProfileTag(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
 class CreateConvoSettingsBuilder {
   final Api _api;
   final _Box _box;
@@ -46226,6 +46619,21 @@ class Client {
     tmp31_1._finalizer = _api._registerFinalizer(tmp31_1);
     final tmp30 = _nativeFuture(tmp31_1, _api.__clientAddPusherFuturePoll);
     return tmp30;
+  }
+
+  /// list of pushers
+  Future<FfiListPusher> pushers() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._clientPushers(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Client_pushers_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__clientPushersFuturePoll);
+    return tmp2;
   }
 
   /// getting a notification item from the notification data;
@@ -50121,6 +50529,62 @@ class _NotificationItemIsNoisyReturn extends ffi.Struct {
   external int arg1;
 }
 
+class _PusherPushkeyReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+}
+
+class _PusherAppIdReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+}
+
+class _PusherAppDisplayNameReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+}
+
+class _PusherDeviceDisplayNameReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+}
+
+class _PusherLangReturn extends ffi.Struct {
+  @ffi.Int64()
+  external int arg0;
+  @ffi.Uint64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+}
+
+class _PusherProfileTagReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+}
+
 class _CreateConvoSettingsBuilderAddInviteeReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -53188,6 +53652,21 @@ class _ClientAddPusherFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ClientPushersFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+}
+
 class _ClientGetNotificationItemFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -54682,6 +55161,65 @@ class FfiListPublicSearchResultItem extends Iterable<PublicSearchResultItem>
   void insert(int index, PublicSearchResultItem element) {
     _api._ffiListPublicSearchResultItemInsert(
         _box.borrow(), index, element._box.borrow());
+    element._box.move();
+  }
+
+  void drop() {
+    _box.drop();
+  }
+}
+
+class FfiListPusher extends Iterable<Pusher> implements CustomIterable<Pusher> {
+  final Api _api;
+  final _Box _box;
+
+  FfiListPusher._(this._api, this._box);
+
+  @override
+  Iterator<Pusher> get iterator => CustomIterator(this);
+
+  @override
+  int get length {
+    return _api._ffiListPusherLen(_box.borrow());
+  }
+
+  /// List object owns the elements, and objects returned by this method hold onto the list object ensuring the pointed to element isn/t dropped.
+  @override
+  Pusher elementAt(int index) {
+    final address = _api._ffiListPusherElementAt(_box.borrow(), index);
+    final reference = _Box(
+      _api,
+      ffi.Pointer.fromAddress(address),
+      "drop_box_Leak",
+      context: this,
+    );
+    return Pusher._(_api, reference);
+  }
+
+  Pusher operator [](int index) {
+    return elementAt(index);
+  }
+
+  /// Moves the element out of this list and returns it
+  Pusher remove(int index) {
+    final address = _api._ffiListPusherRemove(_box.borrow(), index);
+    final reference =
+        _Box(_api, ffi.Pointer.fromAddress(address), "drop_box_Pusher");
+    reference._finalizer = _api._registerFinalizer(reference);
+    return Pusher._(_api, reference);
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void add(Pusher element) {
+    _api._ffiListPusherAdd(_box.borrow(), element._box.borrow());
+    element._box.move();
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void insert(int index, Pusher element) {
+    _api._ffiListPusherInsert(_box.borrow(), index, element._box.borrow());
     element._box.move();
   }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -337,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  email_validator:
+    dependency: "direct main"
+    description:
+      name: email_validator
+      sha256: e9a90f27ab2b915a27d7f9c2a7ddda5dd752d6942616ee83529b686fc086221b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.17"
   emoji_picker_flutter:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -118,6 +118,7 @@ dependencies:
   device_info_plus: ^9.0.3
   great_list_view: ^0.2.3
   flutter_local_notifications: ^16.0.0
+  email_validator: ^2.1.17
 
 
 # FIXME keep until a new version has been published

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1799,7 +1799,17 @@ object NotificationItem {
     fn is_direct_message_room() -> bool;
     fn is_noisy() -> Option<bool>;
     fn joined_members_count() -> u64;
+}
 
+/// The pusher we sent notifications via to the user
+object Pusher {
+    fn is_email_pusher() -> bool;
+    fn pushkey() -> string;
+    fn app_id() -> string;
+    fn app_display_name() -> string;
+    fn device_display_name() -> string;
+    fn lang() -> string;
+    fn profile_tag() -> Option<string>;
 }
 
 /// make convo settings builder
@@ -2031,6 +2041,9 @@ object Client {
 
     /// add another http pusher to the notification system
     fn add_pusher(app_id: string, token: string, device_name: string, app_name: string, server_url: string, with_ios_default: bool, lang: Option<string>) -> Future<Result<bool>>;
+
+    /// list of pushers
+    fn pushers() -> Future<Result<Vec<Pusher>>>;
 
     /// getting a notification item from the notification data;
     fn get_notification_item(room_id: string, event_id: string) -> Future<Result<NotificationItem>>;

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1810,6 +1810,8 @@ object Pusher {
     fn device_display_name() -> string;
     fn lang() -> string;
     fn profile_tag() -> Option<string>;
+
+    fn delete() -> Future<Result<bool>>;
 }
 
 /// make convo settings builder
@@ -2039,11 +2041,14 @@ object Client {
     /// listen to incoming notifications
     fn notifications_stream() -> Stream<Notification>;
 
+    /// list of pushers
+    fn pushers() -> Future<Result<Vec<Pusher>>>;
+
     /// add another http pusher to the notification system
     fn add_pusher(app_id: string, token: string, device_name: string, app_name: string, server_url: string, with_ios_default: bool, lang: Option<string>) -> Future<Result<bool>>;
 
-    /// list of pushers
-    fn pushers() -> Future<Result<Vec<Pusher>>>;
+    /// add another http pusher to the notification system
+    fn add_email_pusher(device_name: string, app_name: string, email: string, lang: Option<string>) -> Future<Result<bool>>;
 
     /// getting a notification item from the notification data;
     fn get_notification_item(room_id: string, event_id: string) -> Future<Result<NotificationItem>>;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -81,7 +81,7 @@ pub use news::{NewsEntry, NewsEntryDraft, NewsEntryUpdateBuilder, NewsSlide};
 pub use notifications::{Notification, NotificationListResult};
 pub use pins::{Pin as ActerPin, PinDraft, PinUpdateBuilder};
 pub use profile::{RoomProfile, UserProfile};
-pub use push::NotificationItem;
+pub use push::{NotificationItem, Pusher};
 pub use receipt::{ReceiptEvent, ReceiptRecord};
 pub use room::{
     Member, MemberPermission, MembershipStatus, Room, SpaceHierarchyListResult,


### PR DESCRIPTION
Build on top of #945 this allows you to configure and remove any particular pusher via the account settings. Additionally this contains the features to add email-pushers but that isn't yet activated until #926 is through.

![Screenshot_1697732716](https://github.com/acterglobal/a3/assets/40496/61bb1f15-321e-4b41-92c4-5f5c98bde7f9)
![Screenshot_1697732718](https://github.com/acterglobal/a3/assets/40496/274191cd-bd8a-48c7-b183-fd763086addc)



Best to review after #945 has been merged I suppose.
