### PR TITLE
add Updates missing APIs

### DIFF
--- a/app/lib/features/news/pages/simple_post.dart
+++ b/app/lib/features/news/pages/simple_post.dart
@@ -84,7 +84,9 @@ class _SimpleNewsPostState extends ConsumerState<SimpleNewsPost> {
               NewsEntryDraft draft = space.newsDraft();
               if (file == null) {
                 final textDraft = client.textMarkdownDraft(caption.text);
+                final text2Draft = client.textMarkdownDraft('hello');
                 await draft.addSlide(textDraft);
+                await draft.insertSlide(1, text2Draft);
               } else {
                 String? mimeType = file.mimeType ?? lookupMimeType(file.path);
                 if (mimeType == null) {

--- a/app/lib/features/news/pages/simple_post.dart
+++ b/app/lib/features/news/pages/simple_post.dart
@@ -84,9 +84,7 @@ class _SimpleNewsPostState extends ConsumerState<SimpleNewsPost> {
               NewsEntryDraft draft = space.newsDraft();
               if (file == null) {
                 final textDraft = client.textMarkdownDraft(caption.text);
-                final text2Draft = client.textMarkdownDraft('hello');
                 await draft.addSlide(textDraft);
-                await draft.insertSlide(1, text2Draft);
               } else {
                 String? mimeType = file.mimeType ?? lookupMimeType(file.path);
                 if (mimeType == null) {

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -26,10 +26,6 @@ class NewsItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final slides = news.slides().toList();
-
-    debugPrint('SLIDES COUNT: ${news.slidesCount()}');
-
-    // else
     final bgColor = convertColor(
       news.colors()?.background(),
       Theme.of(context).colorScheme.background,
@@ -38,6 +34,7 @@ class NewsItem extends ConsumerWidget {
       news.colors()?.color(),
       Theme.of(context).colorScheme.primary,
     );
+
     return PageView.builder(
       scrollDirection: Axis.horizontal,
       itemCount: slides.length,

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -25,8 +25,9 @@ class NewsItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final slide = news.getSlide(0)!;
-    final slideType = slide.typeStr();
+    final slides = news.slides().toList();
+
+    debugPrint('SLIDES COUNT: ${news.slidesCount()}');
 
     // else
     final bgColor = convertColor(
@@ -37,85 +38,96 @@ class NewsItem extends ConsumerWidget {
       news.colors()?.color(),
       Theme.of(context).colorScheme.primary,
     );
+    return PageView.builder(
+      scrollDirection: Axis.horizontal,
+      itemCount: slides.length,
+      itemBuilder: (context, idx) {
+        final slideType = slides[idx].typeStr();
+        switch (slideType) {
+          case 'image':
+            return RegularSlide(
+              news: news,
+              index: index,
+              bgColor: bgColor,
+              fgColor: fgColor,
+              child: ImageSlide(slide: slides[idx]),
+            );
 
-    switch (slideType) {
-      case 'image':
-        return RegularSlide(
-          news: news,
-          index: index,
-          bgColor: bgColor,
-          fgColor: fgColor,
-          child: ImageSlide(slide: slide),
-        );
-
-      case 'video':
-        return RegularSlide(
-          news: news,
-          index: index,
-          bgColor: bgColor,
-          fgColor: fgColor,
-          child: const Expanded(
-            child: Center(
-              child: Text('video slides not yet supported'),
-            ),
-          ),
-        );
-
-      case 'text':
-        return Stack(
-          children: <Widget>[
-            Center(
-              child: Padding(
-                padding: const EdgeInsets.only(left: 8, right: 80, bottom: 8),
-                child: Card(
-                  color: bgColor,
-                  child: Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: slide.hasFormattedText()
-                        ? RenderHtml(
-                            key: NewsUpdateKeys.textUpdateContent,
-                            text: slide.text(),
-                            defaultTextStyle:
-                                Theme.of(context).textTheme.bodyLarge!.copyWith(
-                                      color: fgColor,
-                                    ),
-                          )
-                        : Text(
-                            key: NewsUpdateKeys.textUpdateContent,
-                            slide.text(),
-                            softWrap: true,
-                            style:
-                                Theme.of(context).textTheme.bodyLarge!.copyWith(
-                                      color: fgColor,
-                                    ),
-                          ),
-                  ),
+          case 'video':
+            return RegularSlide(
+              news: news,
+              index: index,
+              bgColor: bgColor,
+              fgColor: fgColor,
+              child: const Expanded(
+                child: Center(
+                  child: Text('video slides not yet supported'),
                 ),
               ),
-            ),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: NewsSideBar(
-                news: news,
-                index: index,
-              ),
-            ),
-          ],
-        );
+            );
 
-      default:
-        return RegularSlide(
-          news: news,
-          index: index,
-          bgColor: bgColor,
-          fgColor: fgColor,
-          child: Expanded(
-            child: Center(
-              child: Text('$slideType slides not yet supported'),
-            ),
-          ),
-        );
-    }
+          case 'text':
+            return Stack(
+              children: <Widget>[
+                Center(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.only(left: 8, right: 80, bottom: 8),
+                    child: Card(
+                      color: bgColor,
+                      child: Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: slides[idx].hasFormattedText()
+                            ? RenderHtml(
+                                key: NewsUpdateKeys.textUpdateContent,
+                                text: slides[idx].text(),
+                                defaultTextStyle: Theme.of(context)
+                                    .textTheme
+                                    .bodyLarge!
+                                    .copyWith(
+                                      color: fgColor,
+                                    ),
+                              )
+                            : Text(
+                                key: NewsUpdateKeys.textUpdateContent,
+                                slides[idx].text(),
+                                softWrap: true,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyLarge!
+                                    .copyWith(
+                                      color: fgColor,
+                                    ),
+                              ),
+                      ),
+                    ),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.bottomRight,
+                  child: NewsSideBar(
+                    news: news,
+                    index: index,
+                  ),
+                ),
+              ],
+            );
+
+          default:
+            return RegularSlide(
+              news: news,
+              index: index,
+              bgColor: bgColor,
+              fgColor: fgColor,
+              child: Expanded(
+                child: Center(
+                  child: Text('$slideType slides not yet supported'),
+                ),
+              ),
+            );
+        }
+      },
+    );
   }
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1882,6 +1882,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __newsEntryDraftInsertSlideFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _newsEntryDraftInsertSlideFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   EventId? __newsEntryDraftSendFuturePoll(
     int boxed,
     int postCobject,
@@ -12774,6 +12818,16 @@ class Api {
         int,
         int,
       )>();
+  late final _newsEntrySlidesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__NewsEntry_slides");
+
+  late final _newsEntrySlides = _newsEntrySlidesPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _newsEntryColorsPtr = _lookup<
       ffi.NativeFunction<
           _NewsEntryColorsReturn Function(
@@ -12846,6 +12900,21 @@ class Api {
         int,
         int,
       )>();
+  late final _newsEntryDraftInsertSlidePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Uint8,
+            ffi.Int64,
+          )>>("__NewsEntryDraft_insert_slide");
+
+  late final _newsEntryDraftInsertSlide =
+      _newsEntryDraftInsertSlidePtr.asFunction<
+          int Function(
+            int,
+            int,
+            int,
+          )>();
   late final _newsEntryDraftUnsetSlidesPtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -18190,16 +18259,6 @@ class Api {
       _SpaceNewsDraftReturn Function(
         int,
       )>();
-  late final _spaceNewsSlideDraftPtr = _lookup<
-      ffi.NativeFunction<
-          _SpaceNewsSlideDraftReturn Function(
-            ffi.Int64,
-          )>>("__Space_news_slide_draft");
-
-  late final _spaceNewsSlideDraft = _spaceNewsSlideDraftPtr.asFunction<
-      _SpaceNewsSlideDraftReturn Function(
-        int,
-      )>();
   late final _spacePinsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -21391,6 +21450,21 @@ class Api {
   late final _newsEntryDraftAddSlideFuturePoll =
       _newsEntryDraftAddSlideFuturePollPtr.asFunction<
           _NewsEntryDraftAddSlideFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _newsEntryDraftInsertSlideFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _NewsEntryDraftInsertSlideFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__NewsEntryDraft_insert_slide_future_poll");
+
+  late final _newsEntryDraftInsertSlideFuturePoll =
+      _newsEntryDraftInsertSlideFuturePollPtr.asFunction<
+          _NewsEntryDraftInsertSlideFuturePollReturn Function(
             int,
             int,
             int,
@@ -27838,6 +27912,22 @@ class NewsEntry {
     return tmp4;
   }
 
+  /// get all slides of this news item
+  FfiListNewsSlide slides() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._newsEntrySlides(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_FfiListNewsSlide");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp4 = FfiListNewsSlide._(_api, tmp3_1);
+    final tmp2 = tmp4;
+    return tmp2;
+  }
+
   /// The color setting
   Colorize? colors() {
     var tmp0 = 0;
@@ -27938,7 +28028,7 @@ class NewsEntryDraft {
 
   NewsEntryDraft._(this._api, this._box);
 
-  /// create news slide
+  /// create news slide draft
   Future<bool> addSlide(
     MsgContentDraft baseDraft,
   ) {
@@ -27957,6 +28047,34 @@ class NewsEntryDraft {
     tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
     final tmp4 = _nativeFuture(tmp5_1, _api.__newsEntryDraftAddSlideFuturePoll);
     return tmp4;
+  }
+
+  /// insert news slide draft at specific index
+  Future<bool> insertSlide(
+    int pos,
+    MsgContentDraft baseDraft,
+  ) {
+    final tmp1 = pos;
+    final tmp3 = baseDraft;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    tmp4 = tmp3._box.move();
+    final tmp5 = _api._newsEntryDraftInsertSlide(
+      tmp0,
+      tmp2,
+      tmp4,
+    );
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 =
+        _Box(_api, tmp7_0, "__NewsEntryDraft_insert_slide_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 =
+        _nativeFuture(tmp7_1, _api.__newsEntryDraftInsertSlideFuturePoll);
+    return tmp6;
   }
 
   /// clear slides
@@ -38299,37 +38417,6 @@ class Space {
     return tmp2;
   }
 
-  /// create news slide draft
-  NewsSlideDraft newsSlideDraft() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._spaceNewsSlideDraft(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    final tmp6 = tmp1.arg3;
-    final tmp7 = tmp1.arg4;
-    if (tmp3 == 0) {
-      debugAllocation("handle error", tmp4, tmp5);
-      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-      final tmp3_0 =
-          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
-      if (tmp5 > 0) {
-        final ffi.Pointer<ffi.Void> tmp4_0;
-        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-        _api.__deallocate(tmp4_0, tmp6, 1);
-      }
-      throw tmp3_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_NewsSlideDraft");
-    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp2 = NewsSlideDraft._(_api, tmp7_1);
-    return tmp2;
-  }
-
   /// the pins of this Space
   Future<FfiListActerPin> pins() {
     var tmp0 = 0;
@@ -46497,19 +46584,6 @@ class _SpaceNewsDraftReturn extends ffi.Struct {
   external int arg4;
 }
 
-class _SpaceNewsSlideDraftReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Int64()
-  external int arg4;
-}
-
 class _SpacePinDraftReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -47184,6 +47258,21 @@ class _NewsSlideSourceBinaryFuturePollReturn extends ffi.Struct {
 }
 
 class _NewsEntryDraftAddSlideFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
+class _NewsEntryDraftInsertSlideFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1882,50 +1882,6 @@ class Api {
     return tmp7;
   }
 
-  bool? __newsEntryDraftInsertSlideFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _newsEntryDraftInsertSlideFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
   EventId? __newsEntryDraftSendFuturePoll(
     int boxed,
     int postCobject,
@@ -12900,17 +12856,17 @@ class Api {
         int,
         int,
       )>();
-  late final _newsEntryDraftInsertSlidePtr = _lookup<
+  late final _newsEntryDraftSwapSlidesPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Int64 Function(
+          ffi.Void Function(
             ffi.Int64,
             ffi.Uint8,
-            ffi.Int64,
-          )>>("__NewsEntryDraft_insert_slide");
+            ffi.Uint8,
+          )>>("__NewsEntryDraft_swap_slides");
 
-  late final _newsEntryDraftInsertSlide =
-      _newsEntryDraftInsertSlidePtr.asFunction<
-          int Function(
+  late final _newsEntryDraftSwapSlides =
+      _newsEntryDraftSwapSlidesPtr.asFunction<
+          void Function(
             int,
             int,
             int,
@@ -21469,21 +21425,6 @@ class Api {
             int,
             int,
           )>();
-  late final _newsEntryDraftInsertSlideFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _NewsEntryDraftInsertSlideFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__NewsEntryDraft_insert_slide_future_poll");
-
-  late final _newsEntryDraftInsertSlideFuturePoll =
-      _newsEntryDraftInsertSlideFuturePollPtr.asFunction<
-          _NewsEntryDraftInsertSlideFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
   late final _newsEntryDraftSendFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _NewsEntryDraftSendFuturePollReturn Function(
@@ -28064,32 +28005,25 @@ class NewsEntryDraft {
     return tmp4;
   }
 
-  /// insert news slide draft at specific index
-  Future<bool> insertSlide(
-    int pos,
-    MsgContentDraft baseDraft,
+  /// change position of slides draft of this news entry
+  void swapSlides(
+    int from,
+    int to,
   ) {
-    final tmp1 = pos;
-    final tmp3 = baseDraft;
+    final tmp1 = from;
+    final tmp3 = to;
     var tmp0 = 0;
     var tmp2 = 0;
     var tmp4 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1;
-    tmp4 = tmp3._box.move();
-    final tmp5 = _api._newsEntryDraftInsertSlide(
+    tmp4 = tmp3;
+    _api._newsEntryDraftSwapSlides(
       tmp0,
       tmp2,
       tmp4,
     );
-    final tmp7 = tmp5;
-    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 =
-        _Box(_api, tmp7_0, "__NewsEntryDraft_insert_slide_future_drop");
-    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp6 =
-        _nativeFuture(tmp7_1, _api.__newsEntryDraftInsertSlideFuturePoll);
-    return tmp6;
+    return;
   }
 
   /// clear slides
@@ -47295,21 +47229,6 @@ class _NewsSlideSourceBinaryFuturePollReturn extends ffi.Struct {
 }
 
 class _NewsEntryDraftAddSlideFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Uint8()
-  external int arg5;
-}
-
-class _NewsEntryDraftInsertSlideFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -12959,15 +12959,15 @@ class Api {
       int Function(
         int,
       )>();
-  late final _newsEntryUpdateBuilderSlidesPtr = _lookup<
+  late final _newsEntryUpdateBuilderAddSlidePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.Int64,
             ffi.Int64,
-          )>>("__NewsEntryUpdateBuilder_slides");
+          )>>("__NewsEntryUpdateBuilder_add_slide");
 
-  late final _newsEntryUpdateBuilderSlides =
-      _newsEntryUpdateBuilderSlidesPtr.asFunction<
+  late final _newsEntryUpdateBuilderAddSlide =
+      _newsEntryUpdateBuilderAddSlidePtr.asFunction<
           void Function(
             int,
             int,
@@ -12992,6 +12992,21 @@ class Api {
   late final _newsEntryUpdateBuilderUnsetSlidesUpdate =
       _newsEntryUpdateBuilderUnsetSlidesUpdatePtr.asFunction<
           void Function(
+            int,
+          )>();
+  late final _newsEntryUpdateBuilderSwapSlidesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Uint8,
+            ffi.Uint8,
+          )>>("__NewsEntryUpdateBuilder_swap_slides");
+
+  late final _newsEntryUpdateBuilderSwapSlides =
+      _newsEntryUpdateBuilderSwapSlidesPtr.asFunction<
+          void Function(
+            int,
+            int,
             int,
           )>();
   late final _newsEntryUpdateBuilderColorsPtr = _lookup<
@@ -25300,55 +25315,6 @@ class Api {
 
   late final _ffiListNewsSlideInsert =
       _ffiListNewsSlideInsertPtr.asFunction<void Function(int, int, int)>();
-  FfiListNewsSlideDraft createFfiListNewsSlideDraft() {
-    final ffi.Pointer<ffi.Void> list_ptr =
-        ffi.Pointer.fromAddress(_ffiListNewsSlideDraftCreate());
-    final list_box = _Box(this, list_ptr, "drop_box_FfiListNewsSlideDraft");
-    return FfiListNewsSlideDraft._(this, list_box);
-  }
-
-  late final _ffiListNewsSlideDraftCreatePtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
-          "__FfiListNewsSlideDraftCreate");
-
-  late final _ffiListNewsSlideDraftCreate =
-      _ffiListNewsSlideDraftCreatePtr.asFunction<int Function()>();
-
-  late final _ffiListNewsSlideDraftLenPtr =
-      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.IntPtr)>>(
-          "__FfiListNewsSlideDraftLen");
-
-  late final _ffiListNewsSlideDraftLen =
-      _ffiListNewsSlideDraftLenPtr.asFunction<int Function(int)>();
-
-  late final _ffiListNewsSlideDraftElementAtPtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
-          "__FfiListNewsSlideDraftElementAt");
-
-  late final _ffiListNewsSlideDraftElementAt =
-      _ffiListNewsSlideDraftElementAtPtr.asFunction<int Function(int, int)>();
-
-  late final _ffiListNewsSlideDraftRemovePtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
-          "__FfiListNewsSlideDraftRemove");
-
-  late final _ffiListNewsSlideDraftRemove =
-      _ffiListNewsSlideDraftRemovePtr.asFunction<int Function(int, int)>();
-
-  late final _ffiListNewsSlideDraftAddPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
-          "__FfiListNewsSlideDraftAdd");
-
-  late final _ffiListNewsSlideDraftAdd =
-      _ffiListNewsSlideDraftAddPtr.asFunction<void Function(int, int)>();
-
-  late final _ffiListNewsSlideDraftInsertPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.IntPtr, ffi.Uint32,
-              ffi.IntPtr)>>("__FfiListNewsSlideDraftInsert");
-
-  late final _ffiListNewsSlideDraftInsert = _ffiListNewsSlideDraftInsertPtr
-      .asFunction<void Function(int, int, int)>();
   FfiListNotification createFfiListNotification() {
     final ffi.Pointer<ffi.Void> list_ptr =
         ffi.Pointer.fromAddress(_ffiListNotificationCreate());
@@ -28189,21 +28155,22 @@ class NewsEntryUpdateBuilder {
   NewsEntryUpdateBuilder._(this._api, this._box);
 
   /// set the slides for this news entry
-  void slides(
-    FfiListNewsSlideDraft slides,
+  void addSlide(
+    MsgContentDraft baseDraft,
   ) {
-    final tmp1 = slides;
+    final tmp1 = baseDraft;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1._box.move();
-    _api._newsEntryUpdateBuilderSlides(
+    _api._newsEntryUpdateBuilderAddSlide(
       tmp0,
       tmp2,
     );
     return;
   }
 
+  /// reset slides for this news entry
   void unsetSlides() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
@@ -28218,6 +28185,27 @@ class NewsEntryUpdateBuilder {
     tmp0 = _box.borrow();
     _api._newsEntryUpdateBuilderUnsetSlidesUpdate(
       tmp0,
+    );
+    return;
+  }
+
+  /// set position of slides for this news entry
+  void swapSlides(
+    int from,
+    int to,
+  ) {
+    final tmp1 = from;
+    final tmp3 = to;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    tmp4 = tmp3;
+    _api._newsEntryUpdateBuilderSwapSlides(
+      tmp0,
+      tmp2,
+      tmp4,
     );
     return;
   }
@@ -51138,67 +51126,6 @@ class FfiListNewsSlide extends Iterable<NewsSlide>
   /// Although you can use the "elementAt" method to get a reference to the added element
   void insert(int index, NewsSlide element) {
     _api._ffiListNewsSlideInsert(_box.borrow(), index, element._box.borrow());
-    element._box.move();
-  }
-
-  void drop() {
-    _box.drop();
-  }
-}
-
-class FfiListNewsSlideDraft extends Iterable<NewsSlideDraft>
-    implements CustomIterable<NewsSlideDraft> {
-  final Api _api;
-  final _Box _box;
-
-  FfiListNewsSlideDraft._(this._api, this._box);
-
-  @override
-  Iterator<NewsSlideDraft> get iterator => CustomIterator(this);
-
-  @override
-  int get length {
-    return _api._ffiListNewsSlideDraftLen(_box.borrow());
-  }
-
-  /// List object owns the elements, and objects returned by this method hold onto the list object ensuring the pointed to element isn/t dropped.
-  @override
-  NewsSlideDraft elementAt(int index) {
-    final address = _api._ffiListNewsSlideDraftElementAt(_box.borrow(), index);
-    final reference = _Box(
-      _api,
-      ffi.Pointer.fromAddress(address),
-      "drop_box_Leak",
-      context: this,
-    );
-    return NewsSlideDraft._(_api, reference);
-  }
-
-  NewsSlideDraft operator [](int index) {
-    return elementAt(index);
-  }
-
-  /// Moves the element out of this list and returns it
-  NewsSlideDraft remove(int index) {
-    final address = _api._ffiListNewsSlideDraftRemove(_box.borrow(), index);
-    final reference =
-        _Box(_api, ffi.Pointer.fromAddress(address), "drop_box_NewsSlideDraft");
-    reference._finalizer = _api._registerFinalizer(reference);
-    return NewsSlideDraft._(_api, reference);
-  }
-
-  /// The inserted element is moved into the list and must not be used again
-  /// Although you can use the "elementAt" method to get a reference to the added element
-  void add(NewsSlideDraft element) {
-    _api._ffiListNewsSlideDraftAdd(_box.borrow(), element._box.borrow());
-    element._box.move();
-  }
-
-  /// The inserted element is moved into the list and must not be used again
-  /// Although you can use the "elementAt" method to get a reference to the added element
-  void insert(int index, NewsSlideDraft element) {
-    _api._ffiListNewsSlideDraftInsert(
-        _box.borrow(), index, element._box.borrow());
     element._box.move();
   }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -18190,6 +18190,16 @@ class Api {
       _SpaceNewsDraftReturn Function(
         int,
       )>();
+  late final _spaceNewsSlideDraftPtr = _lookup<
+      ffi.NativeFunction<
+          _SpaceNewsSlideDraftReturn Function(
+            ffi.Int64,
+          )>>("__Space_news_slide_draft");
+
+  late final _spaceNewsSlideDraft = _spaceNewsSlideDraftPtr.asFunction<
+      _SpaceNewsSlideDraftReturn Function(
+        int,
+      )>();
   late final _spacePinsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -27766,6 +27776,18 @@ class NewsSlide {
     final tmp6 = _nativeFuture(tmp7_1, _api.__newsSlideSourceBinaryFuturePoll);
     return tmp6;
   }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class NewsSlideDraft {
+  final Api _api;
+  final _Box _box;
+
+  NewsSlideDraft._(this._api, this._box);
 
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
@@ -38277,6 +38299,37 @@ class Space {
     return tmp2;
   }
 
+  /// create news slide draft
+  NewsSlideDraft newsSlideDraft() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._spaceNewsSlideDraft(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    final tmp7 = tmp1.arg4;
+    if (tmp3 == 0) {
+      debugAllocation("handle error", tmp4, tmp5);
+      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      final tmp3_0 =
+          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
+      if (tmp5 > 0) {
+        final ffi.Pointer<ffi.Void> tmp4_0;
+        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+        _api.__deallocate(tmp4_0, tmp6, 1);
+      }
+      throw tmp3_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_NewsSlideDraft");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp2 = NewsSlideDraft._(_api, tmp7_1);
+    return tmp2;
+  }
+
   /// the pins of this Space
   Future<FfiListActerPin> pins() {
     var tmp0 = 0;
@@ -46432,6 +46485,19 @@ class _SpaceCalendarEventDraftReturn extends ffi.Struct {
 }
 
 class _SpaceNewsDraftReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Int64()
+  external int arg4;
+}
+
+class _SpaceNewsSlideDraftReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -25300,6 +25300,55 @@ class Api {
 
   late final _ffiListNewsSlideInsert =
       _ffiListNewsSlideInsertPtr.asFunction<void Function(int, int, int)>();
+  FfiListNewsSlideDraft createFfiListNewsSlideDraft() {
+    final ffi.Pointer<ffi.Void> list_ptr =
+        ffi.Pointer.fromAddress(_ffiListNewsSlideDraftCreate());
+    final list_box = _Box(this, list_ptr, "drop_box_FfiListNewsSlideDraft");
+    return FfiListNewsSlideDraft._(this, list_box);
+  }
+
+  late final _ffiListNewsSlideDraftCreatePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
+          "__FfiListNewsSlideDraftCreate");
+
+  late final _ffiListNewsSlideDraftCreate =
+      _ffiListNewsSlideDraftCreatePtr.asFunction<int Function()>();
+
+  late final _ffiListNewsSlideDraftLenPtr =
+      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.IntPtr)>>(
+          "__FfiListNewsSlideDraftLen");
+
+  late final _ffiListNewsSlideDraftLen =
+      _ffiListNewsSlideDraftLenPtr.asFunction<int Function(int)>();
+
+  late final _ffiListNewsSlideDraftElementAtPtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListNewsSlideDraftElementAt");
+
+  late final _ffiListNewsSlideDraftElementAt =
+      _ffiListNewsSlideDraftElementAtPtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftRemovePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListNewsSlideDraftRemove");
+
+  late final _ffiListNewsSlideDraftRemove =
+      _ffiListNewsSlideDraftRemovePtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftAddPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
+          "__FfiListNewsSlideDraftAdd");
+
+  late final _ffiListNewsSlideDraftAdd =
+      _ffiListNewsSlideDraftAddPtr.asFunction<void Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftInsertPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.IntPtr, ffi.Uint32,
+              ffi.IntPtr)>>("__FfiListNewsSlideDraftInsert");
+
+  late final _ffiListNewsSlideDraftInsert = _ffiListNewsSlideDraftInsertPtr
+      .asFunction<void Function(int, int, int)>();
   FfiListNotification createFfiListNotification() {
     final ffi.Pointer<ffi.Void> list_ptr =
         ffi.Pointer.fromAddress(_ffiListNotificationCreate());
@@ -28141,7 +28190,7 @@ class NewsEntryUpdateBuilder {
 
   /// set the slides for this news entry
   void slides(
-    FfiListNewsSlide slides,
+    FfiListNewsSlideDraft slides,
   ) {
     final tmp1 = slides;
     var tmp0 = 0;
@@ -51089,6 +51138,67 @@ class FfiListNewsSlide extends Iterable<NewsSlide>
   /// Although you can use the "elementAt" method to get a reference to the added element
   void insert(int index, NewsSlide element) {
     _api._ffiListNewsSlideInsert(_box.borrow(), index, element._box.borrow());
+    element._box.move();
+  }
+
+  void drop() {
+    _box.drop();
+  }
+}
+
+class FfiListNewsSlideDraft extends Iterable<NewsSlideDraft>
+    implements CustomIterable<NewsSlideDraft> {
+  final Api _api;
+  final _Box _box;
+
+  FfiListNewsSlideDraft._(this._api, this._box);
+
+  @override
+  Iterator<NewsSlideDraft> get iterator => CustomIterator(this);
+
+  @override
+  int get length {
+    return _api._ffiListNewsSlideDraftLen(_box.borrow());
+  }
+
+  /// List object owns the elements, and objects returned by this method hold onto the list object ensuring the pointed to element isn/t dropped.
+  @override
+  NewsSlideDraft elementAt(int index) {
+    final address = _api._ffiListNewsSlideDraftElementAt(_box.borrow(), index);
+    final reference = _Box(
+      _api,
+      ffi.Pointer.fromAddress(address),
+      "drop_box_Leak",
+      context: this,
+    );
+    return NewsSlideDraft._(_api, reference);
+  }
+
+  NewsSlideDraft operator [](int index) {
+    return elementAt(index);
+  }
+
+  /// Moves the element out of this list and returns it
+  NewsSlideDraft remove(int index) {
+    final address = _api._ffiListNewsSlideDraftRemove(_box.borrow(), index);
+    final reference =
+        _Box(_api, ffi.Pointer.fromAddress(address), "drop_box_NewsSlideDraft");
+    reference._finalizer = _api._registerFinalizer(reference);
+    return NewsSlideDraft._(_api, reference);
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void add(NewsSlideDraft element) {
+    _api._ffiListNewsSlideDraftAdd(_box.borrow(), element._box.borrow());
+    element._box.move();
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void insert(int index, NewsSlideDraft element) {
+    _api._ffiListNewsSlideDraftInsert(
+        _box.borrow(), index, element._box.borrow());
     element._box.move();
   }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -350,9 +350,14 @@ object NewsEntryDraft {
 
 object NewsEntryUpdateBuilder {
     /// set the slides for this news entry
-    fn slides(slides: Vec<NewsSlideDraft>);
+    fn add_slide(base_draft: MsgContentDraft);
+
+    /// reset slides for this news entry
     fn unset_slides();
     fn unset_slides_update();
+
+    /// set position of slides for this news entry
+    fn swap_slides(from: u8, to: u8);
 
     /// set the color for this news entry
     fn colors(colors: Colorize);

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -310,6 +310,8 @@ object NewsEntry {
     fn slides_count() -> u8;
     /// The slides belonging to this news item
     fn get_slide(pos: u8) -> Option<NewsSlide>;
+    /// get all slides of this news item
+    fn slides() -> Vec<NewsSlide>;
     /// The color setting
     fn colors() -> Option<Colorize>;
 
@@ -329,8 +331,11 @@ object NewsEntry {
 }
 
 object NewsEntryDraft {
-    /// create news slide
+    /// create news slide draft
     fn add_slide(base_draft: MsgContentDraft) -> Future<Result<bool>>;
+
+    /// insert news slide draft at specific index
+    fn insert_slide(pos: u8, base_draft: MsgContentDraft) -> Future<Result<bool>>;
 
     /// clear slides
     fn unset_slides();
@@ -1707,9 +1712,6 @@ object Space {
 
     /// create news draft
     fn news_draft() -> Result<NewsEntryDraft>;
-
-    /// create news slide draft
-    fn news_slide_draft() -> Result<NewsSlideDraft>;
 
     /// the pins of this Space
     fn pins() -> Future<Result<Vec<ActerPin>>>;

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -334,8 +334,8 @@ object NewsEntryDraft {
     /// create news slide draft
     fn add_slide(base_draft: MsgContentDraft) -> Future<Result<bool>>;
 
-    /// insert news slide draft at specific index
-    fn insert_slide(pos: u8, base_draft: MsgContentDraft) -> Future<Result<bool>>;
+    /// change position of slides draft of this news entry
+    fn swap_slides(from: u8, to:u8);
 
     /// clear slides
     fn unset_slides();

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -350,7 +350,7 @@ object NewsEntryDraft {
 
 object NewsEntryUpdateBuilder {
     /// set the slides for this news entry
-    fn slides(slides: Vec<NewsSlide>);
+    fn slides(slides: Vec<NewsSlideDraft>);
     fn unset_slides();
     fn unset_slides_update();
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -301,6 +301,10 @@ object NewsSlide {
     fn source_binary(thumb_size: Option<ThumbnailSize>) -> Future<Result<buffer<u8>>>;
 }
 
+object NewsSlideDraft {
+    
+}
+
 /// A news entry
 object NewsEntry {
     fn slides_count() -> u8;
@@ -1703,6 +1707,9 @@ object Space {
 
     /// create news draft
     fn news_draft() -> Result<NewsEntryDraft>;
+
+    /// create news slide draft
+    fn news_slide_draft() -> Result<NewsSlideDraft>;
 
     /// the pins of this Space
     fn pins() -> Future<Result<Vec<ActerPin>>>;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -83,7 +83,7 @@ pub use core::time::Duration as EfkDuration;
 pub use device::{DeviceChangedEvent, DeviceNewEvent};
 pub use invitation::Invitation;
 pub use message::{EventSendState, RoomEventItem, RoomMessage, RoomVirtualItem};
-pub use news::{NewsEntry, NewsEntryDraft, NewsEntryUpdateBuilder, NewsSlide};
+pub use news::{NewsEntry, NewsEntryDraft, NewsEntryUpdateBuilder, NewsSlide, NewsSlideDraft};
 pub use notifications::{Notification, NotificationListResult};
 pub use pins::{Pin as ActerPin, PinDraft, PinUpdateBuilder};
 pub use profile::{RoomProfile, UserProfile};

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -294,8 +294,6 @@ impl NewsSlide {
 
 #[derive(Clone)]
 pub struct NewsSlideDraft {
-    client: Client,
-    room: Room,
     content: news::NewsSlideBuilder,
 }
 
@@ -633,11 +631,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Text(text_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::TextMarkdown { body } => {
                 let text_content = TextMessageEventContent::markdown(body);
@@ -645,11 +639,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Text(text_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::Image { source, info } => {
                 let info = info.expect("image info needed");
@@ -683,11 +673,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Image(image_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::Audio { source, info } => {
                 let info = info.expect("audio info needed");
@@ -721,11 +707,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Audio(audio_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::Video { source, info } => {
                 let info = info.expect("image info needed");
@@ -759,11 +741,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Video(video_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::File {
                 source,
@@ -802,11 +780,7 @@ impl MsgContentDraft {
                     .content(NewsContent::File(file_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
             MsgContentDraft::Location {
                 body,
@@ -822,11 +796,7 @@ impl MsgContentDraft {
                     .content(NewsContent::Location(location_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft {
-                    client,
-                    room,
-                    content: builder,
-                })
+                Ok(NewsSlideDraft { content: builder })
             }
         }
     }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -6,7 +6,7 @@ use acter_core::{
     models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
-use anyhow::{bail, Context, Error, Ok, Result};
+use anyhow::{bail, Context, Result};
 use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
@@ -23,21 +23,17 @@ use ruma_events::room::{
     ImageInfo,
 };
 use std::{
-    any::Any,
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
     path::PathBuf,
-    thread::spawn,
 };
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::{wrappers::BroadcastStream, Stream};
 use tracing::{trace, warn};
 
-use crate::ClientStateBuilder;
-
 use super::{
     api::FfiBuffer,
-    client::{Client, ClientState},
+    client::Client,
     common::{MsgContent, ThumbnailSize},
     spaces::Space,
     stream::MsgContentDraft,

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -547,7 +547,7 @@ impl NewsEntryUpdateBuilder {
 
     pub fn swap_slides(&mut self, from: u8, to: u8) -> Result<&mut Self> {
         let content = self.content.build()?;
-        let mut slides = content.slides.clone().expect("content slides");
+        let mut slides = content.slides.expect("content slides");
         if to > slides.len() as u8 {
             bail!("upper bound is exceeded")
         }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -6,7 +6,7 @@ use acter_core::{
     models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
-use anyhow::{bail, Context, Ok, Result};
+use anyhow::{bail, Context, Result};
 use core::time::Duration;
 use futures::stream::StreamExt;
 use matrix_sdk::{
@@ -27,7 +27,6 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
     path::PathBuf,
-    result::Result as r_std,
     thread::spawn,
 };
 use tokio::sync::broadcast::Receiver;
@@ -536,7 +535,7 @@ impl NewsEntryUpdateBuilder {
 
         for slide in slides {
             match slide.to_owned().save() {
-                r_std::Ok(v) => news_slides.push(v),
+                Ok(v) => news_slides.push(v),
                 Err(e) => (),
             };
         }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -471,7 +471,7 @@ impl NewsEntryDraft {
                 anyhow::Ok(draft)
             })
             .await??;
-        if (!self.slides.is_empty() || self.slides.len() > 1) {
+        if (!self.slides.is_empty() && pos < self.slides.len() as u8) {
             self.slides.insert(pos as usize, inner)
         } else {
             self.slides.push(inner)

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -6,9 +6,9 @@ use acter_core::{
     models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
-use anyhow::{anyhow, bail, Context, Ok, Result};
+use anyhow::{bail, Context, Ok, Result};
 use core::time::Duration;
-use futures::{future::err, stream::StreamExt};
+use futures::stream::StreamExt;
 use matrix_sdk::{
     room::Room,
     ruma::{assign, UInt},

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::{wrappers::BroadcastStream, Stream};
-use tracing::{debug, trace, warn};
+use tracing::{trace, warn};
 
 use crate::ClientStateBuilder;
 


### PR DESCRIPTION
Refs: #793 -> Add Updates missing APIs and structs for front-end

- [x] Add ```NewsSlideDraft```, which is automatically created and pushed in draft list by ```fn add_slide()``` in ```NewsEntryDraft```.
- [x] Add ```fn insert_slide(pos: int)``` which can be used for adding and arranging slide drafts.
- [x] Expose ```fn colors()``` for ```NewsEntry```.
- [x] Add and expose ```fn slides()``` for fetching all slides of ```NewsEntry```. 
- [x] Updated flutter code to support horizontal scrolling on ```NewsEntry``` having more slides.
- [x] Added rust integration test for multiple slide draft send and fetch.
- [x] Fix ```NewsEntryUpdateBuilder``` for editing updates.

