### PR TITLE
Ensure we are building on latest flutter stable

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -168,7 +168,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - name: Flutter info

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
       # - uses: actions-rs/cargo@v1
       #   name: Clippy
@@ -80,7 +79,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
       # - uses: actions-rs/cargo@v1
       #   name: Clippy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - name: Install supported toolchain

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -146,7 +146,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - uses: actions/setup-python@v4
@@ -298,7 +297,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - uses: actions/setup-python@v4
@@ -400,7 +398,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -82,7 +82,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
       - uses: actions-rs/cargo@v1
         name: Clippy
@@ -108,7 +107,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
       - name: Install supported rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -192,7 +192,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.13.1'
           channel: 'stable'
 
       - name: Flutter info


### PR DESCRIPTION
Fixes #1280 by removing the flutter-version-pinning from the workflows.