### PR TITLE
Revert setup-matrix-synapse to michaelkaye

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: acterglobal/setup-matrix-synapse@element-hq
+      - uses: michaelkaye/setup-matrix-synapse@main
         with:
           installer: poetry
           uploadLogs: false
@@ -153,7 +153,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: acterglobal/setup-matrix-synapse@element-hq
+      - uses: michaelkaye/setup-matrix-synapse@main
         with:
           installer: poetry
           uploadLogs: true
@@ -305,7 +305,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: acterglobal/setup-matrix-synapse@element-hq
+      - uses: michaelkaye/setup-matrix-synapse@main
         with:
           uploadLogs: true
           httpPort: 8118
@@ -407,7 +407,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: acterglobal/setup-matrix-synapse@element-hq
+      - uses: michaelkaye/setup-matrix-synapse@main
         with:
           uploadLogs: true
           httpPort: 8118


### PR DESCRIPTION
`michaelkaye` approved and merged [this PR](https://github.com/michaelkaye/setup-matrix-synapse/pull/101).
So will revert `setup-matrix-synapse`