### PR TITLE
Fix math fork build problem by pinning to PR commit

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -660,10 +660,11 @@ packages:
   flutter_math_fork:
     dependency: "direct main"
     description:
-      name: flutter_math_fork
-      sha256: a143a3a89131b578043ecbdb5e759c1033a1b3e9174f5cd1b979d93f4a7fb41c
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "3442b36a436880ce1c023e25c868d6f4004c4c24"
+      resolved-ref: "3442b36a436880ce1c023e25c868d6f4004c4c24"
+      url: "https://github.com/The-Redhat/flutter_math_fork/"
+    source: git
     version: "0.7.1"
   flutter_matrix_html:
     dependency: "direct main"
@@ -1153,10 +1154,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: "direct main"
     description:
@@ -1329,10 +1330,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1686,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   state_notifier:
     dependency: transitive
     description:
@@ -1702,10 +1703,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1774,10 +1775,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timelines:
     dependency: "direct main"
     description:
@@ -1942,10 +1943,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.1"
+    version: "11.10.0"
   watcher:
     dependency: transitive
     description:
@@ -1958,10 +1959,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -2027,5 +2028,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.13.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -123,6 +123,11 @@ dependencies:
 
 # FIXME keep until a new version has been published
 dependency_overrides:
+  flutter_math_fork:
+  # FIXME: we need this fix https://github.com/simpleclub-extended/flutter_math_fork/pull/87
+    git:
+      url: https://github.com/The-Redhat/flutter_math_fork/
+      ref: 3442b36a436880ce1c023e25c868d6f4004c4c24
   flutter_secure_storage:
     git:
       url: https://github.com/mogol/flutter_secure_storage


### PR DESCRIPTION
Fixes:
```
Changed 8 dependencies!
24 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

Running Gradle task 'bundleRelease'...                          
/opt/hostedtoolcache/flutter/stable-3.16.0-x64/.pub-cache/hosted/pub.dev/flutter_math_fork-0.7.1/lib/src/widgets/selection/gesture_detector_builder_selectable.dart:38:22: Error: Type 'TapDragUpDetails' not found.
  void onSingleTapUp(TapDragUpDetails details) {
                     ^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/flutter/stable-3.16.0-x64/.pub-cache/hosted/pub.dev/flutter_math_fork-0.7.1/lib/src/widgets/selection/gesture_detector_builder_selectable.dart:38:22: Error: 'TapDragUpDetails' isn't a type.
  void onSingleTapUp(TapDragUpDetails details) {
                     ^^^^^^^^^^^^^^^^
Target kernel_snapshot failed: Exception
````

By pinning the `flutter_math_fork` dependency to [the fix from this PR](https://github.com/simpleclub-extended/flutter_math_fork/pull/87)