### PR TITLE
Fix up proxyman setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "oslog",
  "parse-env-filter",
  "pulldown-cmark",
+ "reqwest",
  "ruma",
  "ruma-common",
  "ruma-events",
@@ -1747,6 +1748,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,6 +2299,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3236,6 +3265,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,6 +3427,32 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -4352,19 +4425,23 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -5460,6 +5537,16 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -396,7 +396,7 @@ class ActerSdk {
 
     try {
       if (httpProxy.isNotEmpty) {
-        developer.log('Setting http proxy to $httpProxy');
+        debugPrint('Setting http proxy to $httpProxy');
         api.setProxy(httpProxy);
       }
     } catch (e) {

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -39,6 +39,8 @@ mime = "0.3.16"
 mime2ext = "0.1.52"
 mime_guess = "2.0.4"
 parse-env-filter = "0.1.0"
+# enable support for system native TLS certificates
+reqwest = { version = "*", features = ["rustls-tls-native-roots"]}
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
 ruma-common = { workspace = true, features = ["client"] }
 ruma-events = { workspace = true }

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -173,11 +173,11 @@ pub async fn login_with_token_under_config(
 
 pub async fn login_with_token(base_path: String, restore_token: String) -> Result<Client> {
     let token: RestoreToken = serde_json::from_str(&restore_token)?;
-    let config = platform::new_client_config(
+    let (config, user_id) = make_client_config(
         base_path,
-        token.session.user_id.to_string(),
+        token.session.user_id.as_str(),
         token.db_passphrase.clone(),
-        false,
+        "", ""
     )
     .await?;
     login_with_token_under_config(token, config).await

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -177,7 +177,8 @@ pub async fn login_with_token(base_path: String, restore_token: String) -> Resul
         base_path,
         token.session.user_id.as_str(),
         token.db_passphrase.clone(),
-        "", ""
+        "",
+        "",
     )
     .await?;
     login_with_token_under_config(token, config).await


### PR DESCRIPTION
Now able to use proxyman on:
 - [x] MacOS

By adding: `--dart-define HTTP_PROXY=http://PROXYMAN_IP:9090` (or `http://localhost9090/`) to the flutter app run command.

<img width="1511" alt="Screenshot 2024-01-15 at 17 24 08" src="https://github.com/acterglobal/a3/assets/40496/d7bc2657-db59-4016-ae97-64e5d27601f1">



Namely this does two things:
 - add support for reading the proxy-param for `login_with_token` in rust, thus actually enabling using the proxy on restarted apps
 - add support for using system certs on reqwest by enabling said feature for the build.