### PR TITLE
Ben fix 938

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk"
 version = "0.6.2"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "anyhow",
  "anymap2",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "aes",
  "as_variant",
@@ -3037,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "async-trait",
  "deadpool-sqlite",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-ui"
 version = "0.6.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=7e53c6821be8ec7ab5adcb84e43e478773e79c30#7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702256b461449260c7d76ce99e#98df2b35c3ccb4702256b461449260c7d76ce99e"
 dependencies = [
  "as_variant",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,25 +7,25 @@ members = [
 default-members = ["native/acter"]
 
 [workspace.dependencies.matrix-sdk]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+git = "https://github.com/gnunicorn/matrix-rust-sdk"
+rev = "98df2b35c3ccb4702256b461449260c7d76ce99e"
 default-features = false
 features = ["experimental-sliding-sync"]
 
 [workspace.dependencies.matrix-sdk-base]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+git = "https://github.com/gnunicorn/matrix-rust-sdk"
+rev = "98df2b35c3ccb4702256b461449260c7d76ce99e"
 default-features = false
 
 [workspace.dependencies.matrix-sdk-sqlite]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+git = "https://github.com/gnunicorn/matrix-rust-sdk"
+rev = "98df2b35c3ccb4702256b461449260c7d76ce99e"
 default-features = false
 features = ["crypto-store", "state-store"]
 
 [workspace.dependencies.matrix-sdk-ui]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "7e53c6821be8ec7ab5adcb84e43e478773e79c30"
+git = "https://github.com/gnunicorn/matrix-rust-sdk"
+rev = "98df2b35c3ccb4702256b461449260c7d76ce99e"
 default-features = false
 features = ["e2e-encryption"]
 

--- a/app/integration_test/support/login.dart
+++ b/app/integration_test/support/login.dart
@@ -2,7 +2,7 @@ import 'package:acter/common/models/keys.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/onboarding/pages/register_page.dart';
-import 'package:acter/features/profile/model/keys.dart';
+import 'package:acter/features/profile/pages/my_profile_page.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,8 +15,10 @@ const defaultRegistrationToken = String.fromEnvironment(
 );
 
 extension ActerLogin on ConvenientTest {
-  Future<String> freshAccount(
-      {String? registrationToken, String? displayName,}) async {
+  Future<String> freshAccount({
+    String? registrationToken,
+    String? displayName,
+  }) async {
     final newId = 'it-${const Uuid().v4().toString()}';
     startFreshTestApp(newId);
     await register(
@@ -90,7 +92,7 @@ extension ActerLogin on ConvenientTest {
     await profileKey.should(findsOneWidget);
     await profileKey.tap();
 
-    final logoutKey = find.byKey(MyProfileKeys.logout);
+    final logoutKey = find.byKey(MyProfile.logoutKey);
     await logoutKey.should(findsOneWidget);
     await logoutKey.tap();
 

--- a/app/integration_test/tests/auth.dart
+++ b/app/integration_test/tests/auth.dart
@@ -6,7 +6,6 @@ import 'package:acter/features/profile/pages/my_profile_page.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../support/login.dart';
 import '../support/setup.dart';

--- a/app/integration_test/tests/auth.dart
+++ b/app/integration_test/tests/auth.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/dialogs/deactivation_confirmation.dart';
 import 'package:acter/common/utils/constants.dart';
+import 'package:acter/features/activities/pages/activities_page.dart';
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
@@ -7,6 +8,7 @@ import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../support/login.dart';
 import '../support/setup.dart';
+import '../support/util.dart';
 
 void authTests() {
   tTestWidgets('registration smoke test', (t) async {
@@ -57,5 +59,16 @@ void authTests() {
     await t.tryLogin(userId); // we try
     // but should fail.
     // FIXME: how to check for a failure...
+  });
+  tTestWidgets('fresh registration has no unauthenticated sessions', (t) async {
+    disableOverflowErrors();
+    await t.freshAccount();
+    await t.navigateTo([
+      MainNavKeys.activities,
+    ]);
+
+    // items _not_ present!
+    find.byKey(ActivitiesPage.oneUnverifiedSessionsCard).should(findsNothing);
+    find.byKey(ActivitiesPage.unverifiedSessionsCard).should(findsNothing);
   });
 }

--- a/app/integration_test/tests/auth.dart
+++ b/app/integration_test/tests/auth.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:acter/common/dialogs/deactivation_confirmation.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/features/activities/pages/activities_page.dart';
@@ -15,18 +13,15 @@ import '../support/setup.dart';
 import '../support/util.dart';
 
 void authTests() {
-  tTestWidgets('registration smoke test', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('registration smoke test', (t) async {
     await t.freshAccount();
   });
-  tTestWidgets('register and login test', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('register and login test', (t) async {
     final userId = await t.freshAccount();
     await t.logout();
     await t.login(userId);
   });
-  tTestWidgets('deactivate account test', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('deactivate account test', (t) async {
     final userId = await t.freshAccount();
 
     await find.byKey(Keys.mainNav).should(findsOneWidget);
@@ -64,8 +59,8 @@ void authTests() {
     // but should fail.
     // FIXME: how to check for a failure...
   });
-  tTestWidgets('fresh registration has no unauthenticated sessions', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('fresh registration has no unauthenticated sessions',
+      (t) async {
     await t.freshAccount();
     await t.navigateTo([
       MainNavKeys.activities,
@@ -75,19 +70,16 @@ void authTests() {
     find.byKey(ActivitiesPage.oneUnverifiedSessionsCard).should(findsNothing);
     find.byKey(ActivitiesPage.unverifiedSessionsCard).should(findsNothing);
   });
-  tTestWidgets('ensure unicode registration works', (t) async {
-    disableOverflowErrors();
-    final testName = "Dwayne 'the 🪨' Johnson";
+  acterTestWidget('ensure unicode registration works', (t) async {
+    const testName = "Dwayne 'the 🪨' Johnson";
     await t.freshAccount(displayName: testName);
     await t.navigateTo([
       MainNavKeys.quickJump,
       QuickJumpKeys.profile,
     ]);
 
-    // items _not_ present!
     final displayName = find.byKey(MyProfile.displayNameKey);
-    displayName.should(findsOneWidget);
-    final text = displayName.evaluate().single.widget as Text;
-    assert(text.data == testName, "${text.data} isn't the expected $testName");
+    await displayName.should(findsOneWidget);
+    await find.text(testName).should(findsOneWidget);
   });
 }

--- a/app/integration_test/tests/auth.dart
+++ b/app/integration_test/tests/auth.dart
@@ -1,10 +1,14 @@
+import 'dart:ui';
+
 import 'package:acter/common/dialogs/deactivation_confirmation.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/features/activities/pages/activities_page.dart';
 import 'package:acter/features/home/data/keys.dart';
+import 'package:acter/features/profile/pages/my_profile_page.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../support/login.dart';
 import '../support/setup.dart';
@@ -70,5 +74,20 @@ void authTests() {
     // items _not_ present!
     find.byKey(ActivitiesPage.oneUnverifiedSessionsCard).should(findsNothing);
     find.byKey(ActivitiesPage.unverifiedSessionsCard).should(findsNothing);
+  });
+  tTestWidgets('ensure unicode registration works', (t) async {
+    disableOverflowErrors();
+    final testName = "Dwayne 'the 🪨' Johnson";
+    await t.freshAccount(displayName: testName);
+    await t.navigateTo([
+      MainNavKeys.quickJump,
+      QuickJumpKeys.profile,
+    ]);
+
+    // items _not_ present!
+    final displayName = find.byKey(MyProfile.displayNameKey);
+    displayName.should(findsOneWidget);
+    final text = displayName.evaluate().single.widget as Text;
+    assert(text.data == testName, "${text.data} isn't the expected $testName");
   });
 }

--- a/app/integration_test/tests/super_invites.dart
+++ b/app/integration_test/tests/super_invites.dart
@@ -93,8 +93,7 @@ extension SuperInvites on ConvenientTest {
 }
 
 void superInvitesTests() {
-  tTestWidgets('Full user flow with registration', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('Full user flow with registration', (t) async {
     final spaceId = await t.freshAccountWithSpace(userDisplayName: 'Alice');
     final token = await t.createSuperInvite([spaceId]);
 
@@ -107,8 +106,7 @@ void superInvitesTests() {
     await t.ensureIsMemberOfSpace(spaceId);
   });
 
-  tTestWidgets('Full user flow redeeming after registration', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('Full user flow redeeming after registration', (t) async {
     final spaceId = await t.freshAccountWithSpace(userDisplayName: 'Alice');
     final token = await t.createSuperInvite([spaceId]);
 
@@ -123,9 +121,8 @@ void superInvitesTests() {
     await t.ensureHasChats(counter: 0);
   });
 
-  tTestWidgets('Full user flow with registration many spaces and chats',
+  acterTestWidget('Full user flow with registration many spaces and chats',
       (t) async {
-    disableOverflowErrors();
     final spaceId = await t.freshAccountWithSpace(userDisplayName: 'Alice');
     final chats = await t.createSpaceChats(spaceId, ['Random', 'General']);
     final spaceId2 = await t.createSpace('Second test space');
@@ -145,8 +142,7 @@ void superInvitesTests() {
     await t.ensureHasChats(ids: chats);
   });
 
-  tTestWidgets('Token with DM', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('Token with DM', (t) async {
     final spaceId = await t.freshAccountWithSpace(userDisplayName: 'Alice');
     final token = await t.createSuperInvite(
       [spaceId],
@@ -168,8 +164,7 @@ void superInvitesTests() {
     await t.ensureHasChats(counter: 1);
   });
 
-  tTestWidgets('Edit and redeem', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('Edit and redeem', (t) async {
     final spaceId = await t.freshAccountWithSpace(userDisplayName: 'Alice');
     final spaceId2 = await t.createSpace('Second test space');
 
@@ -208,8 +203,7 @@ void superInvitesTests() {
     await t.ensureIsMemberOfSpace(spaceId2);
   });
 
-  tTestWidgets("Deleted can't be reused", (t) async {
-    disableOverflowErrors();
+  acterTestWidget("Deleted can't be reused", (t) async {
     await t.freshAccount(displayName: 'Alice');
 
     final token = await t.createSuperInvite([]);

--- a/app/integration_test/tests/updates.dart
+++ b/app/integration_test/tests/updates.dart
@@ -31,8 +31,7 @@ extension ActerNews on ConvenientTest {
 }
 
 void updateTests() {
-  tTestWidgets('Simple Text Update', (t) async {
-    disableOverflowErrors();
+  acterTestWidget('Simple Text Update', (t) async {
     final spaceId = await t.freshAccountWithSpace();
     await t.createTextNews(spaceId, 'Welcome to the show');
 

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -19,6 +19,10 @@ import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:riverpod_infinite_scroll/riverpod_infinite_scroll.dart';
 
 class ActivitiesPage extends ConsumerWidget {
+  static const Key oneUnverifiedSessionsCard =
+      Key('activities-one-unverified-session');
+  static const Key unverifiedSessionsCard =
+      Key('activities-unverified-sessions');
   const ActivitiesPage({super.key});
 
   @override
@@ -35,13 +39,17 @@ class ActivitiesPage extends ConsumerWidget {
         if (sessions.length == 1) {
           children.add(
             SliverToBoxAdapter(
-              child: SessionCard(deviceRecord: sessions[0]),
+              child: SessionCard(
+                key: oneUnverifiedSessionsCard,
+                deviceRecord: sessions[0],
+              ),
             ),
           );
         } else if (sessions.length > 1) {
           children.add(
             SliverToBoxAdapter(
               child: Card(
+                key: unverifiedSessionsCard,
                 child: ListTile(
                   leading: const Icon(Atlas.warning_bold),
                   title: Text(

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -30,7 +30,7 @@ class ActivitiesPage extends ConsumerWidget {
     final size = MediaQuery.of(context).size;
     // ignore: unused_local_variable
     final allDone = ref.watch(hasActivitiesProvider) == HasActivities.none;
-    final allSessions = ref.watch(allSessionsProvider);
+    final allSessions = ref.watch(unknownSessionsProvider);
     final invitations = ref.watch(invitationListProvider);
     final children = [];
     allSessions.when(

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -3,10 +3,7 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_page_header.dart';
 import 'package:acter/features/activities/providers/activities_providers.dart';
 import 'package:acter/features/activities/providers/invitations_providers.dart';
-import 'package:acter/features/activities/providers/notifications_providers.dart';
-import 'package:acter/features/activities/providers/notifiers/notifications_list_notifier.dart';
 import 'package:acter/features/activities/widgets/invitation_card.dart';
-import 'package:acter/features/activities/widgets/notification_card.dart';
 import 'package:acter/features/settings/providers/session_providers.dart';
 import 'package:acter/features/settings/widgets/session_card.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -14,9 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
-import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:riverpod_infinite_scroll/riverpod_infinite_scroll.dart';
 
 class ActivitiesPage extends ConsumerWidget {
   static const Key oneUnverifiedSessionsCard =
@@ -115,7 +109,26 @@ class ActivitiesPage extends ConsumerWidget {
         ),
       );
     }
-    final weAreEmpty = children.isEmpty;
+    if (children.isEmpty) {
+      children.add(
+        SliverToBoxAdapter(
+          child: Center(
+            child: Column(
+              children: [
+                SizedBox(
+                  // nothing found, even in the section before. Show nice fallback
+                  height: 250,
+                  child: SvgPicture.asset(
+                    'assets/images/undraw_project_completed_re_jr7u.svg',
+                  ),
+                ),
+                const Text('All caught up!'),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.neutral,
@@ -135,28 +148,6 @@ class ActivitiesPage extends ConsumerWidget {
                   ),
           ),
           ...children,
-          RiverPagedBuilder<Next?, ffi.Notification>.autoDispose(
-            firstPageKey: const Next(isStart: true),
-            provider: notificationsListProvider,
-            itemBuilder: (ctx, item, index) => NotificationCard(
-              notification: item,
-            ),
-            noItemsFoundIndicatorBuilder: (ctx, controller) => weAreEmpty
-                ? SizedBox(
-                    // nothing found, even in the section before. Show nice fallback
-                    height: 250,
-                    child: Center(
-                      child: SvgPicture.asset(
-                        'assets/images/undraw_project_completed_re_jr7u.svg',
-                      ),
-                    ),
-                  )
-                : const Text(''),
-            pagedBuilder: (controller, builder) => PagedSliverList(
-              pagingController: controller,
-              builderDelegate: builder,
-            ),
-          ),
         ],
       ),
     );

--- a/app/lib/features/cross_signing/cross_signing.dart
+++ b/app/lib/features/cross_signing/cross_signing.dart
@@ -63,7 +63,7 @@ class CrossSigning {
 
   void _installDeviceEvent() {
     _deviceNewPoller = client.deviceNewEventRx()?.listen((event) async {
-      final records = await event.deviceRecords(false);
+      final records = await client.deviceRecords(false);
       final myDevId = client.deviceId();
       var newDevFound = false;
       for (var record in records) {

--- a/app/lib/features/home/data/keys.dart
+++ b/app/lib/features/home/data/keys.dart
@@ -4,6 +4,7 @@ class MainNavKeys {
   static const dashboardHome = Key('main-nav-dashboard-home');
   static const chats = Key('main-nav-chats');
   static const quickJump = Key('main-nav-quick-jump');
+  static const activities = Key('main-nav-activities');
 }
 
 class DashboardKeys {

--- a/app/lib/features/home/providers/navigation.dart
+++ b/app/lib/features/home/providers/navigation.dart
@@ -80,7 +80,10 @@ final spaceItemsProvider = FutureProvider.autoDispose
 final activitiesIconProvider = Provider.family<Widget, BuildContext>(
   (ref, context) {
     final activites = ref.watch(hasActivitiesProvider);
-    const baseIcon = Icon(Atlas.audio_wave_thin);
+    const baseIcon = Icon(
+      Atlas.audio_wave_thin,
+      key: MainNavKeys.activities,
+    );
     switch (activites) {
       case HasActivities.important:
         return Badge(

--- a/app/lib/features/onboarding/pages/register_page.dart
+++ b/app/lib/features/onboarding/pages/register_page.dart
@@ -157,11 +157,6 @@ class _RegisterPageState extends ConsumerState<RegisterPage> {
                                   borderRadius: BorderRadius.circular(12),
                                 ),
                               ),
-                              inputFormatters: [
-                                FilteringTextInputFormatter.deny(
-                                  RegExp(r'\s'),
-                                ),
-                              ],
                               style: Theme.of(context).textTheme.labelLarge,
                               cursorColor:
                                   Theme.of(context).colorScheme.tertiary2,

--- a/app/lib/features/profile/model/keys.dart
+++ b/app/lib/features/profile/model/keys.dart
@@ -1,5 +1,0 @@
-import 'package:flutter/material.dart';
-
-class MyProfileKeys {
-  static const logout = Key('my-profile-logout');
-}

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -4,7 +4,6 @@ import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_dialog.dart';
-import 'package:acter/features/profile/model/keys.dart';
 import 'package:acter/features/profile/widgets/profile_item_tile.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -79,6 +78,8 @@ class _ChangeDisplayNameState extends State<ChangeDisplayName> {
 }
 
 class MyProfile extends ConsumerWidget {
+  static const logoutKey = Key('my-profile-logout');
+  static const displayNameKey = Key('my-profile-display-name');
   const MyProfile({super.key});
 
   Future<void> updateDisplayName(
@@ -204,6 +205,7 @@ class MyProfile extends ConsumerWidget {
                                 constraints:
                                     BoxConstraints(maxWidth: size.width * 0.8),
                                 child: Text(
+                                  key: displayNameKey,
                                   data.profile.displayName ?? '',
                                   overflow: TextOverflow.ellipsis,
                                 ),
@@ -333,7 +335,7 @@ class MyProfile extends ConsumerWidget {
                         child: Column(
                           children: [
                             ProfileItemTile(
-                              gestureKey: MyProfileKeys.logout,
+                              gestureKey: logoutKey,
                               icon: Atlas.exit,
                               title: 'Logout',
                               onPressed: () =>

--- a/app/lib/features/settings/pages/sessions_page.dart
+++ b/app/lib/features/settings/pages/sessions_page.dart
@@ -12,7 +12,7 @@ class SessionsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final allSessions = ref.watch(allSessionsProvider);
+    final allSessions = ref.watch(unknownSessionsProvider);
     return WithSidebar(
       sidebar: const SettingsMenu(),
       child: Scaffold(

--- a/app/lib/features/settings/providers/session_providers.dart
+++ b/app/lib/features/settings/providers/session_providers.dart
@@ -9,9 +9,21 @@ final allSessionsProvider = FutureProvider<List<DeviceRecord>>(
       throw 'Client is not logged in';
     }
     final manager = client.sessionManager();
-    final sessions = (await manager.allSessions()).toList();
+    return (await manager.allSessions()).toList();
+  },
+);
+
+final unknownSessionsProvider = FutureProvider<List<DeviceRecord>>(
+  (ref) async {
+    final client = ref.watch(clientProvider);
+    if (client == null) {
+      throw 'Client is not logged in';
+    }
+    final sessions = await ref.watch(allSessionsProvider.future);
     return sessions
-        .where((sess) => sess.deviceId() != client.deviceId()) // exclude me
+        .where(
+          (session) => !session.isMe(),
+        ) // exclude me
         .toList();
   },
 );

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -11067,6 +11067,54 @@ class Api {
     return tmp7;
   }
 
+  FfiListDeviceRecord? __clientDeviceRecordsFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _clientDeviceRecordsFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListDeviceRecord");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp14 = FfiListDeviceRecord._(this, tmp13_1);
+    final tmp7 = tmp14;
+    return tmp7;
+  }
+
   String? __invitationRoomNameFuturePoll(
     int boxed,
     int postCobject,
@@ -12076,54 +12124,6 @@ class Api {
     return tmp7;
   }
 
-  FfiListDeviceRecord? __deviceNewEventDeviceRecordsFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _deviceNewEventDeviceRecordsFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListDeviceRecord");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp14 = FfiListDeviceRecord._(this, tmp13_1);
-    final tmp7 = tmp14;
-    return tmp7;
-  }
-
   bool? __deviceNewEventRequestVerificationToUserFuturePoll(
     int boxed,
     int postCobject,
@@ -12298,54 +12298,6 @@ class Api {
       throw tmp9_0;
     }
     final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
-  FfiListDeviceRecord? __deviceChangedEventDeviceRecordsFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _deviceChangedEventDeviceRecordsFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_FfiListDeviceRecord");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp14 = FfiListDeviceRecord._(this, tmp13_1);
-    final tmp7 = tmp14;
     return tmp7;
   }
 
@@ -22831,6 +22783,18 @@ class Api {
       int Function(
         int,
       )>();
+  late final _clientDeviceRecordsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Uint8,
+          )>>("__Client_device_records");
+
+  late final _clientDeviceRecords = _clientDeviceRecordsPtr.asFunction<
+      int Function(
+        int,
+        int,
+      )>();
   late final _invitationOriginServerTsPtr = _lookup<
       ffi.NativeFunction<
           _InvitationOriginServerTsReturn Function(
@@ -23353,19 +23317,6 @@ class Api {
       int Function(
         int,
       )>();
-  late final _deviceNewEventDeviceRecordsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-            ffi.Uint8,
-          )>>("__DeviceNewEvent_device_records");
-
-  late final _deviceNewEventDeviceRecords =
-      _deviceNewEventDeviceRecordsPtr.asFunction<
-          int Function(
-            int,
-            int,
-          )>();
   late final _deviceNewEventRequestVerificationToUserPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -23437,19 +23388,6 @@ class Api {
           int Function(
             int,
           )>();
-  late final _deviceChangedEventDeviceRecordsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-            ffi.Uint8,
-          )>>("__DeviceChangedEvent_device_records");
-
-  late final _deviceChangedEventDeviceRecords =
-      _deviceChangedEventDeviceRecordsPtr.asFunction<
-          int Function(
-            int,
-            int,
-          )>();
   late final _deviceRecordDeviceIdPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -23507,6 +23445,16 @@ class Api {
           )>>("__DeviceRecord_is_active");
 
   late final _deviceRecordIsActive = _deviceRecordIsActivePtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _deviceRecordIsMePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.Int64,
+          )>>("__DeviceRecord_is_me");
+
+  late final _deviceRecordIsMe = _deviceRecordIsMePtr.asFunction<
       int Function(
         int,
       )>();
@@ -26631,6 +26579,21 @@ class Api {
             int,
             int,
           )>();
+  late final _clientDeviceRecordsFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ClientDeviceRecordsFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Client_device_records_future_poll");
+
+  late final _clientDeviceRecordsFuturePoll =
+      _clientDeviceRecordsFuturePollPtr.asFunction<
+          _ClientDeviceRecordsFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _invitationRoomNameFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _InvitationRoomNameFuturePollReturn Function(
@@ -26966,21 +26929,6 @@ class Api {
             int,
             int,
           )>();
-  late final _deviceNewEventDeviceRecordsFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _DeviceNewEventDeviceRecordsFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__DeviceNewEvent_device_records_future_poll");
-
-  late final _deviceNewEventDeviceRecordsFuturePoll =
-      _deviceNewEventDeviceRecordsFuturePollPtr.asFunction<
-          _DeviceNewEventDeviceRecordsFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
   late final _deviceNewEventRequestVerificationToUserFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _DeviceNewEventRequestVerificationToUserFuturePollReturn Function(
@@ -27051,21 +26999,6 @@ class Api {
                 int,
                 int,
               )>();
-  late final _deviceChangedEventDeviceRecordsFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _DeviceChangedEventDeviceRecordsFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__DeviceChangedEvent_device_records_future_poll");
-
-  late final _deviceChangedEventDeviceRecordsFuturePoll =
-      _deviceChangedEventDeviceRecordsFuturePollPtr.asFunction<
-          _DeviceChangedEventDeviceRecordsFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
   late final _acterPinSubscribeStreamStreamPollPtr = _lookup<
       ffi.NativeFunction<
           _ActerPinSubscribeStreamStreamPollReturn Function(
@@ -48714,6 +48647,27 @@ class Client {
     return tmp2;
   }
 
+  /// the list of devices
+  Future<FfiListDeviceRecord> deviceRecords(
+    bool verified,
+  ) {
+    final tmp1 = verified;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    final tmp3 = _api._clientDeviceRecords(
+      tmp0,
+      tmp2,
+    );
+    final tmp5 = tmp3;
+    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
+    final tmp5_1 = _Box(_api, tmp5_0, "__Client_device_records_future_drop");
+    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
+    final tmp4 = _nativeFuture(tmp5_1, _api.__clientDeviceRecordsFuturePoll);
+    return tmp4;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -49738,29 +49692,6 @@ class DeviceNewEvent {
     return tmp2;
   }
 
-  /// Get the device list, excluding verified ones
-  Future<FfiListDeviceRecord> deviceRecords(
-    bool verified,
-  ) {
-    final tmp1 = verified;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    tmp0 = _box.borrow();
-    tmp2 = tmp1 ? 1 : 0;
-    final tmp3 = _api._deviceNewEventDeviceRecords(
-      tmp0,
-      tmp2,
-    );
-    final tmp5 = tmp3;
-    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
-    final tmp5_1 =
-        _Box(_api, tmp5_0, "__DeviceNewEvent_device_records_future_drop");
-    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
-    final tmp4 =
-        _nativeFuture(tmp5_1, _api.__deviceNewEventDeviceRecordsFuturePoll);
-    return tmp4;
-  }
-
   /// Request verification to any devices of user
   Future<bool> requestVerificationToUser() {
     var tmp0 = 0;
@@ -49902,29 +49833,6 @@ class DeviceChangedEvent {
     return tmp2;
   }
 
-  /// Get the device list, including deleted ones
-  Future<FfiListDeviceRecord> deviceRecords(
-    bool deleted,
-  ) {
-    final tmp1 = deleted;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    tmp0 = _box.borrow();
-    tmp2 = tmp1 ? 1 : 0;
-    final tmp3 = _api._deviceChangedEventDeviceRecords(
-      tmp0,
-      tmp2,
-    );
-    final tmp5 = tmp3;
-    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
-    final tmp5_1 =
-        _Box(_api, tmp5_0, "__DeviceChangedEvent_device_records_future_drop");
-    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
-    final tmp4 =
-        _nativeFuture(tmp5_1, _api.__deviceChangedEventDeviceRecordsFuturePoll);
-    return tmp4;
-  }
-
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -50054,6 +49962,18 @@ class DeviceRecord {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._deviceRecordIsActive(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// whether it is this session
+  bool isMe() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._deviceRecordIsMe(
       tmp0,
     );
     final tmp3 = tmp1;
@@ -55857,6 +55777,21 @@ class _ClientMyPastEventsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ClientDeviceRecordsFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+}
+
 class _InvitationRoomNameFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -56200,21 +56135,6 @@ class _SessionManagerRequestVerificationFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _DeviceNewEventDeviceRecordsFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Int64()
-  external int arg5;
-}
-
 class _DeviceNewEventRequestVerificationToUserFuturePollReturn
     extends ffi.Struct {
   @ffi.Uint8()
@@ -56276,21 +56196,6 @@ class _DeviceNewEventRequestVerificationToDeviceWithMethodsFuturePollReturn
   @ffi.Uint64()
   external int arg4;
   @ffi.Uint8()
-  external int arg5;
-}
-
-class _DeviceChangedEventDeviceRecordsFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Int64()
   external int arg5;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2390,6 +2390,9 @@ object Client {
     /// super invites interface
     fn super_invites() -> SuperInvites;
 
+    /// the list of devices
+    fn device_records(verified: bool) -> Future<Result<Vec<DeviceRecord>>>;
+
 }
 
 
@@ -2591,9 +2594,6 @@ object DeviceNewEvent {
     /// get device id
     fn device_id() -> DeviceId;
 
-    /// Get the device list, excluding verified ones
-    fn device_records(verified: bool) -> Future<Result<Vec<DeviceRecord>>>;
-
     /// Request verification to any devices of user
     fn request_verification_to_user() -> Future<Result<bool>>;
 
@@ -2612,8 +2612,6 @@ object DeviceChangedEvent {
     /// get device id
     fn device_id() -> DeviceId;
 
-    /// Get the device list, including deleted ones
-    fn device_records(deleted: bool) -> Future<Result<Vec<DeviceRecord>>>;
 }
 
 /// Provide various device infos
@@ -2635,4 +2633,6 @@ object DeviceRecord {
 
     /// whether it is active
     fn is_active() -> bool;
+    /// whether it is this session
+    fn is_me() -> bool;
 }

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -313,8 +313,16 @@ pub async fn register_under_config(
                 "Successfully registered user {user_id}, device {:?}",
                 client.device_id(),
             );
-
-            login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
+            if (client.logged_in()) {
+                let state = ClientStateBuilder::default()
+                    .is_guest(false)
+                    .db_passphrase(db_passphrase)
+                    .build()?;
+                Client::new(client, state).await
+            } else {
+                // we didn't receive the login details yet, do a full login attempt
+                login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
+            }
         })
         .await?
 }
@@ -359,36 +367,46 @@ pub async fn register_with_token_under_config(
     // First we need to log in.
     RUNTIME
         .spawn(async move {
-            let client = {
-                let client = config.build().await?;
-                let request = assign!(register::v3::Request::new(), {
-                    username: Some(user_id.localpart().to_owned()),
-                    password: Some(password.clone()),
-                    initial_device_display_name: Some(user_agent.clone()),
-                    auth: Some(AuthData::Dummy(Dummy::new())),
-                });
+            let client = config.build().await?;
+            let request = assign!(register::v3::Request::new(), {
+                username: Some(user_id.localpart().to_owned()),
+                password: Some(password.clone()),
+                initial_device_display_name: Some(user_agent.clone()),
+                auth: Some(AuthData::Dummy(Dummy::new())),
+            });
 
-                if let Err(err) = client.matrix_auth().register(request).await {
-                    let Some(response) = err.as_uiaa_response() else {
+            if let Err(err) = client.matrix_auth().register(request).await {
+                let Some(response) = err.as_uiaa_response() else {
                         bail!("Server did not indicate how to allow registration.");
                     };
 
-                    info!("Acceptable auth flows: {response:?}");
+                info!("Acceptable auth flows: {response:?}");
 
-                    // FIXME: do actually check the registration types...
-                    let token_request = assign!(register::v3::Request::new(), {
-                        auth: Some(AuthData::RegistrationToken(
-                            assign!(RegistrationToken::new(registration_token), {
-                                session: response.session.clone(),
-                            }),
-                        )),
-                    });
-                    client.matrix_auth().register(token_request).await?;
-                } // else all went well.
-                client
-            };
+                // FIXME: do actually check the registration types...
+                let token_request = assign!(register::v3::Request::new(), {
+                    auth: Some(AuthData::RegistrationToken(
+                        assign!(RegistrationToken::new(registration_token), {
+                            session: response.session.clone(),
+                        }),
+                    )),
+                });
+                client.matrix_auth().register(token_request).await?;
+            } // else all went well.
 
-            login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
+            info!(
+                "Successfully registered user {user_id}, device {:?}",
+                client.device_id(),
+            );
+            if (client.logged_in()) {
+                let state = ClientStateBuilder::default()
+                    .is_guest(false)
+                    .db_passphrase(db_passphrase)
+                    .build()?;
+                Client::new(client, state).await
+            } else {
+                // we didn't receive the login details yet, do a full login attempt
+                login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
+            }
         })
         .await?
 }

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -403,6 +403,7 @@ pub struct DeviceRecord {
     last_seen_ip: Option<String>,
     is_verified: bool,
     is_active: bool,
+    is_me: bool,
 }
 
 impl DeviceRecord {
@@ -413,6 +414,7 @@ impl DeviceRecord {
         last_seen_ip: Option<String>,
         is_verified: bool,
         is_active: bool,
+        is_me: bool,
     ) -> Self {
         DeviceRecord {
             device_id,
@@ -421,6 +423,7 @@ impl DeviceRecord {
             last_seen_ip,
             is_verified,
             is_active,
+            is_me,
         }
     }
 
@@ -442,6 +445,10 @@ impl DeviceRecord {
 
     pub fn is_verified(&self) -> bool {
         self.is_verified
+    }
+
+    pub fn is_me(&self) -> bool {
+        self.is_me
     }
 
     pub fn is_active(&self) -> bool {

--- a/native/acter/src/api/device.rs
+++ b/native/acter/src/api/device.rs
@@ -36,66 +36,6 @@ impl DeviceNewEvent {
     pub fn device_id(&self) -> OwnedDeviceId {
         self.device_id.clone()
     }
-
-    pub async fn device_records(&self, verified: bool) -> Result<Vec<DeviceRecord>> {
-        let client = self.client.clone();
-        RUNTIME
-            .spawn(async move {
-                let user_id = client
-                    .user_id()
-                    .context("guest user cannot get the verified devices")?;
-                let response = client.devices().await?;
-                let crypto_devices = client
-                    .encryption()
-                    .get_user_devices(user_id)
-                    .await
-                    .context("Couldn't get crypto devices")?;
-                let mut sessions = vec![];
-                for device in response.devices {
-                    let is_verified = crypto_devices.get(&device.device_id).is_some_and(|d| {
-                        d.is_cross_signed_by_owner() || d.is_verified_with_cross_signing()
-                    });
-                    let mut is_active = false;
-                    if let Some(last_seen_ts) = device.last_seen_ts {
-                        let limit = SystemTime::now()
-                            .checked_sub(Duration::from_secs(90 * 24 * 60 * 60))
-                            .context("Couldn't get time of 90 days ago")?
-                            .duration_since(UNIX_EPOCH)
-                            .context("Couldn't calculate duration from Unix epoch")?;
-                        let secs: u64 = last_seen_ts.as_secs().into();
-                        if secs < limit.as_secs() {
-                            is_active = true;
-                        }
-                    }
-                    if is_verified == verified {
-                        let found = crypto_devices
-                            .get(&device.device_id)
-                            .is_some_and(|d| d.device_id() == device.device_id);
-                        if found {
-                            sessions.push(DeviceRecord::new(
-                                device.device_id.clone(),
-                                device.display_name.clone(),
-                                device.last_seen_ts,
-                                device.last_seen_ip.clone(),
-                                is_verified,
-                                is_active,
-                            ));
-                        } else {
-                            sessions.push(DeviceRecord::new(
-                                device.device_id.clone(),
-                                device.display_name.clone(),
-                                None,
-                                None,
-                                is_verified,
-                                is_active,
-                            ));
-                        }
-                    }
-                }
-                Ok(sessions)
-            })
-            .await?
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -114,69 +54,6 @@ impl DeviceChangedEvent {
 
     pub fn device_id(&self) -> OwnedDeviceId {
         self.device_id.clone()
-    }
-
-    pub async fn device_records(&self, deleted: bool) -> Result<Vec<DeviceRecord>> {
-        let client = self.client.clone();
-        RUNTIME
-            .spawn(async move {
-                let user_id = client
-                    .user_id()
-                    .context("guest user cannot get the deleted devices")?;
-                let response = client.devices().await?;
-                let crypto_devices = client
-                    .encryption()
-                    .get_user_devices(user_id)
-                    .await
-                    .context("Couldn't get crypto devices")?;
-                let mut sessions = vec![];
-                for device in response.devices {
-                    let is_verified = crypto_devices.get(&device.device_id).is_some_and(|d| {
-                        d.is_cross_signed_by_owner() || d.is_verified_with_cross_signing()
-                    });
-                    let mut is_active = false;
-                    if let Some(last_seen_ts) = device.last_seen_ts {
-                        let limit = SystemTime::now()
-                            .checked_sub(Duration::from_secs(90 * 24 * 60 * 60))
-                            .context("Couldn't get time of 90 days ago")?
-                            .duration_since(UNIX_EPOCH)
-                            .context("Couldn't calculate duration from Unix epoch")?;
-                        let secs: u64 = last_seen_ts.as_secs().into();
-                        if secs < limit.as_secs() {
-                            is_active = true;
-                        }
-                    }
-                    let is_deleted = crypto_devices
-                        .get(&device.device_id)
-                        .is_some_and(|d| d.is_deleted());
-                    if is_deleted == deleted {
-                        let found = crypto_devices
-                            .get(&device.device_id)
-                            .is_some_and(|d| d.device_id() == device.device_id);
-                        if found {
-                            sessions.push(DeviceRecord::new(
-                                device.device_id.clone(),
-                                device.display_name.clone(),
-                                device.last_seen_ts,
-                                device.last_seen_ip.clone(),
-                                is_verified,
-                                is_active,
-                            ));
-                        } else {
-                            sessions.push(DeviceRecord::new(
-                                device.device_id.clone(),
-                                device.display_name.clone(),
-                                None,
-                                None,
-                                is_verified,
-                                is_active,
-                            ));
-                        }
-                    }
-                }
-                Ok(sessions)
-            })
-            .await?
     }
 }
 
@@ -200,7 +77,7 @@ impl DeviceController {
                 .expect("We have to get devices stream");
             let my_id = client
                 .user_id()
-                .expect("We should know our user id afte we have logged in");
+                .expect("We should know our user id after we have logged in");
             pin_mut!(devices_stream);
 
             while let Some(device_updates) = devices_stream.next().await {
@@ -251,5 +128,70 @@ impl Client {
             Ok(mut r) => r.take(),
             Err(e) => None,
         }
+    }
+
+    pub async fn device_records(&self, verified: bool) -> Result<Vec<DeviceRecord>> {
+        let client = self.clone();
+        RUNTIME
+            .spawn(async move {
+                let user_id = client
+                    .user_id()
+                    .context("guest user cannot get the verified devices")?;
+                let this_device_id = client
+                    .device_id()
+                    .context("logged in user must have a device")?;
+                let response = client.devices().await?;
+                let crypto_devices = client
+                    .encryption()
+                    .get_user_devices(&user_id)
+                    .await
+                    .context("Couldn't get crypto devices")?;
+                let mut sessions = vec![];
+                for device in response.devices {
+                    let is_verified = crypto_devices.get(&device.device_id).is_some_and(|d| {
+                        d.is_cross_signed_by_owner() || d.is_verified_with_cross_signing()
+                    });
+                    let mut is_active = false;
+                    if let Some(last_seen_ts) = device.last_seen_ts {
+                        let limit = SystemTime::now()
+                            .checked_sub(Duration::from_secs(90 * 24 * 60 * 60))
+                            .context("Couldn't get time of 90 days ago")?
+                            .duration_since(UNIX_EPOCH)
+                            .context("Couldn't calculate duration from Unix epoch")?;
+                        let secs: u64 = last_seen_ts.as_secs().into();
+                        if secs < limit.as_secs() {
+                            is_active = true;
+                        }
+                    }
+                    if is_verified == verified {
+                        let found = crypto_devices
+                            .get(&device.device_id)
+                            .is_some_and(|d| d.device_id() == device.device_id);
+                        if found {
+                            sessions.push(DeviceRecord::new(
+                                device.device_id.clone(),
+                                device.display_name.clone(),
+                                device.last_seen_ts,
+                                device.last_seen_ip.clone(),
+                                is_verified,
+                                is_active,
+                                device.device_id == this_device_id,
+                            ));
+                        } else {
+                            sessions.push(DeviceRecord::new(
+                                device.device_id.clone(),
+                                device.display_name.clone(),
+                                None,
+                                None,
+                                is_verified,
+                                is_active,
+                                device.device_id == this_device_id,
+                            ));
+                        }
+                    }
+                }
+                Ok(sessions)
+            })
+            .await?
     }
 }

--- a/native/acter/src/api/verification.rs
+++ b/native/acter/src/api/verification.rs
@@ -1180,6 +1180,7 @@ impl SessionManager {
         RUNTIME
             .spawn(async move {
                 let user_id = client.user_id().context("User not found")?;
+                let device_id = client.device_id().context("Client had no device. Wat?!?")?;
                 let response = client.devices().await?;
                 let crypto_devices = client
                     .encryption()
@@ -1210,6 +1211,7 @@ impl SessionManager {
                         device.last_seen_ip.clone(),
                         is_verified,
                         is_active,
+                        device.device_id == device_id,
                     ));
                 }
                 info!("all sessions: {:?}", sessions);

--- a/native/test/src/tests/verification.rs
+++ b/native/test/src/tests/verification.rs
@@ -85,7 +85,7 @@ async fn interactive_verification_started_from_request() -> Result<()> {
     // Alice gets notified that new device (Bob) was logged in
     loop {
         if let Ok(Some(event)) = alice_device_new_rx.try_next() {
-            if let Ok(_devices) = event.device_records(false).await {
+            if let Ok(_devices) = alice.device_records(false).await {
                 // Alice sends a verification request with her desired methods to Bob
                 event
                     .request_verification_to_device_with_methods(


### PR DESCRIPTION
Potentially best reviewed changeset by changeset.

- fixes #938 : turns out that registrating-then-login-pattern creates two sessions for us upon startup. Unfortunately, that is caused by a [matrix-sdk bug](https://github.com/matrix-org/matrix-rust-sdk/pull/2888) but by switching to our own fork, we can avoid that for now. Dropping the number of sessions to 1. However, that still means an "unverified" devices case shows up in the activities stream, so in a second part, we also need to remove our own device from the list of unknown devices.
  This comes with an integration regression tests ensuring that no unverified devices are found upon simple registration (actually, it was even built in test-driven fashion: first made the test, then figured out the fix).
- This, too, fixes a bug reported just earlier today: for reasons unknown we were disallowing spaces in the display name upon registration. This, too, comes with an integration regression test ensuring the display name is taken over properly.
- Lastly, this removes the notification listing from the activities screen, as it served no purpose nor value. Fixes #1180 .