### PR TITLE
Workaround to fix Android forgotten session.

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -262,7 +262,12 @@ class ActerSdk {
       debugPrint("Secure Storage isn't available yet. Delaying");
       await Future.delayed(const Duration(milliseconds: 50));
     }
+
     debugPrint('Secure Storage is available. Attempting to read.');
+    if (Platform.isAndroid) {
+      // fake read for https://github.com/mogol/flutter_secure_storage/issues/566
+      await storage.read(key: _sessionKey);
+    }
     if (!await storage.containsKey(key: _sessionKey)) {
       // not yet set. let's see if we maybe want to migrate instead:
       await _maybeMigrateFromPrefs(appDocPath);


### PR DESCRIPTION
It appears because of a bug in FlutterSecureStorage the first read goes into null. Just adding a fake read at the startup supposedly prevents that problem from occuring. Adding a section to do that.

And indeed it works here for the emulator...

Fixes #1194 