### PR TITLE
Location attachment draft & deserialize_as & check permission on attachment

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -18027,7 +18027,7 @@ class Api {
           int Function(
             int,
           )>();
-  late final _attachmentsManagerImageAttachmentDraftPtr = _lookup<
+  late final _attachmentsManagerImageDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -18051,10 +18051,10 @@ class Api {
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
-          )>>("__AttachmentsManager_image_attachment_draft");
+          )>>("__AttachmentsManager_image_draft");
 
-  late final _attachmentsManagerImageAttachmentDraft =
-      _attachmentsManagerImageAttachmentDraftPtr.asFunction<
+  late final _attachmentsManagerImageDraft =
+      _attachmentsManagerImageDraftPtr.asFunction<
           int Function(
             int,
             int,
@@ -18078,7 +18078,7 @@ class Api {
             int,
             int,
           )>();
-  late final _attachmentsManagerAudioAttachmentDraftPtr = _lookup<
+  late final _attachmentsManagerAudioDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -18096,10 +18096,10 @@ class Api {
             ffi.Uint64,
             ffi.Uint8,
             ffi.Uint64,
-          )>>("__AttachmentsManager_audio_attachment_draft");
+          )>>("__AttachmentsManager_audio_draft");
 
-  late final _attachmentsManagerAudioAttachmentDraft =
-      _attachmentsManagerAudioAttachmentDraftPtr.asFunction<
+  late final _attachmentsManagerAudioDraft =
+      _attachmentsManagerAudioDraftPtr.asFunction<
           int Function(
             int,
             int,
@@ -18117,7 +18117,7 @@ class Api {
             int,
             int,
           )>();
-  late final _attachmentsManagerVideoAttachmentDraftPtr = _lookup<
+  late final _attachmentsManagerVideoDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -18143,10 +18143,10 @@ class Api {
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
-          )>>("__AttachmentsManager_video_attachment_draft");
+          )>>("__AttachmentsManager_video_draft");
 
-  late final _attachmentsManagerVideoAttachmentDraft =
-      _attachmentsManagerVideoAttachmentDraftPtr.asFunction<
+  late final _attachmentsManagerVideoDraft =
+      _attachmentsManagerVideoDraftPtr.asFunction<
           int Function(
             int,
             int,
@@ -18172,7 +18172,7 @@ class Api {
             int,
             int,
           )>();
-  late final _attachmentsManagerFileAttachmentDraftPtr = _lookup<
+  late final _attachmentsManagerFileDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -18188,10 +18188,10 @@ class Api {
             ffi.Uint64,
             ffi.Uint8,
             ffi.Uint64,
-          )>>("__AttachmentsManager_file_attachment_draft");
+          )>>("__AttachmentsManager_file_draft");
 
-  late final _attachmentsManagerFileAttachmentDraft =
-      _attachmentsManagerFileAttachmentDraftPtr.asFunction<
+  late final _attachmentsManagerFileDraft =
+      _attachmentsManagerFileDraftPtr.asFunction<
           int Function(
             int,
             int,
@@ -18207,7 +18207,7 @@ class Api {
             int,
             int,
           )>();
-  late final _attachmentsManagerLocationAttachmentDraftPtr = _lookup<
+  late final _attachmentsManagerLocationDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -18217,10 +18217,10 @@ class Api {
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
-          )>>("__AttachmentsManager_location_attachment_draft");
+          )>>("__AttachmentsManager_location_draft");
 
