### PR TITLE
Put request and openssl behind a proxyman feature-flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,19 +2303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,24 +3253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,11 +3400,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3463,18 +3432,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -4436,12 +4405,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4452,7 +4419,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -5548,16 +5514,6 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -14,6 +14,7 @@ testing = ["dep:matrix-sdk-base"]
 cbindgen = []
 dart = []
 uniffi = ["dep:uniffi", "dep:thiserror"]
+proxyman = ["dep:reqwest", "dep:openssl"]
 
 
 [build-dependencies]
@@ -39,8 +40,6 @@ mime = "0.3.16"
 mime2ext = "0.1.52"
 mime_guess = "2.0.4"
 parse-env-filter = "0.1.0"
-# enable support for system native TLS certificates
-reqwest = { version = "*", features = ["rustls-tls-native-roots"]}
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
 ruma-common = { workspace = true, features = ["client"] }
 ruma-events = { workspace = true }
@@ -61,6 +60,10 @@ pulldown-cmark = { version = "0.9.1", default-features = false }
 # for uniffi support
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["cli"], optional = true }
 thiserror = { version = "1.0.49", optional = true }
+
+# for proxyman support
+# enable support for system native TLS certificates
+reqwest = { optional = true, version = "*", default-features = false, features = ["rustls-tls-native-roots"]}
 
 [dev-dependencies]
 tempfile = "3.3.0"
@@ -100,7 +103,7 @@ matrix-sdk-ui = { workspace = true }
 android_logger = "0.12"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-android = "0.2"
-openssl = { version = "*", features = ["vendored"]}
+openssl = { version = "*", optional = true, features = ["vendored"]}
 
 #   ----   IOS/MACOS
 [target.'cfg(target_os = "ios")'.dependencies]


### PR DESCRIPTION
The two things we recently added for proxy-man support seem to break on certain build. Move that into a feature flag to explicitly activate for proxyman support to avoid that.