### PR TITLE
Add mediakit dependicies to Linux build, introduce MacApp Build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -429,7 +429,9 @@ jobs:
       - name: Generate Changelog
         run: |
           git fetch --prune --unshallow --tags
-          cargo run -p mr_minutes -- --since nightly-latest --output nightly-changes.md
+          cargo run -p mr_minutes -- --since nightly-latest --output nightly-changes-generated.md
+          echo "** Changes since ${{ needs.tags.outputs.prev_tag }} **" > nightly-changes.md
+          cat nightly-changes-generated.md >>  nightly-changes.md
 
       - name: "Generate docs"
         run: |
@@ -448,6 +450,7 @@ jobs:
           git config --global user.email 'acter-sari@users.noreply.github.com'
           git add "docs/content/nightly/${{ needs.tags.outputs.tag }}.md"
           echo "Tagging ${{ needs.tags.outputs.tag }}" > notes.md
+          echo "" >> notes.md
           cat nightly-changes.md >> notes.md
           git commit -F notes.md
           git tag nightly-${{ needs.tags.outputs.tag }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,6 +57,7 @@ jobs:
     outputs:
       tag: ${{ inputs.custom_tag || steps.tag.outputs.tag }}
       build_num: ${{ steps.build_num.outputs.build_num }}
+      prev_tag: ${{ inputs.prev_tag || 'nightly-latest' }}
     steps:
       - id: tag
         run: echo "tag=`date +%F`" >> $GITHUB_OUTPUT
@@ -101,16 +102,17 @@ jobs:
             rename_file: "acter.ipa"
             rename_suffix: "ipa"
             extra_artifacts: "ios-manifest.plist"
-          - name: Mac OSx 
+          - name: MacOS
             os: macos-12
-            with_apple_cert: true
             target: macos
+            with_apple_cert: true
             cargo_make_args: desktop
             flutter_config: "--enable-macos-desktop"
             flutter_build_args: "build macos"
             artifact_prefix: acter-nightly-macosx
             artifact_path: app/build/macos/Build/Products/Release/
-            # tar_files: "Acter.app"
+            rename_file: "Acter.pkg"
+            rename_suffix: "pkg"
           - name: Windows
             os: windows-latest
             cargo_make_args: desktop
@@ -301,30 +303,15 @@ jobs:
           ##    ##  ##  ##    ##  ##   ### 
            ######  ####  ######   ##    ## 
 
-      - name: Sign & notorize Acter.app
+      # Package app
+      - name: Package Acter.app to Acter.pkg
         if: matrix.target == 'macos'
-        env:
-          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
-          APPLE_SIGN_CERTNAME: ${{ secrets.APPLE_MAC_APPSTORE_SIGN_CERTNAME }}
         working-directory: ${{ matrix.artifact_path }}
+        env:
+          APPLE_SIGN_CERTNAME: ${{ secrets.APPLE_MAC_APPSTORE_SIGN_CERTNAME }}
         run: |
-          mkdir private_keys
-          echo -n "$APPLE_API_KEY_BASE64" | base64 --decode --output "private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
-          ls -ltas private_keys
-          echo "Notorizing"
-          export NEW_NAME=${{ matrix.artifact_prefix }}-${{ needs.tags.outputs.tag }}.app
-          mv Acter.app "$NEW_NAME"
-          /usr/bin/ditto -c -k --keepParent $NEW_NAME Acter.zip
-          echo "Notarytool"
-          xcrun notarytool submit Acter.zip --wait \
-            --key "private_keys/AuthKey_$APPLE_API_KEY_ID.p8" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_ISSUER_ID" \
-            --bundle-id global.acter.a3
-          echo "Staple"
-          xcrun stapler staple $NEW_NAME
+          echo "Productbuild"
+          productbuild --component Acter.app /Applications --sign "$APPLE_SIGN_CERTNAME" Acter.pkg
 
       # Important! Cleanup: remove the certificate and provisioning profile from the runner!
       - name: Clean up keychain and provisioning profile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
           - name: Linux x64
             os: ubuntu-latest
             target: linux
-            apt_install: ninja-build libgtk-3-dev
+            apt_install: ninja-build libgtk-3-dev libmpv-dev mpv
             cargo_make_args: desktop
             flutter_config: "--enable-linux-desktop"
             flutter_build_args: "build linux"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -440,7 +440,9 @@ jobs:
       - name: Generate Changelog
         run: |
           git fetch --prune --unshallow --tags
-          cargo run -p mr_minutes -- --since ${{ needs.tags.outputs.prev_tag }} --output CHANGELOG.md
+          cargo run -p mr_minutes -- --since ${{ needs.tags.outputs.prev_tag }} --output CHANGELOG-generated.md
+          echo "# Changes since ${{ needs.tags.outputs.prev_tag }} " > CHANGELOG.md
+          cat CHANGELOG-generated.md >> CHANGELOG.md
 
       - uses: actions/upload-artifact@v3
         name: "Upload Changelog"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
           - name: Linux x64
             target: linux
             os: ubuntu-latest
-            apt_install: ninja-build libgtk-3-dev
+            apt_install: ninja-build libgtk-3-dev libmpv-dev mpv
             cargo_make_args: desktop
             flutter_config: "--enable-linux-desktop"
             flutter_build_args: "build linux"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,8 +121,8 @@ jobs:
             flutter_build_args: "build macos --split-debug-info=debug_symbols --verbose"
             artifact_prefix: acter-macosx
             artifact_path: app/build/macos/Build/Products/Release/
-            rename_file: "Acter.app"
-            rename_suffix: "app"
+            rename_file: "Acter.pkg"
+            rename_suffix: "pkg"
             with_debug_symbols: true
           - name: Windows
             os: windows-latest
@@ -305,12 +305,15 @@ jobs:
           ##    ##  ##  ##    ##  ##   ### 
            ######  ####  ######   ##    ## 
 
-
       # ignore codesign
-      # - name: Sign Acter.app
-      #   if: matrix.target == 'macos'
-      #   working-directory: ${{ matrix.artifact_path }}
-      #   run: codesign --deep --force --verbose --sign "${{ secrets.MAC_SIGNING_IDENTIY}}" Acter.app
+      - name: Package Acter.app to Acter.pkg
+        if: matrix.target == 'macos'
+        working-directory: ${{ matrix.artifact_path }}
+        env:
+          APPLE_SIGN_CERTNAME: ${{ secrets.APPLE_MAC_APPSTORE_SIGN_CERTNAME }}
+        run: |
+          echo "Productbuild"
+          productbuild --component Acter.app /Applications --sign "$APPLE_SIGN_CERTNAME" Acter.pkg
 
       # Important! Cleanup: remove the certificate and provisioning profile from the runner!
       - name: Clean up keychain and provisioning profile
@@ -725,30 +728,19 @@ jobs:
           cp .github/assets/provision_profiles/* ~/Library/MobileDevice/Provisioning\ Profiles/
           ls -ltas ~/Library/MobileDevice/Provisioning\ Profiles/
 
-      # - name: Rename and check pkg
-      #   run: |
-      #     mv *.app Acter.app
-      #     codesign --verify --deep --verbose Acter.app
-      #     echo "Done"
       - name: Upload to App Store
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
-          APPLE_SIGN_CERTNAME: ${{ secrets.APPLE_MAC_APPSTORE_SIGN_CERTNAME }}
         run: |
           mkdir private_keys
           echo -n "$APPLE_API_KEY_BASE64" | base64 --decode --output "private_keys/AuthKey_$APPLE_API_KEY_ID.p8"
           ls -ltas private_keys
-          echo "Productbuild"
-          productbuild --component *.app /Applications --sign "$APPLE_SIGN_CERTNAME" Acter.pkg
-          xcrun altool --upload-app --type macos --file Acter.pkg \
+          xcrun altool --upload-app --type macos --file acter-macosx-${{ needs.tags.outputs.tag }}.pkg \
               --bundle-id global.acter.a3 \
               --apiKey "$APPLE_API_KEY_ID" \
-              --apiIssuer "$APPLE_ISSUER_ID" \
-          # xcrun notarytool submit Acter.zip --wait \
-          #     --key "private_keys/AuthKey_$APPLE_API_KEY_ID.p8" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_ISSUER_ID" --bundle-id global.acter.a3
-          # xcrun stapler staple Acter.app
+              --apiIssuer "$APPLE_ISSUER_ID"
         shell: bash
 
       - name: Clean up keychain and provisioning profile

--- a/app/flatpak/global.acter.a3.yml
+++ b/app/flatpak/global.acter.a3.yml
@@ -133,6 +133,6 @@ modules:
     sources:
     - type: git
       url: https://git.ffmpeg.org/ffmpeg.git
-      branch: release/6.0
-      commit: 3d5edb89e75fe3ab3a6757208ef121fa2b0f54c7
+      tag: n6.1
+      commit: d4ff0020b40b524a490cf62eccbd3a318f4c0e58
 # END ----------------------------------------------------------------------------------- MediaKit

--- a/app/flatpak/global.acter.a3.yml
+++ b/app/flatpak/global.acter.a3.yml
@@ -133,6 +133,6 @@ modules:
     sources:
     - type: git
       url: https://git.ffmpeg.org/ffmpeg.git
-      tag: n6.1
-      commit: d4ff0020b40b524a490cf62eccbd3a318f4c0e58
+      tag: n6.0.1
+      commit: c41ff724ede7da657762d61097e26fac296c53bf
 # END ----------------------------------------------------------------------------------- MediaKit

--- a/app/flatpak/global.acter.a3.yml
+++ b/app/flatpak/global.acter.a3.yml
@@ -13,19 +13,126 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --socket=pulseaudio
-  - --talk-name=org.freedesktop.secrets
   - --share=network
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.secrets
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-run/gvfs    #This might be needed for MediaKit
+  - --filesystem=xdg-run/pipewire-0:ro #This might be needed for MediaKit
+  - --own-name=global.acter.a3
+  - --system-talk-name=org.freedesktop.NetworkManager
 modules:
-  - shared-modules/libsecret/libsecret.json
-  - name: Acter
-    buildsystem: simple
-    only-arches:
-      - x86_64
-    build-commands:
-      - "./build-flatpak.sh"
+- shared-modules/libsecret/libsecret.json
+- name: Acter
+  buildsystem: simple
+  only-arches:
+    - x86_64
+  build-commands:
+    - "./build-flatpak.sh"
+  sources:
+  
+    - type: dir
+      path: .
+    - type: file
+      path: ../assets/icon/acter-logo.svg
+
+# Media-kit required build dependencies
+- name: libmpv
+  cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  buildsystem: simple
+  build-commands:
+  - python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date
+    --disable-alsa
+  - python3 waf build
+  - python3 waf install
+  sources:
+  - type: git
+    url: https://github.com/mpv-player/mpv.git
+    tag: v0.35.1
+  - type: file
+    url: https://waf.io/waf-2.0.25
+    sha256: 21199cd220ccf60434133e1fd2ab8c8e5217c3799199c82722543970dc8e38d5
+    dest-filename: waf
+  modules:
+  - name: libass
+    cleanup:
+    - /include
+    - /lib/*.la
+    - /lib/pkgconfig
+    config-opts:
+    - --disable-static
     sources:
-    
-      - type: dir
-        path: .
-      - type: file
-        path: ../assets/icon/acter-logo.svg
+    - type: archive
+      url: https://github.com/libass/libass/releases/download/0.17.1/libass-0.17.1.tar.xz
+      sha256: f0da0bbfba476c16ae3e1cfd862256d30915911f7abaa1b16ce62ee653192784
+    modules:
+    - name: fribidi
+      cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /lib/*.la
+      - /share/man
+      buildsystem: meson
+      config-opts:
+      - --buildtype=release
+      - -Ddocs=false
+      sources:
+      - type: git
+        url: https://github.com/fribidi/fribidi.git
+        tag: v1.0.13
+        commit: b54871c339dabb7434718da3fed2fa63320997e5
+  - name: x264
+    cleanup:
+    - /include
+    - /lib/pkgconfig
+    - /share/man
+    config-opts:
+    - --disable-cli
+    - --enable-shared
+    sources:
+    - type: git
+      url: https://code.videolan.org/videolan/x264.git
+      commit: a8b68ebfaa68621b5ac8907610d3335971839d52
+      x-checker-data:
+        type: json
+        url: https://code.videolan.org/api/v4/projects/536/repository/commits
+        commit-query: first( .[].id )
+        version-query: first( .[].id )
+        timestamp-query: first( .[].committed_date )
+  - name: nv-codec-headers
+    cleanup:
+    - '*'
+    no-autogen: true
+    make-install-args:
+    - PREFIX=/app
+    sources:
+    - type: git
+      url: https://github.com/FFmpeg/nv-codec-headers.git
+      commit: 855f8263d97bbdcaeabaaaa2997e1ccad7c52dc3
+  - name: ffmpeg
+    cleanup:
+    - /include
+    - /lib/pkgconfig
+    - /share/ffmpeg/examples
+    config-opts:
+    - --enable-shared
+    - --disable-static
+    - --enable-gnutls
+    - --disable-doc
+    - --disable-programs
+    - --disable-encoders
+    - --disable-muxers
+    - --enable-encoder=png
+    - --enable-libv4l2
+    - --enable-libdav1d
+    sources:
+    - type: git
+      url: https://git.ffmpeg.org/ffmpeg.git
+      branch: release/6.0
+      commit: 3d5edb89e75fe3ab3a6757208ef121fa2b0f54c7
+# END ----------------------------------------------------------------------------------- MediaKit

--- a/docs/content/docs/getting-started/setup.md
+++ b/docs/content/docs/getting-started/setup.md
@@ -17,11 +17,23 @@ You'll need a recent:
 - [Rustup](https://rustup.rs/) setup for Rust
 - Android NDK / XCode setup for the target - and device or simulator set up
 - [flutter](https://docs.flutter.dev/get-started/install)
-- on Linux you additionally need: `libsecret-1-0` ( & `libsecret-1-dev`) and `libjsoncpp-dev`
+- on Linux you additionally need: `libsecret-1-0` ( & `libsecret-1-dev`), `mpv` (& `libmpv-dev`) and `libjsoncpp-dev`
+  <details>
+    <summary>on Ubuntu with apt</summary>
+    <code>
+    sudo apt install ninja-build libgtk-3-dev libmpv-dev mpv libjsoncpp-dev libsecret-1-dev`
+    </code>
+  </details>
+  <details>
+    <summary>on Arch with pamac</summary>
+    <code>
+    pamac install mpv libsecret libjson
+    </code>
+  </details>
 
 ## Setup
 
-You need `cargo make` for managing and building the native core artefacts. Install via
+You need `cargo make` for managing and building the native core artifacts. Install via
 `cargo install cargo-make`
 
 Then you run the init once in the root of the repository:
@@ -44,7 +56,7 @@ Whenever the native SDK changed, you need to (re)build the artifacts. To do that
 
 ## Running the App
 
-Once the SDK is rebuilded, you can run the flutter as usual on your device or emulator per:
+Once the SDK is rebuilt, you can run the flutter as usual on your device or emulator per:
 
 F5 in VS Code or `flutter run` in `app` directory
 


### PR DESCRIPTION
- Fixes the Linux build that broke because of the new media kit dependency, fixes #1205 
- Fixes the publication procedure for MacApp shipping a properly signed version, fixes #1212 