-  late final _attachmentsManagerLocationAttachmentDraft =
-      _attachmentsManagerLocationAttachmentDraftPtr.asFunction<
+  late final _attachmentsManagerLocationDraft =
+      _attachmentsManagerLocationDraftPtr.asFunction<
           int Function(
             int,
             int,
@@ -39468,7 +39468,7 @@ class AttachmentsManager {
   }
 
   /// create news slide for image msg
-  AttachmentDraft imageAttachmentDraft(
+  AttachmentDraft imageDraft(
     String body,
     String url,
     String? mimetype,
@@ -39571,7 +39571,7 @@ class AttachmentsManager {
       tmp30 = tmp30_0.address;
       tmp32 = tmp31;
     }
-    final tmp33 = _api._attachmentsManagerImageAttachmentDraft(
+    final tmp33 = _api._attachmentsManagerImageDraft(
       tmp0,
       tmp2,
       tmp3,
@@ -39603,7 +39603,7 @@ class AttachmentsManager {
   }
 
   /// create news slide for audio msg
-  AttachmentDraft audioAttachmentDraft(
+  AttachmentDraft audioDraft(
     String body,
     String url,
     String? mimetype,
@@ -39675,7 +39675,7 @@ class AttachmentsManager {
       final tmp21 = tmp19;
       tmp22 = tmp21;
     }
-    final tmp23 = _api._attachmentsManagerAudioAttachmentDraft(
+    final tmp23 = _api._attachmentsManagerAudioDraft(
       tmp0,
       tmp2,
       tmp3,
@@ -39701,7 +39701,7 @@ class AttachmentsManager {
   }
 
   /// create news slide for video msg
-  AttachmentDraft videoAttachmentDraft(
+  AttachmentDraft videoDraft(
     String body,
     String url,
     String? mimetype,
@@ -39815,7 +39815,7 @@ class AttachmentsManager {
       tmp34 = tmp34_0.address;
       tmp36 = tmp35;
     }
-    final tmp37 = _api._attachmentsManagerVideoAttachmentDraft(
+    final tmp37 = _api._attachmentsManagerVideoDraft(
       tmp0,
       tmp2,
       tmp3,
@@ -39849,7 +39849,7 @@ class AttachmentsManager {
   }
 
   /// create news slide for file msg
-  AttachmentDraft fileAttachmentDraft(
+  AttachmentDraft fileDraft(
     String body,
     String url,
     String? mimetype,
@@ -39910,7 +39910,7 @@ class AttachmentsManager {
       final tmp17 = tmp15;
       tmp18 = tmp17;
     }
-    final tmp19 = _api._attachmentsManagerFileAttachmentDraft(
+    final tmp19 = _api._attachmentsManagerFileDraft(
       tmp0,
       tmp2,
       tmp3,
@@ -39934,7 +39934,7 @@ class AttachmentsManager {
   }
 
   /// create news slide for location msg
-  AttachmentDraft locationAttachmentDraft(
+  AttachmentDraft locationDraft(
     String body,
     String geoUri,
   ) {
@@ -39964,7 +39964,7 @@ class AttachmentsManager {
     tmp6_1.setAll(0, tmp5_0);
     tmp6 = tmp6_0.address;
     tmp8 = tmp7;
-    final tmp9 = _api._attachmentsManagerLocationAttachmentDraft(
+    final tmp9 = _api._attachmentsManagerLocationDraft(
       tmp0,
       tmp2,
       tmp3,

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -18218,6 +18218,29 @@ class Api {
             int,
             int,
           )>();
+  late final _attachmentsManagerLocationAttachmentDraftPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__AttachmentsManager_location_attachment_draft");
+
+  late final _attachmentsManagerLocationAttachmentDraft =
+      _attachmentsManagerLocationAttachmentDraftPtr.asFunction<
+          int Function(
+            int,
+            int,
+            int,
+            int,
+            int,
+            int,
+            int,
+          )>();
   late final _taskTitlePtr = _lookup<
       ffi.NativeFunction<
           _TaskTitleReturn Function(
@@ -39934,6 +39957,54 @@ class AttachmentsManager {
     tmp21_1._finalizer = _api._registerFinalizer(tmp21_1);
     final tmp20 = AttachmentDraft._(_api, tmp21_1);
     return tmp20;
+  }
+
+  /// create news slide for location msg
+  AttachmentDraft locationAttachmentDraft(
+    String body,
+    String geoUri,
+  ) {
+    final tmp1 = body;
+    final tmp5 = geoUri;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp8 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5_0 = utf8.encode(tmp5);
+    tmp7 = tmp5_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp6_0 = _api.__allocate(tmp7 * 1, 1);
+    final Uint8List tmp6_1 = tmp6_0.asTypedList(tmp7);
+    tmp6_1.setAll(0, tmp5_0);
+    tmp6 = tmp6_0.address;
+    tmp8 = tmp7;
+    final tmp9 = _api._attachmentsManagerLocationAttachmentDraft(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+      tmp7,
+      tmp8,
+    );
+    final tmp11 = tmp9;
+    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+    final tmp11_1 = _Box(_api, tmp11_0, "drop_box_AttachmentDraft");
+    tmp11_1._finalizer = _api._registerFinalizer(tmp11_1);
+    final tmp10 = AttachmentDraft._(_api, tmp11_1);
+    return tmp10;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -18027,17 +18027,6 @@ class Api {
           int Function(
             int,
           )>();
-  late final _attachmentsManagerAttachmentDraftPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-          )>>("__AttachmentsManager_attachment_draft");
-
-  late final _attachmentsManagerAttachmentDraft =
-      _attachmentsManagerAttachmentDraftPtr.asFunction<
-          int Function(
-            int,
-          )>();
   late final _attachmentsManagerImageAttachmentDraftPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -39475,21 +39464,6 @@ class AttachmentsManager {
     );
     final tmp3 = tmp1;
     final tmp2 = tmp3;
-    return tmp2;
-  }
-
-  /// draft a new attachment for this item
-  AttachmentDraft attachmentDraft() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._attachmentsManagerAttachmentDraft(
-      tmp0,
-    );
-    final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_AttachmentDraft");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = AttachmentDraft._(_api, tmp3_1);
     return tmp2;
   }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1286,9 +1286,6 @@ object AttachmentsManager {
     /// How many attachments does this item have
     fn attachments_count() -> u32;
 
-    /// draft a new attachment for this item
-    fn attachment_draft() -> AttachmentDraft;
-
     /// create news slide for image msg
     fn image_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, width: Option<u64>, height: Option<u64>, blurhash: Option<string>) -> AttachmentDraft;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1287,19 +1287,19 @@ object AttachmentsManager {
     fn attachments_count() -> u32;
 
     /// create news slide for image msg
-    fn image_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, width: Option<u64>, height: Option<u64>, blurhash: Option<string>) -> AttachmentDraft;
+    fn image_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, width: Option<u64>, height: Option<u64>, blurhash: Option<string>) -> AttachmentDraft;
 
     /// create news slide for audio msg
-    fn audio_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, secs: Option<u64>) -> AttachmentDraft;
+    fn audio_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, secs: Option<u64>) -> AttachmentDraft;
 
     /// create news slide for video msg
-    fn video_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, secs: Option<u64>, width: Option<u64>, height: Option<u64>, blurhash: Option<string>) -> AttachmentDraft;
+    fn video_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>, secs: Option<u64>, width: Option<u64>, height: Option<u64>, blurhash: Option<string>) -> AttachmentDraft;
 
     /// create news slide for file msg
-    fn file_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>) -> AttachmentDraft;
+    fn file_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>) -> AttachmentDraft;
 
     /// create news slide for location msg
-    fn location_attachment_draft(body: string, geo_uri: string) -> AttachmentDraft;
+    fn location_draft(body: string, geo_uri: string) -> AttachmentDraft;
 }
 
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1300,6 +1300,9 @@ object AttachmentsManager {
 
     /// create news slide for file msg
     fn file_attachment_draft(body: string, url: string, mimetype: Option<string>, size: Option<u64>) -> AttachmentDraft;
+
+    /// create news slide for location msg
+    fn location_attachment_draft(body: string, geo_uri: string) -> AttachmentDraft;
 }
 
 

--- a/native/acter/src/api/account.rs
+++ b/native/acter/src/api/account.rs
@@ -5,7 +5,6 @@ use ruma_events::ignored_user_list::IgnoredUserListEventContent;
 use std::{ops::Deref, path::PathBuf, str::FromStr};
 
 use super::{
-    api::FfiBuffer,
     common::{OptionBuffer, OptionString},
     RUNTIME,
 };

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -248,7 +248,7 @@ impl AttachmentsManager {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn image_attachment_draft(
+    pub fn image_draft(
         &self,
         body: String,
         url: String,
@@ -278,7 +278,7 @@ impl AttachmentsManager {
         })
     }
 
-    pub fn audio_attachment_draft(
+    pub fn audio_draft(
         &self,
         body: String,
         url: String,
@@ -305,7 +305,7 @@ impl AttachmentsManager {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn video_attachment_draft(
+    pub fn video_draft(
         &self,
         body: String,
         url: String,
@@ -337,7 +337,7 @@ impl AttachmentsManager {
         })
     }
 
-    pub fn file_attachment_draft(
+    pub fn file_draft(
         &self,
         body: String,
         url: String,
@@ -357,11 +357,7 @@ impl AttachmentsManager {
         })
     }
 
-    pub fn location_attachment_draft(
-        &self,
-        body: String,
-        geo_uri: String,
-    ) -> Result<AttachmentDraft> {
+    pub fn location_draft(&self, body: String, geo_uri: String) -> Result<AttachmentDraft> {
         let mut builder = self.inner.draft_builder();
         let info = LocationInfo::new();
         let mut location_content = LocationMessageEventContent::new(body, geo_uri);

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -11,13 +11,16 @@ use matrix_sdk::{
     RoomState,
 };
 use ruma_common::{MxcUri, OwnedEventId, OwnedUserId};
-use ruma_events::room::{
-    message::{
-        AudioInfo, AudioMessageEventContent, FileInfo, FileMessageEventContent,
-        ImageMessageEventContent, LocationInfo, LocationMessageEventContent, VideoInfo,
-        VideoMessageEventContent,
+use ruma_events::{
+    room::{
+        message::{
+            AudioInfo, AudioMessageEventContent, FileInfo, FileMessageEventContent,
+            ImageMessageEventContent, LocationInfo, LocationMessageEventContent, VideoInfo,
+            VideoMessageEventContent,
+        },
+        ImageInfo,
     },
-    ImageInfo,
+    MessageLikeEventType,
 };
 use std::ops::Deref;
 use tokio::sync::broadcast::Receiver;
@@ -166,13 +169,32 @@ pub struct AttachmentDraft {
 }
 
 impl AttachmentDraft {
+    fn is_joined(&self) -> bool {
+        matches!(self.room.state(), RoomState::Joined)
+    }
+
     pub async fn send(&self) -> Result<OwnedEventId> {
+        if !self.is_joined() {
+            bail!("Can only attachment in joined rooms");
+        }
         let room = self.room.clone();
+        let my_id = room
+            .client()
+            .user_id()
+            .context("User not found")?
+            .to_owned();
         let inner = self.inner.build()?;
         RUNTIME
             .spawn(async move {
-                let resp = room.send(inner).await?;
-                Ok(resp.event_id)
+                let member = room
+                    .get_member(&my_id)
+                    .await?
+                    .context("Couldn't find me among room members")?;
+                if !member.can_send_message(MessageLikeEventType::RoomMessage) {
+                    bail!("No permission to send message in this room");
+                }
+                let response = room.send(inner).await?;
+                Ok(response.event_id)
             })
             .await?
     }
@@ -225,21 +247,6 @@ impl AttachmentsManager {
             .await?
     }
 
-    fn is_joined(&self) -> bool {
-        matches!(self.room.state(), RoomState::Joined)
-    }
-
-    pub fn attachment_draft(&self) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
-        Ok(AttachmentDraft {
-            client: self.client.clone(),
-            room: self.room.clone(),
-            inner: self.inner.draft_builder(),
-        })
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn image_attachment_draft(
         &self,
@@ -251,9 +258,6 @@ impl AttachmentsManager {
         height: Option<u64>,
         blurhash: Option<String>,
     ) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
         let info = assign!(ImageInfo::new(), {
             height: height.and_then(UInt::new),
             width: width.and_then(UInt::new),
@@ -282,9 +286,6 @@ impl AttachmentsManager {
         size: Option<u64>,
         secs: Option<u64>,
     ) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
         let info = assign!(AudioInfo::new(), {
             duration: secs.map(|x| Duration::new(x, 0)),
             mimetype,
@@ -315,9 +316,6 @@ impl AttachmentsManager {
         height: Option<u64>,
         blurhash: Option<String>,
     ) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
         let info = assign!(VideoInfo::new(), {
             duration: secs.map(|x| Duration::new(x, 0)),
             height: height.and_then(UInt::new),
@@ -346,9 +344,6 @@ impl AttachmentsManager {
         mimetype: Option<String>,
         size: Option<u64>,
     ) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
         let mut builder = self.inner.draft_builder();
         let size = size.and_then(UInt::new);
         let info = assign!(FileInfo::new(), { mimetype, size });
@@ -367,9 +362,6 @@ impl AttachmentsManager {
         body: String,
         geo_uri: String,
     ) -> Result<AttachmentDraft> {
-        if !self.is_joined() {
-            bail!("Can only attachment in joined rooms");
-        }
         let mut builder = self.inner.draft_builder();
         let info = LocationInfo::new();
         let mut location_content = LocationMessageEventContent::new(body, geo_uri);

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -14,7 +14,8 @@ use ruma_common::{MxcUri, OwnedEventId, OwnedUserId};
 use ruma_events::room::{
     message::{
         AudioInfo, AudioMessageEventContent, FileInfo, FileMessageEventContent,
-        ImageMessageEventContent, LocationMessageEventContent, VideoInfo, VideoMessageEventContent,
+        ImageMessageEventContent, LocationInfo, LocationMessageEventContent, VideoInfo,
+        VideoMessageEventContent,
     },
     ImageInfo,
 };
@@ -354,6 +355,26 @@ impl AttachmentsManager {
         let mut file_content = FileMessageEventContent::plain(body, url.into());
         file_content.info = Some(Box::new(info));
         builder.content(AttachmentContent::File(file_content));
+        Ok(AttachmentDraft {
+            client: self.client.clone(),
+            room: self.room.clone(),
+            inner: builder,
+        })
+    }
+
+    pub fn location_attachment_draft(
+        &self,
+        body: String,
+        geo_uri: String,
+    ) -> Result<AttachmentDraft> {
+        if !self.is_joined() {
+            bail!("Can only attachment in joined rooms");
+        }
+        let mut builder = self.inner.draft_builder();
+        let info = LocationInfo::new();
+        let mut location_content = LocationMessageEventContent::new(body, geo_uri);
+        location_content.info = Some(Box::new(info));
+        builder.content(AttachmentContent::Location(location_content));
         Ok(AttachmentDraft {
             client: self.client.clone(),
             room: self.room.clone(),

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -1,6 +1,6 @@
 use acter_core::{
     events::attachments::{AttachmentBuilder, AttachmentContent},
-    models::{self, ActerModel, AnyActerModel, Color},
+    models::{self, ActerModel, AnyActerModel},
 };
 use anyhow::{bail, Context, Result};
 use core::time::Duration;

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -12,7 +12,6 @@ use matrix_sdk::{
     Client as SdkClient, ClientBuilder, SessionMeta,
 };
 use ruma_common::OwnedUserId;
-use std::backtrace::Backtrace;
 use std::sync::RwLock;
 use tracing::{error, info};
 

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -1,9 +1,9 @@
 use acter_core::{
     events::{
         calendar::{self as calendar_events, CalendarEventBuilder},
-        Icon, UtcDateTime,
+        UtcDateTime,
     },
-    models::{self, ActerModel, AnyActerModel, Color},
+    models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};

--- a/native/acter/src/api/comments.rs
+++ b/native/acter/src/api/comments.rs
@@ -1,6 +1,6 @@
 use acter_core::{
     events::comments::CommentBuilder,
-    models::{self, ActerModel, AnyActerModel, Color},
+    models::{self, ActerModel, AnyActerModel},
 };
 use anyhow::{bail, Context, Result};
 use core::time::Duration;

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -1,4 +1,3 @@
-use acter_core::models::TextMessageContent;
 use core::time::Duration;
 use ruma_common::{MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId};
 use ruma_events::room::{

--- a/native/acter/src/api/device.rs
+++ b/native/acter/src/api/device.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use futures::{
-    channel::mpsc::{channel, Receiver, Sender},
+    channel::mpsc::{channel, Receiver},
     pin_mut,
     stream::StreamExt,
 };

--- a/native/acter/src/api/invitation.rs
+++ b/native/acter/src/api/invitation.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use futures_signals::signal::{Mutable, MutableSignalCloned, SignalExt, SignalStream};
 use matrix_sdk::{
     event_handler::{Ctx, EventHandlerHandle},
-    room::{Room, RoomMember},
+    room::Room,
     ruma::api::client::user_directory::search_users,
     Client as SdkClient, RoomMemberships, RoomState,
 };

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -35,8 +35,8 @@ use ruma_events::{
         join_rules::{OriginalRoomJoinRulesEvent, OriginalSyncRoomJoinRulesEvent},
         member::{MembershipState, OriginalRoomMemberEvent, OriginalSyncRoomMemberEvent},
         message::{
-            MessageFormat, MessageType, OriginalRoomMessageEvent, OriginalSyncRoomMessageEvent,
-            Relation, RoomMessageEvent,
+            MessageType, OriginalRoomMessageEvent, OriginalSyncRoomMessageEvent, Relation,
+            RoomMessageEvent,
         },
         name::{OriginalRoomNameEvent, OriginalSyncRoomNameEvent},
         pinned_events::{OriginalRoomPinnedEventsEvent, OriginalSyncRoomPinnedEventsEvent},
@@ -1199,9 +1199,7 @@ impl RoomMessage {
             }
             MessageType::Emote(content) => {
                 if let Some(formatted) = &content.formatted {
-                    if formatted.format == MessageFormat::Html {
-                        text_desc.set_formatted_body(Some(formatted.body.clone()));
-                    }
+                    text_desc.set_formatted_body(Some(formatted.body.clone()));
                 }
             }
             MessageType::File(content) => {
@@ -1233,9 +1231,7 @@ impl RoomMessage {
             }
             MessageType::Text(content) => {
                 if let Some(formatted) = &content.formatted {
-                    if formatted.format == MessageFormat::Html {
-                        text_desc.set_formatted_body(Some(formatted.body.clone()));
-                    }
+                    text_desc.set_formatted_body(Some(formatted.body.clone()));
                 }
             }
             MessageType::Video(content) => {
@@ -1291,9 +1287,7 @@ impl RoomMessage {
             }
             MessageType::Emote(content) => {
                 if let Some(formatted) = &content.formatted {
-                    if formatted.format == MessageFormat::Html {
-                        text_desc.set_formatted_body(Some(formatted.body.clone()));
-                    }
+                    text_desc.set_formatted_body(Some(formatted.body.clone()));
                 }
             }
             MessageType::File(content) => {
@@ -1325,9 +1319,7 @@ impl RoomMessage {
             }
             MessageType::Text(content) => {
                 if let Some(formatted) = &content.formatted {
-                    if formatted.format == MessageFormat::Html {
-                        text_desc.set_formatted_body(Some(formatted.body.clone()));
-                    }
+                    text_desc.set_formatted_body(Some(formatted.body.clone()));
                 }
             }
             MessageType::Video(content) => {
@@ -1833,9 +1825,7 @@ impl RoomMessage {
                 match msg_type {
                     MessageType::Text(content) => {
                         if let Some(formatted) = &content.formatted {
-                            if formatted.format == MessageFormat::Html {
-                                text_desc.set_formatted_body(Some(formatted.body.clone()));
-                            }
+                            text_desc.set_formatted_body(Some(formatted.body.clone()));
                         }
                         if sent_by_me {
                             result.set_editable(true);
@@ -1843,9 +1833,7 @@ impl RoomMessage {
                     }
                     MessageType::Emote(content) => {
                         if let Some(formatted) = &content.formatted {
-                            if formatted.format == MessageFormat::Html {
-                                text_desc.set_formatted_body(Some(formatted.body.clone()));
-                            }
+                            text_desc.set_formatted_body(Some(formatted.body.clone()));
                         }
                         if sent_by_me {
                             result.set_editable(true);

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use core::time::Duration;
-use matrix_sdk::{deserialized_responses::SyncTimelineEvent, room::Room};
+use matrix_sdk::room::Room;
 use matrix_sdk_ui::timeline::{
     EventSendState as SdkEventSendState, EventTimelineItem, MembershipChange, TimelineItem,
     TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
@@ -12,21 +11,6 @@ use ruma_events::{
         candidates::{OriginalCallCandidatesEvent, OriginalSyncCallCandidatesEvent},
         hangup::{OriginalCallHangupEvent, OriginalSyncCallHangupEvent},
         invite::{OriginalCallInviteEvent, OriginalSyncCallInviteEvent},
-    },
-    key::verification::{
-        accept::{
-            AcceptMethod, OriginalKeyVerificationAcceptEvent,
-            OriginalSyncKeyVerificationAcceptEvent,
-        },
-        cancel::{OriginalKeyVerificationCancelEvent, OriginalSyncKeyVerificationCancelEvent},
-        done::{OriginalKeyVerificationDoneEvent, OriginalSyncKeyVerificationDoneEvent},
-        key::{OriginalKeyVerificationKeyEvent, OriginalSyncKeyVerificationKeyEvent},
-        mac::{OriginalKeyVerificationMacEvent, OriginalSyncKeyVerificationMacEvent},
-        ready::{OriginalKeyVerificationReadyEvent, OriginalSyncKeyVerificationReadyEvent},
-        start::{
-            OriginalKeyVerificationStartEvent, OriginalSyncKeyVerificationStartEvent, StartMethod,
-        },
-        VerificationMethod,
     },
     policy::rule::{
         room::{OriginalPolicyRuleRoomEvent, OriginalSyncPolicyRuleRoomEvent},
@@ -51,8 +35,8 @@ use ruma_events::{
         join_rules::{OriginalRoomJoinRulesEvent, OriginalSyncRoomJoinRulesEvent},
         member::{MembershipState, OriginalRoomMemberEvent, OriginalSyncRoomMemberEvent},
         message::{
-            AudioInfo, FileInfo, MessageFormat, MessageType, OriginalRoomMessageEvent,
-            OriginalSyncRoomMessageEvent, Relation, VideoInfo,
+            MessageFormat, MessageType, OriginalRoomMessageEvent, OriginalSyncRoomMessageEvent,
+            Relation,
         },
         name::{OriginalRoomNameEvent, OriginalSyncRoomNameEvent},
         pinned_events::{OriginalRoomPinnedEventsEvent, OriginalSyncRoomPinnedEventsEvent},
@@ -71,8 +55,8 @@ use ruma_events::{
         parent::{OriginalSpaceParentEvent, OriginalSyncSpaceParentEvent},
     },
     sticker::{OriginalStickerEvent, OriginalSyncStickerEvent},
-    AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
-    SyncMessageLikeEvent, SyncStateEvent,
+    AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
+    SyncStateEvent,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, ops::Deref, sync::Arc};

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -36,7 +36,7 @@ use ruma_events::{
         member::{MembershipState, OriginalRoomMemberEvent, OriginalSyncRoomMemberEvent},
         message::{
             MessageFormat, MessageType, OriginalRoomMessageEvent, OriginalSyncRoomMessageEvent,
-            Relation,
+            Relation, RoomMessageEvent,
         },
         name::{OriginalRoomNameEvent, OriginalSyncRoomNameEvent},
         pinned_events::{OriginalRoomPinnedEventsEvent, OriginalSyncRoomPinnedEventsEvent},
@@ -1812,22 +1812,21 @@ impl RoomMessage {
                     _ => "Unknown timeline item".to_string(),
                 };
                 if let Some(json) = event.latest_edit_json() {
-                    if let Ok(AnySyncTimelineEvent::MessageLike(
-                        AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Original(ev)),
-                    )) = json.deserialize()
-                    {
-                        fallback = match ev.content.msgtype {
-                            MessageType::Audio(content) => "sent an audio.".to_string(),
-                            MessageType::Emote(content) => content.body,
-                            MessageType::File(content) => "sent a file.".to_string(),
-                            MessageType::Image(content) => "sent an image.".to_string(),
-                            MessageType::Location(content) => content.body,
-                            MessageType::Notice(content) => content.body,
-                            MessageType::ServerNotice(content) => content.body,
-                            MessageType::Text(content) => content.body,
-                            MessageType::Video(content) => "sent a video.".to_string(),
-                            _ => "Unknown timeline item".to_string(),
-                        };
+                    if let Ok(event_content) = json.deserialize_as::<RoomMessageEvent>() {
+                        if let Some(original) = event_content.as_original() {
+                            fallback = match &original.content.msgtype {
+                                MessageType::Audio(content) => "sent an audio.".to_string(),
+                                MessageType::Emote(content) => content.body.clone(),
+                                MessageType::File(content) => "sent a file.".to_string(),
+                                MessageType::Image(content) => "sent an image.".to_string(),
+                                MessageType::Location(content) => content.body.clone(),
+                                MessageType::Notice(content) => content.body.clone(),
+                                MessageType::ServerNotice(content) => content.body.clone(),
+                                MessageType::Text(content) => content.body.clone(),
+                                MessageType::Video(content) => "sent a video.".to_string(),
+                                _ => "Unknown timeline item".to_string(),
+                            };
+                        }
                     }
                 }
                 let mut text_desc = TextDesc::new(fallback);
@@ -1902,75 +1901,70 @@ impl RoomMessage {
                     _ => {}
                 }
                 if let Some(json) = event.latest_edit_json() {
-                    if let Ok(AnySyncTimelineEvent::MessageLike(
-                        AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Original(ev)),
-                    )) = json.deserialize()
-                    {
-                        match ev.content.msgtype {
-                            MessageType::Text(content) => {
-                                if let Some(formatted) = &content.formatted {
-                                    if formatted.format == MessageFormat::Html {
+                    if let Ok(event_content) = json.deserialize_as::<RoomMessageEvent>() {
+                        if let Some(original) = event_content.as_original() {
+                            match &original.content.msgtype {
+                                MessageType::Text(content) => {
+                                    if let Some(formatted) = &content.formatted {
                                         text_desc.set_formatted_body(Some(formatted.body.clone()));
                                     }
                                 }
-                            }
-                            MessageType::Emote(content) => {
-                                if let Some(formatted) = &content.formatted {
-                                    if formatted.format == MessageFormat::Html {
+                                MessageType::Emote(content) => {
+                                    if let Some(formatted) = &content.formatted {
                                         text_desc.set_formatted_body(Some(formatted.body.clone()));
                                     }
                                 }
-                            }
-                            MessageType::Image(content) => {
-                                if let Some(info) = &content.info {
-                                    let image_desc = ImageDesc::new(
-                                        content.body.clone(),
-                                        content.source.clone(),
-                                        *info.clone(),
-                                    );
-                                    result.set_image_desc(image_desc);
+                                MessageType::Image(content) => {
+                                    if let Some(info) = &content.info {
+                                        let image_desc = ImageDesc::new(
+                                            content.body.clone(),
+                                            content.source.clone(),
+                                            *info.clone(),
+                                        );
+                                        result.set_image_desc(image_desc);
+                                    }
                                 }
-                            }
-                            MessageType::Audio(content) => {
-                                if let Some(info) = &content.info {
-                                    let audio_desc = AudioDesc::new(
-                                        content.body.clone(),
-                                        content.source.clone(),
-                                        *info.clone(),
-                                    );
-                                    result.set_audio_desc(audio_desc);
+                                MessageType::Audio(content) => {
+                                    if let Some(info) = &content.info {
+                                        let audio_desc = AudioDesc::new(
+                                            content.body.clone(),
+                                            content.source.clone(),
+                                            *info.clone(),
+                                        );
+                                        result.set_audio_desc(audio_desc);
+                                    }
                                 }
-                            }
-                            MessageType::Video(content) => {
-                                if let Some(info) = &content.info {
-                                    let video_desc = VideoDesc::new(
-                                        content.body.clone(),
-                                        content.source.clone(),
-                                        *info.clone(),
-                                    );
-                                    result.set_video_desc(video_desc);
+                                MessageType::Video(content) => {
+                                    if let Some(info) = &content.info {
+                                        let video_desc = VideoDesc::new(
+                                            content.body.clone(),
+                                            content.source.clone(),
+                                            *info.clone(),
+                                        );
+                                        result.set_video_desc(video_desc);
+                                    }
                                 }
-                            }
-                            MessageType::File(content) => {
-                                if let Some(info) = &content.info {
-                                    let file_desc = FileDesc::new(
-                                        content.body.clone(),
-                                        content.source.clone(),
-                                        *info.clone(),
-                                    );
-                                    result.set_file_desc(file_desc);
+                                MessageType::File(content) => {
+                                    if let Some(info) = &content.info {
+                                        let file_desc = FileDesc::new(
+                                            content.body.clone(),
+                                            content.source.clone(),
+                                            *info.clone(),
+                                        );
+                                        result.set_file_desc(file_desc);
+                                    }
                                 }
-                            }
-                            MessageType::Location(content) => {
-                                if let Some(info) = &content.info {
-                                    let location_desc = LocationDesc::new(
-                                        content.body.clone(),
-                                        content.geo_uri.clone(),
-                                    );
-                                    result.set_location_desc(location_desc);
+                                MessageType::Location(content) => {
+                                    if let Some(info) = &content.info {
+                                        let location_desc = LocationDesc::new(
+                                            content.body.clone(),
+                                            content.geo_uri.clone(),
+                                        );
+                                        result.set_location_desc(location_desc);
+                                    }
                                 }
+                                _ => {}
                             }
-                            _ => {}
                         }
                     }
                 }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -10,7 +10,6 @@ use anyhow::{bail, Context, Result};
 use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
-    media::{MediaFormat, MediaRequest},
     room::Room,
     ruma::{assign, UInt},
     RoomState,
@@ -18,9 +17,8 @@ use matrix_sdk::{
 use ruma_common::{MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId};
 use ruma_events::room::{
     message::{
-        AudioInfo, AudioMessageEventContent, FileInfo, FileMessageEventContent,
-        ImageMessageEventContent, LocationMessageEventContent, TextMessageEventContent, VideoInfo,
-        VideoMessageEventContent,
+        AudioMessageEventContent, FileMessageEventContent, ImageMessageEventContent,
+        LocationMessageEventContent, TextMessageEventContent, VideoMessageEventContent,
     },
     ImageInfo,
 };

--- a/native/acter/src/api/profile.rs
+++ b/native/acter/src/api/profile.rs
@@ -12,7 +12,6 @@ use ruma_common::{OwnedRoomId, OwnedUserId};
 use ruma_events::room::MediaSource;
 
 use super::{
-    api::FfiBuffer,
     common::{OptionBuffer, OptionString},
     RUNTIME,
 };

--- a/native/acter/src/api/push.rs
+++ b/native/acter/src/api/push.rs
@@ -1,9 +1,3 @@
-use crate::{RoomMessage, RUNTIME};
-
-use super::{
-    message::{any_sync_event_to_message, sync_event_to_message},
-    Client,
-};
 use anyhow::{bail, Context, Result};
 use matrix_sdk::ruma::{
     api::client::push::{
@@ -18,6 +12,10 @@ use matrix_sdk_ui::notification_client::{
     NotificationProcessSetup,
 };
 use ruma_common::{OwnedEventId, OwnedRoomId};
+
+use super::{message::any_sync_event_to_message, Client};
+
+use crate::{RoomMessage, RUNTIME};
 
 pub struct NotificationItem {
     pub(crate) inner: SdkNotificationItem,

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -38,7 +38,7 @@ use ruma_events::{
     room::{
         avatar::ImageInfo as AvatarImageInfo,
         join_rules::{AllowRule, JoinRule},
-        message::MessageType,
+        message::{MessageType, RoomMessageEvent},
         MediaSource,
     },
     space::{child::HierarchySpaceChildEvent, parent::SpaceParentEventContent},
@@ -959,12 +959,13 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&event_id).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                let MessageType::Image(content) = &m.content.msgtype else {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                let MessageType::Image(content) = &original.content.msgtype else {
                     bail!("Invalid file format");
                 };
                 let request = MediaRequest {
@@ -988,12 +989,13 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&event_id).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                let MessageType::Audio(content) = &m.content.msgtype else {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                let MessageType::Audio(content) = &original.content.msgtype else {
                     bail!("Invalid file format");
                 };
                 let request = MediaRequest {
@@ -1018,12 +1020,13 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&event_id).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                let MessageType::Video(content) = &m.content.msgtype else {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                let MessageType::Video(content) = &original.content.msgtype else {
                     bail!("Invalid file format");
                 };
                 let request = MediaRequest {
@@ -1048,12 +1051,13 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&event_id).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                let MessageType::File(content) = &m.content.msgtype else {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                let MessageType::File(content) = &original.content.msgtype else {
                     bail!("Invalid file format");
                 };
                 let request = MediaRequest {
@@ -1192,39 +1196,40 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&eid).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                let (request, name) = match m.content.msgtype {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                let (request, name) = match &original.content.msgtype {
                     MessageType::Image(content) => {
                         let request = MediaRequest {
                             source: content.source.clone(),
                             format: MediaFormat::File,
                         };
-                        (request, content.body)
+                        (request, content.body.clone())
                     }
                     MessageType::Audio(content) => {
                         let request = MediaRequest {
                             source: content.source.clone(),
                             format: MediaFormat::File,
                         };
-                        (request, content.body)
+                        (request, content.body.clone())
                     }
                     MessageType::Video(content) => {
                         let request = MediaRequest {
                             source: content.source.clone(),
                             format: MediaFormat::File,
                         };
-                        (request, content.body)
+                        (request, content.body.clone())
                     }
                     MessageType::File(content) => {
                         let request = MediaRequest {
                             source: content.source.clone(),
                             format: MediaFormat::File,
                         };
-                        (request, content.body)
+                        (request, content.body.clone())
                     }
                     _ => bail!("This message type is not downloadable"),
                 };
@@ -1263,12 +1268,13 @@ impl Room {
         RUNTIME
             .spawn(async move {
                 let evt = room.event(&eid).await?;
-                let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-                    MessageLikeEvent::Original(m),
-                ))) = evt.event.deserialize() else {
-                    bail!("It is not message");
+                let Ok(event_content) = evt.event.deserialize_as::<RoomMessageEvent>() else {
+                    bail!("It is not message")
                 };
-                match m.content.msgtype {
+                let original = event_content
+                    .as_original()
+                    .expect("Couldn't get original msg");
+                match &original.content.msgtype {
                     MessageType::Image(content) => {}
                     MessageType::Audio(content) => {}
                     MessageType::Video(content) => {}

--- a/native/acter/src/api/rsvp.rs
+++ b/native/acter/src/api/rsvp.rs
@@ -1,6 +1,6 @@
 use acter_core::{
     events::rsvp::{RsvpBuilder, RsvpStatus},
-    models::{self, ActerModel, AnyActerModel, Color},
+    models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -8,13 +8,13 @@ use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{room::Room, RoomState};
 use ruma_common::{OwnedEventId, OwnedUserId};
-use ruma_events::{room::message::TextMessageEventContent, MessageLikeEventType};
+use ruma_events::MessageLikeEventType;
 use std::{ops::Deref, str::FromStr};
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::{wrappers::BroadcastStream, Stream};
 use tracing::{error, trace, warn};
 
-use super::{calendar_events::CalendarEvent, client::Client, common::OptionString, RUNTIME};
+use super::{calendar_events::CalendarEvent, client::Client, RUNTIME};
 
 impl Client {
     pub async fn wait_for_rsvp(&self, key: String, timeout: Option<Box<Duration>>) -> Result<Rsvp> {

--- a/native/acter/src/api/search.rs
+++ b/native/acter/src/api/search.rs
@@ -5,7 +5,6 @@ use ruma_common::{
     room::RoomType,
     OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
 };
-use tracing::{error, trace};
 
 use super::{client::Client, RUNTIME};
 

--- a/native/acter/src/api/settings.rs
+++ b/native/acter/src/api/settings.rs
@@ -2,29 +2,22 @@ pub use acter_core::events::settings::{
     ActerAppSettingsContent, EventsSettings, NewsSettings, PinsSettings, SimpleSettingWithTurnOff,
     SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
 };
-
 use acter_core::events::{
     calendar::CalendarEventEventContent,
-    news::{NewsEntryEventContent, NewsEntryUpdateEvent},
+    news::NewsEntryEventContent,
     pins::PinEventContent,
     settings::ActerAppSettingsContentBuilder,
     tasks::{TaskEventContent, TaskListEventContent},
 };
 use anyhow::{bail, Result};
-use matrix_sdk::{
-    deserialized_responses::SyncOrStrippedState,
-    room::{Messages, MessagesOptions},
-    ruma::Int,
-    RoomState,
-};
+use matrix_sdk::{deserialized_responses::SyncOrStrippedState, ruma::Int};
 use ruma_events::{
     room::power_levels::{RoomPowerLevels as RumaRoomPowerLevels, RoomPowerLevelsEventContent},
-    MessageLikeEvent, StaticEventContent, SyncStateEvent, TimelineEventType,
+    StaticEventContent, SyncStateEvent, TimelineEventType,
 };
 use std::{collections::btree_map, ops::Deref};
 
-use crate::Room;
-use crate::RUNTIME;
+use crate::{Room, RUNTIME};
 
 #[derive(Clone)]
 pub struct ActerAppSettingsBuilder {

--- a/native/acter/src/api/stream.rs
+++ b/native/acter/src/api/stream.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{
 use matrix_sdk_ui::timeline::{
     BackPaginationStatus, EventTimelineItem, PaginationOptions, Timeline,
 };
-use ruma_common::{EventId, OwnedEventId, OwnedTransactionId, TransactionId};
+use ruma_common::{EventId, OwnedEventId, OwnedTransactionId};
 use ruma_events::{
     reaction::ReactionEventContent,
     receipt::ReceiptThread,

--- a/native/acter/src/api/super_invites.rs
+++ b/native/acter/src/api/super_invites.rs
@@ -1,8 +1,9 @@
 // internal API
 
-use crate::{Client, RUNTIME};
 use acter_core::super_invites::{api, CreateToken, Token, UpdateToken};
 use anyhow::Result;
+
+use crate::{Client, RUNTIME};
 
 pub struct SuperInviteToken {
     token: Token,

--- a/native/acter/src/api/three_pid.rs
+++ b/native/acter/src/api/three_pid.rs
@@ -14,7 +14,6 @@ use matrix_sdk::{
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, ops::Deref};
-use tracing::warn;
 
 use super::{client::Client, RUNTIME};
 

--- a/native/acter/src/api/uniffi_api.rs
+++ b/native/acter/src/api/uniffi_api.rs
@@ -1,12 +1,11 @@
-use crate::{api::NotificationItem as ApiNotificationItem, login_with_token};
-use matrix_sdk::ruma::events::room::message::MessageType;
-use matrix_sdk::ruma::events::AnySyncMessageLikeEvent;
-use matrix_sdk::ruma::events::AnySyncTimelineEvent;
-use matrix_sdk::ruma::events::SyncMessageLikeEvent;
-
-use matrix_sdk_ui::notification_client::{
-    NotificationClient, NotificationEvent, NotificationItem as SdkNotificationItem,
+use matrix_sdk::ruma::events::{
+    room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
 };
+use matrix_sdk_ui::notification_client::{
+    NotificationEvent, NotificationItem as SdkNotificationItem,
+};
+
+use crate::{api::NotificationItem as ApiNotificationItem, login_with_token};
 
 #[derive(Debug, uniffi::Error, thiserror::Error)]
 #[uniffi(flat_error)]

--- a/native/acter/src/api/verification.rs
+++ b/native/acter/src/api/verification.rs
@@ -18,10 +18,7 @@ use matrix_sdk::{
 use ruma_common::{device_id, OwnedDeviceId, OwnedEventId, OwnedTransactionId, OwnedUserId};
 use ruma_events::{
     key::verification::{accept::AcceptMethod, start::StartMethod, VerificationMethod},
-    room::{
-        encrypted::OriginalSyncRoomEncryptedEvent,
-        message::{MessageType, OriginalSyncRoomMessageEvent},
-    },
+    room::message::{MessageType, OriginalSyncRoomMessageEvent},
     AnyToDeviceEvent, EventContent,
 };
 use std::{

--- a/native/test/src/tests/pins.rs
+++ b/native/test/src/tests/pins.rs
@@ -185,9 +185,10 @@ async fn pin_attachments() -> Result<()> {
     let attachment = attachments.first().unwrap();
     assert_eq!(attachment.event_id(), attachment_1_id);
     assert_eq!(attachment.type_str(), "image");
-    assert_eq!(attachment.image_desc().unwrap().name(), "acter logo");
+    let image_desc = attachment.image_desc().expect("image desc needed");
+    assert_eq!(image_desc.name(), "acter logo");
     assert_eq!(
-        attachment.image_desc().unwrap().source().url(),
+        image_desc.source().url(),
         "https://raw.githubusercontent.com/acterglobal/a3/main/app/assets/icon/acter-logo.svg"
     );
 

--- a/native/test/src/tests/pins.rs
+++ b/native/test/src/tests/pins.rs
@@ -158,7 +158,7 @@ async fn pin_attachments() -> Result<()> {
 
     let attachments_listener = attachments_manager.subscribe();
     let attachment_1_id = attachments_manager
-        .image_attachment_draft(
+        .image_draft(
             "acter logo".to_owned(),
             "https://raw.githubusercontent.com/acterglobal/a3/main/app/assets/icon/acter-logo.svg"
                 .to_owned(),
@@ -195,7 +195,7 @@ async fn pin_attachments() -> Result<()> {
 
     let attachments_listener = attachments_manager.subscribe();
     let attachment_2_id = attachments_manager
-        .file_attachment_draft(
+        .file_draft(
             "effektio whitepaper".to_owned(),
             "mxc://acter.global/tVLtaQaErMyoXmcCroPZdfNG".to_owned(),
             None,

--- a/native/test/src/tests/redact.rs
+++ b/native/test/src/tests/redact.rs
@@ -1,7 +1,5 @@
 use acter::{
-    api::RoomMessage,
-    ruma_common::OwnedEventId,
-    ruma_events::{AnyMessageLikeEvent, AnyTimelineEvent},
+    api::RoomMessage, ruma_common::OwnedEventId, ruma_events::room::redaction::RoomRedactionEvent,
 };
 use anyhow::{bail, Result};
 use core::time::Duration;
@@ -83,12 +81,12 @@ async fn message_redaction() -> Result<()> {
         .await?;
 
     let ev = convo.event(&redact_id).await?;
-    let Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomRedaction(redaction_event))) = ev.event.deserialize() else {
+    let Ok(event_content) = ev.event.deserialize_as::<RoomRedactionEvent>() else {
         bail!("This should be m.room.redaction event")
     };
-    let Some(original) = redaction_event.as_original() else {
-        bail!("Redaction event should get original event")
-    };
+    let original = event_content
+        .as_original()
+        .expect("Redaction event should get original event");
     assert_eq!(original.redacts, Some(received));
     assert_eq!(original.content.reason, Some("redact-test".to_string()));
 


### PR DESCRIPTION
- Implement location attachment draft
- Replace `deserialize()` for specified msg event with `deserialize_as()`. Will not touch `deserialize()` that covers multiple cases.
- Remove unused import
- Check permission when sending attachment
- Simplify fn name