### PR TITLE
Ignore this device detection in cross signing

### DIFF
--- a/app/lib/features/cross_signing/cross_signing.dart
+++ b/app/lib/features/cross_signing/cross_signing.dart
@@ -64,17 +64,23 @@ class CrossSigning {
   void _installDeviceEvent() {
     _deviceNewPoller = client.deviceNewEventRx()?.listen((event) async {
       final records = await event.deviceRecords(false);
+      final myDevId = client.deviceId();
+      var newDevFound = false;
       for (var record in records) {
-        debugPrint('found device id: ${record.deviceId()}');
+        final newDevId = record.deviceId();
+        if (newDevId.toString() != myDevId.toString()) {
+          // ignore detection of this device in this device
+          newDevFound = true;
+          debugPrint('found device id: $newDevId');
+        }
       }
 
-      if (!_shouldShowNewDevicePopup()) {
+      if (!_shouldShowNewDevicePopup() || !newDevFound) {
         return;
       }
       showSimpleNotification(
         ListTile(
-          leading:
-              isDesktop ? const Icon(Atlas.laptop) : const Icon(Atlas.phone),
+          leading: Icon(isDesktop ? Atlas.laptop : Atlas.phone),
           title: const Text('New Session Alert'),
           subtitle: const Text('Tap to review and verify!'),
         ),

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -289,7 +289,11 @@ pub async fn register_under_config(
     RUNTIME
         .spawn(async move {
             let client = config.build().await?;
-            if let Err(resp) = client.matrix_auth().register(register::v3::Request::new()).await {
+            if let Err(resp) = client
+                .matrix_auth()
+                .register(register::v3::Request::new())
+                .await
+            {
                 // FIXME: do actually check the registration types...
                 if resp.as_uiaa_response().is_some() {
                     let request = assign!(register::v3::Request::new(), {

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -4,7 +4,7 @@ use matrix_sdk::{
     matrix_auth::{MatrixSession, MatrixSessionTokens},
     ruma::{
         api::client::{
-            account::register::{v3::Request as RegisterRequest, RegistrationKind},
+            account::register,
             uiaa::{AuthData, Dummy, Password, RegistrationToken},
         },
         assign,
@@ -89,8 +89,8 @@ pub async fn guest_client(
     RUNTIME
         .spawn(async move {
             let client = config.build().await?;
-            let request = assign!(RegisterRequest::new(), {
-                kind: RegistrationKind::Guest,
+            let request = assign!(register::v3::Request::new(), {
+                kind: register::RegistrationKind::Guest,
                 initial_device_display_name: device_name,
             });
             let response = client.matrix_auth().register(request).await?;
@@ -289,10 +289,10 @@ pub async fn register_under_config(
     RUNTIME
         .spawn(async move {
             let client = config.build().await?;
-            if let Err(resp) = client.matrix_auth().register(RegisterRequest::new()).await {
+            if let Err(resp) = client.matrix_auth().register(register::v3::Request::new()).await {
                 // FIXME: do actually check the registration types...
                 if resp.as_uiaa_response().is_some() {
-                    let request = assign!(RegisterRequest::new(), {
+                    let request = assign!(register::v3::Request::new(), {
                         username: Some(user_id.localpart().to_owned()),
                         password: Some(password.clone()),
                         initial_device_display_name: Some(user_agent.clone()),
@@ -357,7 +357,7 @@ pub async fn register_with_token_under_config(
         .spawn(async move {
             let client = {
                 let client = config.build().await?;
-                let request = assign!(RegisterRequest::new(), {
+                let request = assign!(register::v3::Request::new(), {
                     username: Some(user_id.localpart().to_owned()),
                     password: Some(password.clone()),
                     initial_device_display_name: Some(user_agent.clone()),
@@ -372,7 +372,7 @@ pub async fn register_with_token_under_config(
                     info!("Acceptable auth flows: {response:?}");
 
                     // FIXME: do actually check the registration types...
-                    let token_request = assign!(RegisterRequest::new(), {
+                    let token_request = assign!(register::v3::Request::new(), {
                         auth: Some(AuthData::RegistrationToken(
                             assign!(RegistrationToken::new(registration_token), {
                                 session: response.session.clone(),

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -22,7 +22,7 @@ use matrix_sdk::{
     room::Room as SdkRoom,
     ruma::api::client::{
         error::{ErrorBody, ErrorKind},
-        push::get_notifications::v3::Notification as RumaNotification,
+        push::get_notifications,
         Error,
     },
     Client as SdkClient, LoopCtrl, RoomState, RumaApiError,
@@ -89,7 +89,7 @@ pub struct Client {
     pub(crate) receipt_controller: ReceiptController,
     pub spaces: Arc<RwLock<eyeball_im::ObservableVector<Space>>>,
     pub convos: Arc<RwLock<eyeball_im::ObservableVector<Convo>>>,
-    pub(crate) notifications: Arc<Sender<RumaNotification>>,
+    pub(crate) notifications: Arc<Sender<get_notifications::v3::Notification>>,
 }
 
 impl Deref for Client {

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -9,10 +9,7 @@ use matrix_sdk::{
     executor::JoinHandle,
     room::MessagesOptions,
     ruma::{
-        api::client::room::{
-            create_room::v3::{CreationContent, Request as CreateRoomRequest},
-            Visibility,
-        },
+        api::client::room::{create_room, Visibility},
         assign,
     },
     Client as SdkClient, RoomMemberships,
@@ -392,8 +389,8 @@ impl Client {
                     initial_states.push(join_rule.to_raw_any());
                 };
 
-                let request = assign!(CreateRoomRequest::new(), {
-                    creation_content: Some(Raw::new(&CreationContent::new())?),
+                let request = assign!(create_room::v3::Request::new(), {
+                    creation_content: Some(Raw::new(&create_room::v3::CreationContent::new())?),
                     initial_state: initial_states,
                     is_direct: true,
                     invite: settings.invites,

--- a/native/acter/src/api/invitation.rs
+++ b/native/acter/src/api/invitation.rs
@@ -3,7 +3,7 @@ use futures_signals::signal::{Mutable, MutableSignalCloned, SignalExt, SignalStr
 use matrix_sdk::{
     event_handler::{Ctx, EventHandlerHandle},
     room::{Room, RoomMember},
-    ruma::api::client::user_directory::search_users::v3::User,
+    ruma::api::client::user_directory::search_users,
     Client as SdkClient, RoomMemberships, RoomState,
 };
 use ruma_common::{OwnedRoomId, OwnedUserId, RoomId};
@@ -286,7 +286,7 @@ impl InvitationController {
 }
 
 struct SearchedUser {
-    inner: User,
+    inner: search_users::v3::User,
 }
 
 impl SearchedUser {

--- a/native/acter/src/api/notifications.rs
+++ b/native/acter/src/api/notifications.rs
@@ -1,9 +1,6 @@
 use acter_core::spaces::is_acter_space;
 use anyhow::{Context, Result};
-use matrix_sdk::ruma::{
-    api::client::push::get_notifications,
-    assign,
-};
+use matrix_sdk::ruma::{api::client::push::get_notifications, assign};
 use ruma_common::OwnedRoomId;
 
 use crate::{Convo, RoomMessage, Space};
@@ -20,7 +17,10 @@ pub struct Notification {
 }
 
 impl Notification {
-    pub(crate) async fn new(notification: get_notifications::v3::Notification, client: Client) -> Self {
+    pub(crate) async fn new(
+        notification: get_notifications::v3::Notification,
+        client: Client,
+    ) -> Self {
         let room = client.room_by_id_typed(&notification.room_id);
         let (is_space, is_acter_space) = if let Some(room) = &room {
             if room.is_space() {

--- a/native/acter/src/api/notifications.rs
+++ b/native/acter/src/api/notifications.rs
@@ -1,10 +1,7 @@
 use acter_core::spaces::is_acter_space;
 use anyhow::{Context, Result};
 use matrix_sdk::ruma::{
-    api::client::push::get_notifications::v3::{
-        Notification as RumaNotification, Request as GetNotificationsRequest,
-        Response as GetNotificationsResponse,
-    },
+    api::client::push::get_notifications,
     assign,
 };
 use ruma_common::OwnedRoomId;
@@ -14,7 +11,7 @@ use crate::{Convo, RoomMessage, Space};
 use super::{client::Client, message::sync_event_to_message, room::Room, RUNTIME};
 
 pub struct Notification {
-    notification: RumaNotification,
+    notification: get_notifications::v3::Notification,
     client: Client,
     room: Option<Room>,
     room_message: Option<RoomMessage>,
@@ -23,7 +20,7 @@ pub struct Notification {
 }
 
 impl Notification {
-    pub(crate) async fn new(notification: RumaNotification, client: Client) -> Self {
+    pub(crate) async fn new(notification: get_notifications::v3::Notification, client: Client) -> Self {
         let room = client.room_by_id_typed(&notification.room_id);
         let (is_space, is_acter_space) = if let Some(room) = &room {
             if room.is_space() {
@@ -93,7 +90,7 @@ impl Notification {
 }
 
 pub struct NotificationListResult {
-    resp: GetNotificationsResponse,
+    resp: get_notifications::v3::Response,
     client: Client,
 }
 
@@ -126,7 +123,7 @@ impl Client {
         let c = self.clone();
         RUNTIME
             .spawn(async move {
-                let request = assign!(GetNotificationsRequest::new(), { from: since, only });
+                let request = assign!(get_notifications::v3::Request::new(), { from: since, only });
                 let resp = c.send(request, None).await?;
                 Ok(NotificationListResult { resp, client: c })
             })

--- a/native/acter/src/api/profile.rs
+++ b/native/acter/src/api/profile.rs
@@ -4,8 +4,8 @@ use matrix_sdk::{
     room::RoomMember,
     ruma::{
         api::client::{
-            media::get_content_thumbnail::v3::Method as ThumbnailMethod,
-            user_directory::search_users::v3::User,
+            media::get_content_thumbnail,
+            user_directory::search_users,
         },
         UInt,
     },
@@ -22,12 +22,12 @@ use super::{
 
 #[derive(Clone)]
 pub struct PublicProfile {
-    inner: User,
+    inner: search_users::v3::User,
     client: Client,
 }
 
 impl PublicProfile {
-    pub fn new(inner: User, client: Client) -> Self {
+    pub fn new(inner: search_users::v3::User, client: Client) -> Self {
         PublicProfile { inner, client }
     }
 
@@ -145,7 +145,7 @@ impl UserProfile {
             return RUNTIME
                 .spawn(async move {
                     let size = MediaThumbnailSize {
-                        method: ThumbnailMethod::Scale,
+                        method: get_content_thumbnail::v3::Method::Scale,
                         width,
                         height,
                     };
@@ -158,7 +158,7 @@ impl UserProfile {
             return RUNTIME
                 .spawn(async move {
                     let size = MediaThumbnailSize {
-                        method: ThumbnailMethod::Scale,
+                        method: get_content_thumbnail::v3::Method::Scale,
                         width,
                         height,
                     };
@@ -237,7 +237,7 @@ impl RoomProfile {
         RUNTIME
             .spawn(async move {
                 let size = MediaThumbnailSize {
-                    method: ThumbnailMethod::Scale,
+                    method: get_content_thumbnail::v3::Method::Scale,
                     width,
                     height,
                 };

--- a/native/acter/src/api/profile.rs
+++ b/native/acter/src/api/profile.rs
@@ -3,10 +3,7 @@ use matrix_sdk::{
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
     room::RoomMember,
     ruma::{
-        api::client::{
-            media::get_content_thumbnail,
-            user_directory::search_users,
-        },
+        api::client::{media::get_content_thumbnail, user_directory::search_users},
         UInt,
     },
     Account, Client, DisplayName,

--- a/native/acter/src/api/push.rs
+++ b/native/acter/src/api/push.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use anyhow::{bail, Context, Result};
 use matrix_sdk::ruma::{
-    api::client::push::{set_pusher, Pusher as RumaPusher, PusherIds, PusherInit, PusherKind},
+    api::client::push::{get_pushers, set_pusher, EmailPusherData, Pusher as RumaPusher, PusherIds, PusherInit, PusherKind},
     assign,
     push::HttpPusherData,
 };
@@ -14,7 +14,6 @@ use matrix_sdk_ui::notification_client::{
     NotificationClient, NotificationEvent, NotificationItem as SdkNotificationItem,
     NotificationProcessSetup,
 };
-use ruma::api::client::push::{get_pushers, EmailPusherData};
 use ruma_common::{OwnedEventId, OwnedRoomId};
 
 pub struct NotificationItem {

--- a/native/acter/src/api/push.rs
+++ b/native/acter/src/api/push.rs
@@ -6,7 +6,10 @@ use super::{
 };
 use anyhow::{bail, Context, Result};
 use matrix_sdk::ruma::{
-    api::client::push::{get_pushers, set_pusher, EmailPusherData, Pusher as RumaPusher, PusherIds, PusherInit, PusherKind},
+    api::client::push::{
+        get_pushers, set_pusher, EmailPusherData, Pusher as RumaPusher, PusherIds, PusherInit,
+        PusherKind,
+    },
     assign,
     push::HttpPusherData,
 };

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -25,14 +25,9 @@ use matrix_sdk::{
     room::{Room as SdkRoom, RoomMember},
     ruma::{
         api::client::{
-            receipt::create_receipt::v3::ReceiptType as CreateReceiptType,
-            room::report_content::v3::Request as ReportContentRequest,
-            space::{
-                get_hierarchy::v1::{
-                    Request as GetHierarchyRequest, Response as GetHierarchyResponse,
-                },
-                SpaceHierarchyRoomsChunk,
-            },
+            receipt::create_receipt,
+            room::report_content,
+            space::{get_hierarchy, SpaceHierarchyRoomsChunk},
         },
         assign, Int, UInt,
     },
@@ -423,7 +418,7 @@ impl SpaceHierarchyRoomInfo {
 }
 
 pub struct SpaceHierarchyListResult {
-    resp: GetHierarchyResponse,
+    resp: get_hierarchy::v1::Response,
     client: CoreClient,
 }
 
@@ -472,7 +467,7 @@ impl SpaceRelations {
         let room_id = self.room.room_id().to_owned();
         RUNTIME
             .spawn(async move {
-                let request = assign!(GetHierarchyRequest::new(room_id), { from, max_depth: Some(1u32.into()) });
+                let request = assign!(get_hierarchy::v1::Request::new(room_id), { from, max_depth: Some(1u32.into()) });
                 let resp = c.client().send(request, None).await?;
                 Ok(SpaceHierarchyListResult { resp, client: c.clone() })
             })
@@ -905,7 +900,7 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 room.send_single_receipt(
-                    CreateReceiptType::Read,
+                    create_receipt::v3::ReceiptType::Read,
                     ReceiptThread::Unthreaded,
                     event_id,
                 )
@@ -2704,7 +2699,7 @@ impl Room {
 
         RUNTIME
             .spawn(async move {
-                let request = ReportContentRequest::new(
+                let request = report_content::v3::Request::new(
                     room.room_id().to_owned(),
                     event_id,
                     int_score,

--- a/native/acter/src/api/search.rs
+++ b/native/acter/src/api/search.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-use matrix_sdk::ruma::{
-    api::client::directory::get_public_rooms_filtered,
-    assign,
-};
+use matrix_sdk::ruma::{api::client::directory::get_public_rooms_filtered, assign};
 use ruma_common::{
     directory::{Filter, PublicRoomJoinRule, PublicRoomsChunk, RoomNetwork, RoomTypeFilter},
     room::RoomType,

--- a/native/acter/src/api/search.rs
+++ b/native/acter/src/api/search.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use matrix_sdk::ruma::{
-    api::client::directory::get_public_rooms_filtered::v3::{
-        Request as FilteredRequest, Response as FilteredResponse,
-    },
+    api::client::directory::get_public_rooms_filtered,
     assign,
 };
 use ruma_common::{
@@ -89,7 +87,7 @@ impl PublicSearchResultItem {
 }
 
 pub struct PublicSearchResult {
-    resp: FilteredResponse,
+    resp: get_public_rooms_filtered::v3::Response,
 }
 
 impl PublicSearchResult {
@@ -140,7 +138,7 @@ impl Client {
                 } else {
                     None
                 };
-                let request = assign!(FilteredRequest::new(), {
+                let request = assign!(get_public_rooms_filtered::v3::Request::new(), {
                     since,
                     filter,
                     server,

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -24,10 +24,7 @@ use matrix_sdk::{
     event_handler::{Ctx, EventHandlerHandle},
     media::{MediaFormat, MediaRequest},
     room::{Messages, MessagesOptions, Room as SdkRoom},
-    ruma::{
-        api::client::state::send_state_event,
-        assign,
-    },
+    ruma::{api::client::state::send_state_event, assign},
     RoomState,
 };
 use ruma_common::{

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -25,15 +25,7 @@ use matrix_sdk::{
     media::{MediaFormat, MediaRequest},
     room::{Messages, MessagesOptions, Room as SdkRoom},
     ruma::{
-        api::client::{
-            space::{
-                get_hierarchy::v1::{
-                    Request as GetHierarchyRequest, Response as GetHierarchyResponse,
-                },
-                SpaceHierarchyRoomsChunk,
-            },
-            state::send_state_event::v3::Request as SendStateEventRequest,
-        },
+        api::client::state::send_state_event,
         assign,
     },
     RoomState,
@@ -514,7 +506,7 @@ impl Space {
                         );
                     }
 
-                    requests.push(SendStateEventRequest::new_raw(
+                    requests.push(send_state_event::v3::Request::new_raw(
                         room_id.clone(),
                         event_type,
                         state_key,

--- a/native/acter/src/api/stream.rs
+++ b/native/acter/src/api/stream.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use futures::stream::{Stream, StreamExt};
 use matrix_sdk::{
     room::{Receipts, Room},
-    ruma::api::client::receipt::create_receipt::v3::ReceiptType,
+    ruma::api::client::receipt::create_receipt,
     RoomState,
 };
 use matrix_sdk_ui::timeline::{BackPaginationStatus, PaginationOptions, Timeline};
@@ -126,9 +126,9 @@ impl TimelineStream {
     ) -> Result<bool> {
         let timeline = self.timeline.clone();
         let receipt_type = match receipt_type.as_str() {
-            "FullyRead" => ReceiptType::FullyRead,
-            "Read" => ReceiptType::Read,
-            "ReadPrivate" => ReceiptType::ReadPrivate,
+            "FullyRead" => create_receipt::v3::ReceiptType::FullyRead,
+            "Read" => create_receipt::v3::ReceiptType::Read,
+            "ReadPrivate" => create_receipt::v3::ReceiptType::ReadPrivate,
             _ => {
                 bail!("Wrong receipt type")
             }

--- a/native/core/src/spaces.rs
+++ b/native/core/src/spaces.rs
@@ -2,10 +2,7 @@ use derive_builder::Builder;
 use matrix_sdk::{
     room::Room,
     ruma::{
-        api::client::room::{
-            create_room::v3::{CreationContent, Request as CreateRoomRequest},
-            Visibility,
-        },
+        api::client::room::{create_room, Visibility},
         assign,
     },
 };
@@ -187,7 +184,7 @@ impl SpaceRelations {
 impl CoreClient {
     pub async fn create_acter_space(&self, settings: CreateSpaceSettings) -> Result<OwnedRoomId> {
         let client = self.client();
-        let content = assign!(CreationContent::new(), {
+        let content = assign!(create_room::v3::CreationContent::new(), {
             room_type: Some(RoomType::Space),
         });
         let CreateSpaceSettings {
@@ -247,7 +244,7 @@ impl CoreClient {
             initial_states.push(join_rule.to_raw_any());
         };
 
-        let request = assign!(CreateRoomRequest::new(), {
+        let request = assign!(create_room::v3::Request::new(), {
             creation_content: Some(Raw::new(&content)?),
             initial_state: initial_states,
             is_direct: false,


### PR DESCRIPTION
- Ignore detection of this device in this device. It is meaningless to process the detection of this device in this device.
- Remove crate alias from usage of ruma api like `matrix-sdk` project does so.