### PR TITLE
Fix iOS release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,10 @@ jobs:
       prev_tag: ${{ inputs.prev_tag || 'release-latest' }}
     steps:
       - id: version
-        run: echo "version=`date +1.%y.%-m%d`" >> $GITHUB_OUTPUT
+        # FIXME: the `2` here is a stupidity-counter: by running it once manually with the wrong tag 1.24.1178
+        #        by accident and apple enforcing an increasing number scheme, we now have to add prefix them with `2`
+        #        until 2025 ...
+        run: echo "version=`date +1.%y.2%-m%d`" >> $GITHUB_OUTPUT
       - id: build_num
         run: echo "build_num=`date +%s`" >> $GITHUB_OUTPUT
 

--- a/app/ios/Flutter/AppFrameworkInfo.plist
+++ b/app/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>12.0</string>
 </dict>
 </plist>

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>12.0</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Take pictures to share in Acter.</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
fixes #1269 by bumping the internal OS version for iOS to `12.0`, which we appeared to be used by some internal dependencies. Additionally at trying to run this I accidentally submitted a too high version number an now we are forced to increase from that or get all apps rejected. That's what the second commit does ...