### PR TITLE
matrix-org stopped synapse development

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: michaelkaye/setup-matrix-synapse@main
+      - uses: acterglobal/setup-matrix-synapse@element-hq
         with:
           installer: poetry
           uploadLogs: false
@@ -153,7 +153,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: michaelkaye/setup-matrix-synapse@main
+      - uses: acterglobal/setup-matrix-synapse@element-hq
         with:
           installer: poetry
           uploadLogs: true
@@ -305,7 +305,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: michaelkaye/setup-matrix-synapse@main
+      - uses: acterglobal/setup-matrix-synapse@element-hq
         with:
           uploadLogs: true
           httpPort: 8118
@@ -407,7 +407,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: michaelkaye/setup-matrix-synapse@main
+      - uses: acterglobal/setup-matrix-synapse@element-hq
         with:
           uploadLogs: true
           httpPort: 8118


### PR DESCRIPTION
Getting [this error](https://github.com/acterglobal/a3/actions/runs/7212043241/job/19648883356?pr=1216) since 2023-12-14.
Cloned `setup-matrix-synapse` into `acterglobal` and replaced `matrix-org/synapse` with `element-hq/synapse`, because we have no permission to [setup-matrix-synapse](https://github.com/michaelkaye/setup-matrix-synapse).
This is [ref document](https://github.com/matrix-org/synapse/releases/tag/v1.98.0).