### PR TITLE
Several improvements on loading

### DIFF
--- a/app/devtools_options.yaml
+++ b/app/devtools_options.yaml
@@ -1,0 +1,1 @@
+extensions:

--- a/app/lib/common/dialogs/invite_to_room_dialog.dart
+++ b/app/lib/common/dialogs/invite_to_room_dialog.dart
@@ -8,6 +8,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 final userNameRegExp = RegExp(
   r'@\S+:\S+.\S+$',
@@ -364,7 +365,7 @@ class _DirectInvite extends ConsumerWidget {
             invited: isInvited(userId, invited),
           ),
           error: (err, stackTrace) => Text('Error: $err'),
-          loading: () => const Text('Loading room'),
+          loading: () => const Skeletonizer(child: Text('Loading room')),
         ),
       ),
     );

--- a/app/lib/common/dialogs/invite_to_room_dialog.dart
+++ b/app/lib/common/dialogs/invite_to_room_dialog.dart
@@ -40,7 +40,7 @@ class FoundUser {
 
 final userAvatarProvider =
     FutureProvider.family<MemoryImage?, UserProfile>((ref, user) async {
-  if (await user.hasAvatar()) {
+  if (user.hasAvatar()) {
     try {
       final data = (await user.getAvatar(null)).data();
       if (data != null) {
@@ -51,11 +51,6 @@ final userAvatarProvider =
     }
   }
   return null;
-});
-
-final displayNameProvider =
-    FutureProvider.family<String?, UserProfile>((ref, user) async {
-  return (await user.getDisplayName()).text();
 });
 
 final searchResultProvider = FutureProvider<List<UserProfile>>((ref) async {
@@ -80,9 +75,9 @@ final suggestedUsersProvider =
   final suggested = (await client.suggestedUsersToInvite(roomId)).toList();
   final List<FoundUser> ret = [];
   for (final user in suggested) {
-    String? displayName = (await user.getDisplayName()).text();
+    String? displayName = user.getDisplayName();
     FfiBufferUint8? avatar;
-    if (await user.hasAvatar()) {
+    if (user.hasAvatar()) {
       try {
         avatar = (await user.getAvatar(null)).data();
       } catch (e) {

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -93,11 +93,11 @@ final memberProfileByInfoProvider =
 final memberProfileProvider =
     FutureProvider.family<ProfileData, Member>((ref, member) async {
   UserProfile profile = member.getProfile();
-  OptionString displayName = await profile.getDisplayName();
+  final displayName = profile.getDisplayName();
   final sdk = await ref.watch(sdkProvider.future);
   final size = sdk.newThumbSize(62, 60);
   final avatar = await profile.getAvatar(size);
-  return ProfileData(displayName.text(), avatar.data());
+  return ProfileData(displayName, avatar.data());
 });
 
 final memberProvider =

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -1,5 +1,6 @@
 /// Get the relations of the given SpaceId.  Throws
 library;
+
 import 'dart:core';
 
 import 'package:acter/common/models/profile_data.dart';
@@ -240,11 +241,11 @@ final userProfileDataProvider =
   final sdk = await ref.watch(sdkProvider.future);
   // this ensure we are staying up to dates on updates to convo
   final profile = member.getProfile();
-  final displayName = await profile.getDisplayName();
-  if (!await profile.hasAvatar()) {
-    return ProfileData(displayName.text(), null);
+  final displayName = profile.getDisplayName();
+  if (!profile.hasAvatar()) {
+    return ProfileData(displayName, null);
   }
   final size = sdk.newThumbSize(48, 48);
   final avatar = await profile.getAvatar(size);
-  return ProfileData(displayName.text(), avatar.data());
+  return ProfileData(displayName, avatar.data());
 });

--- a/app/lib/common/widgets/chat/convo_hierarchy_card.dart
+++ b/app/lib/common/widgets/chat/convo_hierarchy_card.dart
@@ -6,6 +6,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class ConvoHierarchyCard extends ConsumerWidget {
   final SpaceHierarchyRoomInfo space;
@@ -114,9 +115,11 @@ class ConvoHierarchyCard extends ConsumerWidget {
         title: Text('Error loading: $roomId'),
         subtitle: Text('$error'),
       ),
-      loading: () => ListTile(
-        title: Text(roomId),
-        subtitle: const Text('loading'),
+      loading: () => Skeletonizer(
+        child: ListTile(
+          title: Text(roomId),
+          subtitle: const Text('loading'),
+        ),
       ),
     );
   }

--- a/app/lib/common/widgets/member_list_entry.dart
+++ b/app/lib/common/widgets/member_list_entry.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class ChangePowerLevel extends StatefulWidget {
   final Member member;
@@ -558,10 +559,12 @@ class MemberListEntry extends ConsumerWidget {
           ),
           size: 18,
         ),
-        loading: () => ActerAvatar(
-          mode: DisplayMode.DM,
-          avatarInfo: AvatarInfo(uniqueId: userId),
-          size: 18,
+        loading: () => Skeletonizer(
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(uniqueId: userId),
+            size: 18,
+          ),
         ),
         error: (e, t) {
           debugPrint('loading avatar failed: $e');
@@ -578,9 +581,11 @@ class MemberListEntry extends ConsumerWidget {
           style: Theme.of(context).textTheme.bodyMedium,
           overflow: TextOverflow.ellipsis,
         ),
-        loading: () => Text(
-          userId,
-          style: Theme.of(context).textTheme.bodyMedium,
+        loading: () => Skeletonizer(
+          child: Text(
+            userId,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
         ),
         error: (e, s) {
           debugPrint('loading Profile failed $e');

--- a/app/lib/common/widgets/room/room_avatar_builder.dart
+++ b/app/lib/common/widgets/room/room_avatar_builder.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomAvatarBuilder extends ConsumerWidget {
   final String roomId;
@@ -38,10 +39,12 @@ class RoomAvatarBuilder extends ConsumerWidget {
           size: avatarSize,
         );
       },
-      loading: () => ActerAvatar(
-        mode: displayMode,
-        avatarInfo: AvatarInfo(uniqueId: roomId, displayName: roomId),
-        size: avatarSize,
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: displayMode,
+          avatarInfo: AvatarInfo(uniqueId: roomId, displayName: roomId),
+          size: avatarSize,
+        ),
       ),
     );
     if (padding != null) {

--- a/app/lib/common/widgets/spaces/select_space_form_field.dart
+++ b/app/lib/common/widgets/spaces/select_space_form_field.dart
@@ -3,6 +3,7 @@ import 'package:acter/features/home/widgets/space_chip.dart';
 import 'package:acter/common/widgets/spaces/space_selector_drawer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class SelectSpaceFormField extends ConsumerWidget {
   static Key openKey = const Key('select-space-form-field-open');
@@ -91,7 +92,9 @@ class SelectSpaceFormField extends ConsumerWidget {
       data: (space) =>
           space != null ? SpaceChip(space: space) : Text(currentSelectedSpace!),
       error: (e, s) => Text('error: $e'),
-      loading: () => const Text('loading'),
+      loading: () => const Skeletonizer(
+        child: Text('loading'),
+      ),
     );
   }
 }

--- a/app/lib/common/widgets/spaces/space_card.dart
+++ b/app/lib/common/widgets/spaces/space_card.dart
@@ -4,6 +4,7 @@ import 'package:acter/common/widgets/spaces/space_with_profile_card.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 typedef SubtitleFn = Widget? Function(Space);
 
@@ -141,9 +142,11 @@ class SpaceCard extends ConsumerWidget {
         title: Text('Error loading: $roomId'),
         subtitle: Text('$error'),
       ),
-      loading: () => ListTile(
-        title: Text(roomId),
-        subtitle: const Text('loading'),
+      loading: () => Skeletonizer(
+        child: ListTile(
+          title: Text(roomId),
+          subtitle: const Text('loading'),
+        ),
       ),
     );
   }

--- a/app/lib/common/widgets/spaces/space_hierarchy_card.dart
+++ b/app/lib/common/widgets/spaces/space_hierarchy_card.dart
@@ -7,6 +7,7 @@ import 'package:expandable_text/expandable_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomHierarchyJoinButtons extends ConsumerWidget {
   final Function(String)? forward;
@@ -193,9 +194,11 @@ class SpaceHierarchyCard extends ConsumerWidget {
         title: Text('Error loading: $roomId'),
         subtitle: Text('$error'),
       ),
-      loading: () => ListTile(
-        title: Text(roomId),
-        subtitle: const Text('loading'),
+      loading: () => Skeletonizer(
+        child: ListTile(
+          title: Text(roomId),
+          subtitle: const Text('loading'),
+        ),
       ),
     );
   }

--- a/app/lib/common/widgets/user_avatar.dart
+++ b/app/lib/common/widgets/user_avatar.dart
@@ -3,6 +3,7 @@ import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class UserAvatarWidget extends ConsumerWidget {
   final double size;
@@ -15,27 +16,27 @@ class UserAvatarWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final client = ref.watch(alwaysClientProvider);
+    final userId = client.userId().toString();
     final accountProfile = ref.watch(accountProfileProvider);
     return accountProfile.when(
-      data: (data) {
-        return Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ActerAvatar(
-              mode: DisplayMode.DM,
-              avatarInfo: AvatarInfo(
-                uniqueId: client.userId().toString(),
-                displayName: data.profile.displayName,
-                avatar: data.profile.getAvatarImage(),
-              ),
-              size: size,
-            ),
-          ],
-        );
-      },
+      data: (data) => ActerAvatar(
+        mode: DisplayMode.DM,
+        size: size,
+        avatarInfo: AvatarInfo(
+          uniqueId: userId,
+          displayName: data.profile.displayName,
+          avatar: data.profile.getAvatarImage(),
+        ),
+      ),
       error: (error, stackTrace) => const Text("Couldn't load avatar"),
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: DisplayMode.DM,
+          size: size,
+          avatarInfo: AvatarInfo(
+            uniqueId: userId,
+          ),
+        ),
       ),
     );
   }

--- a/app/lib/common/widgets/user_builder.dart
+++ b/app/lib/common/widgets/user_builder.dart
@@ -4,6 +4,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 final userAvatarProvider =
     FutureProvider.family<MemoryImage?, UserProfile>((ref, user) async {
@@ -66,7 +67,9 @@ class UserBuilder extends ConsumerWidget {
             invited: isInvited(userId, invited),
           ),
           error: (err, stackTrace) => Text('Error: $err'),
-          loading: () => const Text('Loading user'),
+          loading: () => const Skeletonizer(
+            child: Text('Loading user'),
+          ),
         ),
       ),
     );

--- a/app/lib/common/widgets/user_builder.dart
+++ b/app/lib/common/widgets/user_builder.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final userAvatarProvider =
     FutureProvider.family<MemoryImage?, UserProfile>((ref, user) async {
-  if (await user.hasAvatar()) {
+  if (user.hasAvatar()) {
     try {
       final data = (await user.getAvatar(null)).data();
       if (data != null) {
@@ -18,11 +18,6 @@ final userAvatarProvider =
     }
   }
   return null;
-});
-
-final displayNameProvider =
-    FutureProvider.family<String?, UserProfile>((ref, user) async {
-  return (await user.getDisplayName()).text();
 });
 
 bool isInvited(String userId, List<Member> invited) {
@@ -50,27 +45,17 @@ class UserBuilder extends ConsumerWidget {
     final invited =
         ref.watch(roomInvitedMembersProvider(roomId)).valueOrNull ?? [];
     final avatarProv = ref.watch(userAvatarProvider(profile));
-    final displayName = ref.watch(displayNameProvider(profile));
+    final displayName = profile.getDisplayName();
     final userId = profile.userId().toString();
     return Card(
       child: ListTile(
-        title: displayName.when(
-          data: (data) => Text(data ?? userId),
-          error: (err, stackTrace) => Text('Error: $err'),
-          loading: () => const Text('Loading display name'),
-        ),
-        subtitle: displayName.when(
-          data: (data) {
-            return (data == null) ? null : Text(userId);
-          },
-          error: (err, stackTrace) => Text('Error: $err'),
-          loading: () => const Text('Loading display name'),
-        ),
+        title: Text(displayName ?? userId),
+        subtitle: (displayName == null) ? null : Text(userId),
         leading: ActerAvatar(
           mode: DisplayMode.DM,
           avatarInfo: AvatarInfo(
             uniqueId: userId,
-            displayName: displayName.valueOrNull,
+            displayName: displayName,
             avatar: avatarProv.valueOrNull,
           ),
         ),

--- a/app/lib/features/activities/providers/invitations_providers.dart
+++ b/app/lib/features/activities/providers/invitations_providers.dart
@@ -16,7 +16,7 @@ final invitationProfileProvider =
   FfiBufferUint8? avatar;
   try {
     UserProfile profile = await invitation.getSenderProfile();
-    displayName = (await profile.getDisplayName()).text();
+    displayName = profile.getDisplayName();
     avatar = (await profile.getAvatar(null)).data();
   } catch (e) {
     debugPrint('failed to load profile: $e');

--- a/app/lib/features/activities/widgets/invitation_card.dart
+++ b/app/lib/features/activities/widgets/invitation_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class InvitationCard extends ConsumerWidget {
   final Invitation invitation;
@@ -77,7 +78,11 @@ class InvitationCard extends ConsumerWidget {
         );
       },
       error: (error, stackTrace) => const Text('Error loading invitation'),
-      loading: () => const CircularProgressIndicator(),
+      loading: () => const Skeletonizer(
+        child: Card(
+          child: ListTile(leading: Text('Something')),
+        ),
+      ),
     );
   }
 

--- a/app/lib/features/activities/widgets/notification_card.dart
+++ b/app/lib/features/activities/widgets/notification_card.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 final notificationSpaceDataProvider = FutureProvider.autoDispose
     .family<ProfileData, ffi.Notification>((ref, notification) async {
@@ -65,8 +66,13 @@ class NotificationCard extends ConsumerWidget {
                     size: 48,
                   );
                 },
-                loading: () => const Center(
-                  child: CircularProgressIndicator(),
+                loading: () => Skeletonizer(
+                  child: ActerAvatar(
+                    mode: DisplayMode.Space,
+                    avatarInfo:
+                        AvatarInfo(uniqueId: roomId, displayName: roomId),
+                    size: 48,
+                  ),
                 ),
               ),
             );
@@ -80,7 +86,9 @@ class NotificationCard extends ConsumerWidget {
               data: (value) => Text(value.displayName ?? roomId),
               error: (error, stackTrace) =>
                   Text('Failed to load space Text(roomId)due to $error'),
-              loading: () => Text(roomId),
+              loading: () => Skeletonizer(
+                child: Text(roomId),
+              ),
             );
           },
         );
@@ -115,8 +123,13 @@ class NotificationCard extends ConsumerWidget {
                     size: 48,
                   );
                 },
-                loading: () => const Center(
-                  child: CircularProgressIndicator(),
+                loading: () => Skeletonizer(
+                  child: ActerAvatar(
+                    mode: DisplayMode.Space,
+                    avatarInfo:
+                        AvatarInfo(uniqueId: roomId, displayName: roomId),
+                    size: 48,
+                  ),
                 ),
               ),
             );
@@ -130,7 +143,9 @@ class NotificationCard extends ConsumerWidget {
               data: (value) => Text(value.displayName ?? roomId),
               error: (error, stackTrace) =>
                   Text('Failed to load room due to $error'),
-              loading: () => Text(roomId),
+              loading: () => Skeletonizer(
+                child: Text(roomId),
+              ),
             );
           },
         );

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -24,6 +24,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomPage extends ConsumerWidget {
   static const roomPageKey = Key('chat-room-page');
@@ -157,7 +158,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
                       error: (error, stackTrace) => Text(
                         'Error loading profile $error',
                       ),
-                      loading: () => const CircularProgressIndicator(),
+                      loading: () => const Skeletonizer(child: Text('loading')),
                     ),
                     const SizedBox(height: 5),
                     activeMembers.when(
@@ -171,7 +172,11 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
                       skipLoadingOnReload: false,
                       error: (error, stackTrace) =>
                           Text('Error loading members count $error'),
-                      loading: () => const CircularProgressIndicator(),
+                      loading: () => Skeletonizer(
+                        child: Text(
+                          '100 ${AppLocalizations.of(context)!.members}',
+                        ),
+                      ),
                     ),
                   ],
                 ),

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -17,6 +17,7 @@ import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:settings_ui/settings_ui.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomProfilePage extends ConsumerWidget {
   final String roomId;
@@ -46,7 +47,11 @@ class RoomProfilePage extends ConsumerWidget {
         );
       },
       error: (error, stackTrace) => Text('Error loading members count $error'),
-      loading: () => const CircularProgressIndicator(),
+      loading: () => const Skeletonizer(
+        child: Text(
+          '100 members',
+        ),
+      ),
     );
 
     return Scaffold(
@@ -105,7 +110,7 @@ class RoomProfilePage extends ConsumerWidget {
                       style: Theme.of(context).textTheme.titleSmall,
                     );
                   },
-                  loading: () => const CircularProgressIndicator(),
+                  loading: () => Skeletonizer(child: Text(roomId)),
                 ),
               ],
             ),
@@ -119,7 +124,7 @@ class RoomProfilePage extends ConsumerWidget {
                   defaultTextStyle: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
-              loading: () => const Text('loading...'),
+              loading: () => const Skeletonizer(child: Text('loading...')),
               error: (e, s) => Text('Error: $e'),
             ),
           ),
@@ -190,7 +195,7 @@ class RoomProfilePage extends ConsumerWidget {
                         title: Text('Error loading tile due to $e'),
                       ),
                       loading: () => SettingsTile(
-                        title: const Text('Loading'),
+                        title: const Skeletonizer(child: Text('Loading')),
                       ),
                     ),
                     SettingsTile(
@@ -205,7 +210,9 @@ class RoomProfilePage extends ConsumerWidget {
                             title: topMenu,
                             description: convo.when(
                               data: (data) => MemberList(convo: data),
-                              loading: () => const Text('loading...'),
+                              loading: () => const Skeletonizer(
+                                child: Text('loading...'),
+                              ),
                               error: (e, s) => Text('Error: $e'),
                             ),
                           ),

--- a/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
@@ -226,7 +226,7 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
       String userId = activeMembers[i].userId().toString();
       final profile = activeMembers[i].getProfile();
       Map<String, String> record = {};
-      final userName = (await profile.getDisplayName()).text();
+      final userName = (profile.getDisplayName());
       record['display'] = userName ?? simplifyUserId(userId)!;
       record['link'] = userId;
       mentionRecords.add(record);

--- a/app/lib/features/chat/widgets/avatar_builder.dart
+++ b/app/lib/features/chat/widgets/avatar_builder.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class AvatarBuilder extends ConsumerWidget {
   final String roomId;
@@ -43,12 +44,14 @@ class AvatarBuilder extends ConsumerWidget {
           ),
         );
       },
-      loading: () => Padding(
-        padding: const EdgeInsets.only(right: 10),
-        child: ActerAvatar(
-          mode: DisplayMode.DM,
-          avatarInfo: AvatarInfo(uniqueId: userId, displayName: userId),
-          size: 14,
+      loading: () => Skeletonizer(
+        child: Padding(
+          padding: const EdgeInsets.only(right: 10),
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(uniqueId: userId, displayName: userId),
+            size: 14,
+          ),
         ),
       ),
     );

--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -15,6 +15,7 @@ import 'package:bubble/bubble.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 import 'package:swipe_to/swipe_to.dart';
 
 class BubbleBuilder extends ConsumerWidget {
@@ -255,7 +256,13 @@ class _ChatBubble extends ConsumerWidget {
               size: 24,
             );
           },
-          loading: () => const CircularProgressIndicator(),
+          loading: () => Skeletonizer(
+            child: ActerAvatar(
+              mode: DisplayMode.DM,
+              avatarInfo: AvatarInfo(uniqueId: authorId),
+              size: 24,
+            ),
+          ),
         ),
         const SizedBox(width: 5),
         replyProfile.when(
@@ -269,7 +276,7 @@ class _ChatBubble extends ConsumerWidget {
             debugPrint('Failed to load profile due to $err');
             return const Text('');
           },
-          loading: () => const CircularProgressIndicator(),
+          loading: () => Skeletonizer(child: Text(authorId)),
         ),
       ],
     );

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -278,8 +278,8 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
                       builder: (context, ref, child) {
                         final avatarProv =
                             ref.watch(userAvatarProvider(selectedUsers[index]));
-                        final displayName = ref
-                            .watch(displayNameProvider(selectedUsers[index]));
+                        final displayName =
+                            selectedUsers[index].getDisplayName();
                         final userId = selectedUsers[index].userId().toString();
                         return Row(
                           mainAxisSize: MainAxisSize.min,
@@ -288,14 +288,14 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
                               mode: DisplayMode.DM,
                               avatarInfo: AvatarInfo(
                                 uniqueId: userId,
-                                displayName: displayName.valueOrNull ?? userId,
+                                displayName: displayName ?? userId,
                                 avatar: avatarProv.valueOrNull,
                               ),
                               size: 14,
                             ),
                             const SizedBox(width: 5),
                             Text(
-                              displayName.valueOrNull ?? userId,
+                              displayName ?? userId,
                               style: Theme.of(context)
                                   .textTheme
                                   .labelMedium!
@@ -390,9 +390,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
                         mode: DisplayMode.DM,
                         avatarInfo: AvatarInfo(
                           uniqueId: selectedUsers[0].userId().toString(),
-                          displayName: ref
-                              .watch(displayNameProvider(selectedUsers[0]))
-                              .valueOrNull,
+                          displayName: selectedUsers[0].getDisplayName(),
                           avatar: ref
                               .watch(userAvatarProvider(selectedUsers[0]))
                               .valueOrNull,
@@ -692,7 +690,7 @@ class _UserWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final avatarProv = ref.watch(userAvatarProvider(profile));
-    final displayName = ref.watch(displayNameProvider(profile));
+    final displayName = profile.getDisplayName();
     final userId = profile.userId().toString();
     return ListTile(
       onTap: () {
@@ -704,35 +702,25 @@ class _UserWidget extends ConsumerWidget {
         }
         onUp();
       },
-      title: displayName.when(
-        data: (data) => Text(
-          data ?? userId,
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
-        error: (err, stackTrace) => Text('Error: $err'),
-        loading: () => const Text('Loading display name'),
+      title: Text(
+        displayName ?? userId,
+        style: Theme.of(context).textTheme.bodyMedium,
       ),
-      subtitle: displayName.when(
-        data: (data) {
-          return (data == null)
-              ? null
-              : Text(
-                  userId,
-                  style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.neutral5,
-                      ),
-                );
-        },
-        error: (err, stackTrace) => Text('Error: $err'),
-        loading: () => const Text('Loading display name'),
-      ),
+      subtitle: (displayName == null)
+          ? null
+          : Text(
+              userId,
+              style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                    color: Theme.of(context).colorScheme.neutral5,
+                  ),
+            ),
       leading: avatarProv.when(
         data: (data) {
           return ActerAvatar(
             mode: DisplayMode.DM,
             avatarInfo: AvatarInfo(
               uniqueId: userId,
-              displayName: displayName.valueOrNull,
+              displayName: displayName,
               avatar: data,
             ),
             size: 18,

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 /// saves selected users from search result
 final _selectedUsersProvider =
@@ -727,7 +728,13 @@ class _UserWidget extends ConsumerWidget {
           );
         },
         error: (e, st) => Text('Error loading avatar $e'),
-        loading: () => const CircularProgressIndicator(),
+        loading: () => Skeletonizer(
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(uniqueId: userId),
+            size: 18,
+          ),
+        ),
       ),
     );
   }

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -29,6 +29,7 @@ import 'package:html/parser.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart' show toBeginningOfSentenceCase;
 import 'package:mime/mime.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 enum ChatAttachmentType { camera, image, audio, video, file }
 
@@ -691,7 +692,13 @@ class _CustomChatInputState extends ConsumerState<CustomChatInput> {
               size: 24,
             );
           },
-          loading: () => const CircularProgressIndicator(),
+          loading: () => Skeletonizer(
+            child: ActerAvatar(
+              mode: DisplayMode.DM,
+              avatarInfo: AvatarInfo(uniqueId: authorId),
+              size: 24,
+            ),
+          ),
         ),
         const SizedBox(width: 5),
         Text(

--- a/app/lib/features/chat/widgets/emoji_reaction_item.dart
+++ b/app/lib/features/chat/widgets/emoji_reaction_item.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class EmojiReactionItem extends ConsumerWidget {
   final List<String> emojis;
@@ -31,7 +32,13 @@ class EmojiReactionItem extends ConsumerWidget {
           ),
           size: 18,
         ),
-        loading: () => const Text('loading'),
+        loading: () => Skeletonizer(
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(uniqueId: userId),
+            size: 24,
+          ),
+        ),
         error: (e, t) {
           debugPrint('loading avatar failed: $e');
           return ActerAvatar(
@@ -43,7 +50,7 @@ class EmojiReactionItem extends ConsumerWidget {
       ),
       title: profile.when(
         data: (data) => Text(data.displayName ?? userId),
-        loading: () => Text(userId),
+        loading: () => Skeletonizer(child: Text(userId)),
         error: (e, s) => Text('loading profile failed: $e'),
       ),
       subtitle: Text(userId),

--- a/app/lib/features/chat/widgets/mention_profile_builder.dart
+++ b/app/lib/features/chat/widgets/mention_profile_builder.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class MentionProfileBuilder extends ConsumerWidget {
   final String roomId;
@@ -37,7 +38,13 @@ class MentionProfileBuilder extends ConsumerWidget {
           size: 18,
         );
       },
-      loading: () => const CircularProgressIndicator(),
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: DisplayMode.DM,
+          avatarInfo: AvatarInfo(uniqueId: authorId),
+          size: 18,
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/chat/widgets/room_avatar.dart
+++ b/app/lib/features/chat/widgets/room_avatar.dart
@@ -5,6 +5,7 @@ import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomAvatar extends ConsumerWidget {
   final String roomId;
@@ -86,17 +87,23 @@ class RoomAvatar extends ConsumerWidget {
       },
       skipLoadingOnReload: false,
       error: (err, stackTrace) {
-        debugPrint('Failed to load avatar due to $err');
+        debugPrint('Failed to load avatar due to $err, $stackTrace');
         return ActerAvatar(
           mode: convo.isDm() ? DisplayMode.DM : DisplayMode.GroupChat,
           avatarInfo: AvatarInfo(
-            uniqueId: convo.getRoomIdStr(),
-            displayName: convo.getRoomIdStr(),
+            uniqueId: roomId,
+            displayName: roomId,
           ),
           size: avatarSize,
         );
       },
-      loading: () => const CircularProgressIndicator(),
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: DisplayMode.DM,
+          avatarInfo: AvatarInfo(uniqueId: roomId),
+          size: 24,
+        ),
+      ),
     );
   }
 
@@ -132,11 +139,12 @@ class RoomAvatar extends ConsumerWidget {
 
   Widget memberAvatar(Member member, WidgetRef ref) {
     final memberProfile = ref.watch(memberProfileProvider(member));
+    final userId = member.userId().toString();
     return memberProfile.when(
       data: (data) => ActerAvatar(
         mode: DisplayMode.DM,
         avatarInfo: AvatarInfo(
-          uniqueId: member.userId().toString(),
+          uniqueId: userId,
           displayName: data.displayName,
           avatar: data.getAvatarImage(),
         ),
@@ -147,14 +155,17 @@ class RoomAvatar extends ConsumerWidget {
         return ActerAvatar(
           mode: DisplayMode.DM,
           avatarInfo: AvatarInfo(
-            uniqueId: member.userId().toString(),
-            displayName: member.userId().toString(),
+            uniqueId: userId,
           ),
           size: avatarSize,
         );
       },
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: DisplayMode.DM,
+          avatarInfo: AvatarInfo(uniqueId: userId),
+          size: avatarSize,
+        ),
       ),
     );
   }
@@ -191,7 +202,13 @@ class RoomAvatar extends ConsumerWidget {
           size: avatarSize / 2,
         );
       },
-      loading: () => const CircularProgressIndicator(),
+      loading: () => Skeletonizer(
+        child: ActerAvatar(
+          mode: DisplayMode.GroupDM,
+          avatarInfo: AvatarInfo(uniqueId: userId),
+          size: avatarSize / 2,
+        ),
+      ),
       error: (err, st) {
         debugPrint('Couldn\'t load group Avatar');
         return ActerAvatar(

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -40,12 +40,7 @@ class AsyncCalendarEventNotifier
 
   Future<ffi.CalendarEvent> _getCalendarEvent() async {
     final client = ref.watch(alwaysClientProvider);
-    try {
-      return await client.calendarEvent(arg);
-    } catch (e) {
-      return await client.waitForCalendarEvent(arg, null);
-    }
-    // this might throw internally
+    return await client.waitForCalendarEvent(arg, null);
   }
 
   @override

--- a/app/lib/features/home/widgets/space_chip.dart
+++ b/app/lib/features/home/widgets/space_chip.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class SpaceChip extends ConsumerWidget {
   final SpaceItem? space;
@@ -25,12 +26,25 @@ class SpaceChip extends ConsumerWidget {
         error: (error, st) => Chip(
           label: Text('Loading failed: $error'),
         ),
-        loading: () => const Chip(
-          label: Text('loading'),
-        ),
+        loading: () => renderLoading(spaceId!),
       );
     }
     return renderSpace(space!);
+  }
+
+  Widget renderLoading(String spaceId) {
+    return Skeletonizer(
+      child: Chip(
+        avatar: ActerAvatar(
+          mode: DisplayMode.Space,
+          avatarInfo: AvatarInfo(
+            uniqueId: spaceId,
+          ),
+          size: 24,
+        ),
+        label: Text(spaceId),
+      ),
+    );
   }
 
   Widget renderSpace(space) {

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -10,6 +10,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class NewsItem extends ConsumerWidget {
   final Client client;
@@ -160,7 +161,9 @@ class RegularSlide extends ConsumerWidget {
                   data: (space) =>
                       Text(space!.spaceProfileData.displayName ?? roomId),
                   error: (e, st) => Text('Error loading space: $e'),
-                  loading: () => Text(roomId),
+                  loading: () => Skeletonizer(
+                    child: Text(roomId),
+                  ),
                 ),
               ),
               Text(

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -14,6 +14,7 @@ import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class NewsSideBar extends ConsumerWidget {
   final ffi.NewsEntry news;
@@ -109,7 +110,13 @@ class NewsSideBar extends ConsumerWidget {
               size: 42,
             );
           },
-          loading: () => const Text('l'),
+          loading: () => Skeletonizer(
+            child: ActerAvatar(
+              mode: DisplayMode.Space,
+              avatarInfo: AvatarInfo(uniqueId: roomId),
+              size: 42,
+            ),
+          ),
         ),
         const SizedBox(height: 15),
       ],

--- a/app/lib/features/space/widgets/member_avatar.dart
+++ b/app/lib/features/space/widgets/member_avatar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_avatar/acter_avatar.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class MemberAvatar extends ConsumerWidget {
   final Member member;
@@ -40,8 +41,12 @@ class MemberAvatar extends ConsumerWidget {
             size: 18,
           );
         },
-        loading: () => const Center(
-          child: CircularProgressIndicator(),
+        loading: () => Skeletonizer(
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(uniqueId: userId),
+            size: 18,
+          ),
         ),
       ),
     );

--- a/app/lib/features/space/widgets/space_header_profile.dart
+++ b/app/lib/features/space/widgets/space_header_profile.dart
@@ -7,6 +7,7 @@ import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class SpaceHeaderProfile extends ConsumerWidget {
   static const headerKey = Key('space-header');
@@ -127,7 +128,20 @@ class SpaceHeaderProfile extends ConsumerWidget {
         );
       },
       error: (error, stack) => Text('Loading members failed: $error'),
-      loading: () => const CircularProgressIndicator(),
+      loading: () => const Skeletonizer(
+        child: Wrap(
+          direction: Axis.horizontal,
+          spacing: -12,
+          children: [
+            CircleAvatar(child: Text('0')),
+            CircleAvatar(child: Text('1')),
+            CircleAvatar(child: Text('2')),
+            CircleAvatar(child: Text('3')),
+            CircleAvatar(child: Text('4')),
+            CircleAvatar(child: Text('5')),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/tasks/providers/tasklists.dart
+++ b/app/lib/features/tasks/providers/tasklists.dart
@@ -1,6 +1,7 @@
 import 'dart:core';
 
 import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter/features/tasks/providers/notifiers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -27,21 +28,15 @@ class AsyncTaskListsNotifier extends AsyncNotifier<List<TaskList>> {
   }
 }
 
-final taskListProvider = FutureProvider.autoDispose
-    .family<TaskList, String>((ref, taskListId) async {
-  final lists = await ref.watch(tasksListsProvider.future);
-  for (final list in lists) {
-    if (list.eventIdStr() == taskListId) {
-      return list;
-    }
-  }
-  throw 'Task List not found';
-});
+final taskListProvider =
+    AsyncNotifierProvider.family<TaskListNotifier, TaskList, String>(
+  () => TaskListNotifier(),
+);
 
 final tasksListsProvider =
-    AsyncNotifierProvider<AsyncTaskListsNotifier, List<TaskList>>(() {
-  return AsyncTaskListsNotifier();
-});
+    AsyncNotifierProvider<AsyncTaskListsNotifier, List<TaskList>>(
+  () => AsyncTaskListsNotifier(),
+);
 
 final spaceTasksListsProvider =
     FutureProvider.family<List<TaskList>, String>((ref, spaceId) async {

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1558,50 +1558,6 @@ class Api {
     return tmp7;
   }
 
-  bool? __userProfileHasAvatarFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _userProfileHasAvatarFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
   OptionBuffer? __userProfileGetAvatarFuturePoll(
     int boxed,
     int postCobject,
@@ -1646,53 +1602,6 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_OptionBuffer");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = OptionBuffer._(this, tmp13_1);
-    return tmp7;
-  }
-
-  OptionString? __userProfileGetDisplayNameFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _userProfileGetDisplayNameFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_OptionString");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp7 = OptionString._(this, tmp13_1);
     return tmp7;
   }
 
@@ -12374,7 +12283,7 @@ class Api {
       )>();
   late final _userProfileHasAvatarPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Int64 Function(
+          ffi.Uint8 Function(
             ffi.Int64,
           )>>("__UserProfile_has_avatar");
 
@@ -12398,23 +12307,23 @@ class Api {
       )>();
   late final _userProfileGetDisplayNamePtr = _lookup<
       ffi.NativeFunction<
-          ffi.Int64 Function(
+          _UserProfileGetDisplayNameReturn Function(
             ffi.Int64,
           )>>("__UserProfile_get_display_name");
 
   late final _userProfileGetDisplayName =
       _userProfileGetDisplayNamePtr.asFunction<
-          int Function(
+          _UserProfileGetDisplayNameReturn Function(
             int,
           )>();
   late final _roomProfileHasAvatarPtr = _lookup<
       ffi.NativeFunction<
-          _RoomProfileHasAvatarReturn Function(
+          ffi.Uint8 Function(
             ffi.Int64,
           )>>("__RoomProfile_has_avatar");
 
   late final _roomProfileHasAvatar = _roomProfileHasAvatarPtr.asFunction<
-      _RoomProfileHasAvatarReturn Function(
+      int Function(
         int,
       )>();
   late final _roomProfileGetAvatarPtr = _lookup<
@@ -21270,21 +21179,6 @@ class Api {
             int,
             int,
           )>();
-  late final _userProfileHasAvatarFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _UserProfileHasAvatarFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__UserProfile_has_avatar_future_poll");
-
-  late final _userProfileHasAvatarFuturePoll =
-      _userProfileHasAvatarFuturePollPtr.asFunction<
-          _UserProfileHasAvatarFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
   late final _userProfileGetAvatarFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _UserProfileGetAvatarFuturePollReturn Function(
@@ -21296,21 +21190,6 @@ class Api {
   late final _userProfileGetAvatarFuturePoll =
       _userProfileGetAvatarFuturePollPtr.asFunction<
           _UserProfileGetAvatarFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
-  late final _userProfileGetDisplayNameFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _UserProfileGetDisplayNameFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__UserProfile_get_display_name_future_poll");
-
-  late final _userProfileGetDisplayNameFuturePoll =
-      _userProfileGetDisplayNameFuturePollPtr.asFunction<
-          _UserProfileGetDisplayNameFuturePollReturn Function(
             int,
             int,
             int,
@@ -26756,17 +26635,14 @@ class UserProfile {
   }
 
   /// whether to have avatar
-  Future<bool> hasAvatar() {
+  bool hasAvatar() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._userProfileHasAvatar(
       tmp0,
     );
     final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(_api, tmp3_0, "__UserProfile_has_avatar_future_drop");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = _nativeFuture(tmp3_1, _api.__userProfileHasAvatarFuturePoll);
+    final tmp2 = tmp3 > 0;
     return tmp2;
   }
 
@@ -26802,19 +26678,36 @@ class UserProfile {
   }
 
   /// get the display name
-  Future<OptionString> getDisplayName() {
+  String? getDisplayName() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._userProfileGetDisplayName(
       tmp0,
     );
-    final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 =
-        _Box(_api, tmp3_0, "__UserProfile_get_display_name_future_drop");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 =
-        _nativeFuture(tmp3_1, _api.__userProfileGetDisplayNameFuturePoll);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
     return tmp2;
   }
 
@@ -26837,24 +26730,8 @@ class RoomProfile {
     final tmp1 = _api._roomProfileHasAvatar(
       tmp0,
     );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    final tmp6 = tmp1.arg3;
-    final tmp7 = tmp1.arg4;
-    if (tmp3 == 0) {
-      debugAllocation("handle error", tmp4, tmp5);
-      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-      final tmp3_0 =
-          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
-      if (tmp5 > 0) {
-        final ffi.Pointer<ffi.Void> tmp4_0;
-        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-        _api.__deallocate(tmp4_0, tmp6, 1);
-      }
-      throw tmp3_0;
-    }
-    final tmp2 = tmp7 > 0;
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
     return tmp2;
   }
 
@@ -44973,7 +44850,7 @@ class _OptionBufferDataReturn extends ffi.Struct {
   external int arg1;
 }
 
-class _RoomProfileHasAvatarReturn extends ffi.Struct {
+class _UserProfileGetDisplayNameReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()
@@ -44982,8 +44859,6 @@ class _RoomProfileHasAvatarReturn extends ffi.Struct {
   external int arg2;
   @ffi.Uint64()
   external int arg3;
-  @ffi.Uint8()
-  external int arg4;
 }
 
 class _ReceiptThreadThreadIdReturn extends ffi.Struct {
@@ -46973,37 +46848,7 @@ class _DestroyLocalDataFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _UserProfileHasAvatarFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Uint8()
-  external int arg5;
-}
-
 class _UserProfileGetAvatarFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Int64()
-  external int arg5;
-}
-
-class _UserProfileGetDisplayNameFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -19584,16 +19584,6 @@ class Api {
         int,
         int,
       )>();
-  late final _clientGetUserProfilePtr = _lookup<
-      ffi.NativeFunction<
-          _ClientGetUserProfileReturn Function(
-            ffi.Int64,
-          )>>("__Client_get_user_profile");
-
-  late final _clientGetUserProfile = _clientGetUserProfilePtr.asFunction<
-      _ClientGetUserProfileReturn Function(
-        int,
-      )>();
   late final _clientUploadMediaPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -41186,37 +41176,6 @@ class Client {
     return tmp6;
   }
 
-  /// get the user profile that contains avatar and display name
-  UserProfile getUserProfile() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._clientGetUserProfile(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    final tmp6 = tmp1.arg3;
-    final tmp7 = tmp1.arg4;
-    if (tmp3 == 0) {
-      debugAllocation("handle error", tmp4, tmp5);
-      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-      final tmp3_0 =
-          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
-      if (tmp5 > 0) {
-        final ffi.Pointer<ffi.Void> tmp4_0;
-        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-        _api.__deallocate(tmp4_0, tmp6, 1);
-      }
-      throw tmp3_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_UserProfile");
-    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp2 = UserProfile._(_api, tmp7_1);
-    return tmp2;
-  }
-
   /// upload file and return remote url
   Future<MxcUri> uploadMedia(
     String uri,
@@ -46785,19 +46744,6 @@ class _ClientUserIdReturn extends ffi.Struct {
 }
 
 class _ClientDmWithUserReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Int64()
-  external int arg4;
-}
-
-class _ClientGetUserProfileReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -9092,7 +9092,7 @@ class Api {
     return tmp7;
   }
 
-  TaskList? __clientWaitForTaskListFuturePoll(
+  TaskList? __clientTaskListFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -9106,7 +9106,7 @@ class Api {
     tmp1 = tmp0;
     tmp3 = tmp2;
     tmp5 = tmp4;
-    final tmp6 = _clientWaitForTaskListFuturePoll(
+    final tmp6 = _clientTaskListFuturePoll(
       tmp1,
       tmp3,
       tmp5,
@@ -9231,53 +9231,6 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_Task");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = Task._(this, tmp13_1);
-    return tmp7;
-  }
-
-  TaskList? __clientTaskListFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _clientTaskListFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_TaskList");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp7 = TaskList._(this, tmp13_1);
     return tmp7;
   }
 
@@ -19826,7 +19779,7 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_comment");
 
   late final _clientWaitForComment = _clientWaitForCommentPtr.asFunction<
@@ -19846,7 +19799,7 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_news");
 
   late final _clientWaitForNews = _clientWaitForNewsPtr.asFunction<
@@ -19878,7 +19831,7 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_pin");
 
   late final _clientWaitForPin = _clientWaitForPinPtr.asFunction<
@@ -19916,7 +19869,7 @@ class Api {
         int,
         int,
       )>();
-  late final _clientWaitForTaskListPtr = _lookup<
+  late final _clientTaskListPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
@@ -19924,10 +19877,10 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
-          )>>("__Client_wait_for_task_list");
+            ffi.Uint8,
+          )>>("__Client_task_list");
 
-  late final _clientWaitForTaskList = _clientWaitForTaskListPtr.asFunction<
+  late final _clientTaskList = _clientTaskListPtr.asFunction<
       int Function(
         int,
         int,
@@ -19954,29 +19907,13 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_task");
 
   late final _clientWaitForTask = _clientWaitForTaskPtr.asFunction<
       int Function(
         int,
         int,
-        int,
-        int,
-        int,
-        int,
-      )>();
-  late final _clientTaskListPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Uint64,
-            ffi.Uint64,
-          )>>("__Client_task_list");
-
-  late final _clientTaskList = _clientTaskListPtr.asFunction<
-      int Function(
         int,
         int,
         int,
@@ -20037,7 +19974,7 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_calendar_event");
 
   late final _clientWaitForCalendarEvent =
@@ -20058,7 +19995,7 @@ class Api {
             ffi.Uint64,
             ffi.Uint64,
             ffi.Uint8,
-            ffi.Int64,
+            ffi.Uint8,
           )>>("__Client_wait_for_rsvp");
 
   late final _clientWaitForRsvp = _clientWaitForRsvpPtr.asFunction<
@@ -23566,17 +23503,17 @@ class Api {
         int,
         int,
       )>();
-  late final _clientWaitForTaskListFuturePollPtr = _lookup<
+  late final _clientTaskListFuturePollPtr = _lookup<
       ffi.NativeFunction<
-          _ClientWaitForTaskListFuturePollReturn Function(
+          _ClientTaskListFuturePollReturn Function(
             ffi.Int64,
             ffi.Int64,
             ffi.Int64,
-          )>>("__Client_wait_for_task_list_future_poll");
+          )>>("__Client_task_list_future_poll");
 
-  late final _clientWaitForTaskListFuturePoll =
-      _clientWaitForTaskListFuturePollPtr.asFunction<
-          _ClientWaitForTaskListFuturePollReturn Function(
+  late final _clientTaskListFuturePoll =
+      _clientTaskListFuturePollPtr.asFunction<
+          _ClientTaskListFuturePollReturn Function(
             int,
             int,
             int,
@@ -23607,21 +23544,6 @@ class Api {
   late final _clientWaitForTaskFuturePoll =
       _clientWaitForTaskFuturePollPtr.asFunction<
           _ClientWaitForTaskFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
-  late final _clientTaskListFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _ClientTaskListFuturePollReturn Function(
-            ffi.Int64,
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__Client_task_list_future_poll");
-
-  late final _clientTaskListFuturePoll =
-      _clientTaskListFuturePollPtr.asFunction<
-          _ClientTaskListFuturePollReturn Function(
             int,
             int,
             int,
@@ -41700,7 +41622,7 @@ class Client {
   /// Fetch the Comment or use its event_id to wait for it to come down the wire
   Future<Comment> waitForComment(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -41724,7 +41646,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForComment(
       tmp0,
@@ -41746,7 +41668,7 @@ class Client {
   /// Fetch the NewsEntry or use its event_id to wait for it to come down the wire
   Future<NewsEntry> waitForNews(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -41770,7 +41692,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForNews(
       tmp0,
@@ -41814,7 +41736,7 @@ class Client {
   /// Fetch the ActerPin or use its event_id to wait for it to come down the wire
   Future<ActerPin> waitForPin(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -41838,7 +41760,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForPin(
       tmp0,
@@ -41904,9 +41826,9 @@ class Client {
   }
 
   /// Fetch the Tasklist or use its event_id to wait for it to come down the wire
-  Future<TaskList> waitForTaskList(
+  Future<TaskList> taskList(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -41930,9 +41852,9 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
-    final tmp9 = _api._clientWaitForTaskList(
+    final tmp9 = _api._clientTaskList(
       tmp0,
       tmp2,
       tmp3,
@@ -41942,11 +41864,9 @@ class Client {
     );
     final tmp11 = tmp9;
     final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
-    final tmp11_1 =
-        _Box(_api, tmp11_0, "__Client_wait_for_task_list_future_drop");
+    final tmp11_1 = _Box(_api, tmp11_0, "__Client_task_list_future_drop");
     tmp11_1._finalizer = _api._registerFinalizer(tmp11_1);
-    final tmp10 =
-        _nativeFuture(tmp11_1, _api.__clientWaitForTaskListFuturePoll);
+    final tmp10 = _nativeFuture(tmp11_1, _api.__clientTaskListFuturePoll);
     return tmp10;
   }
 
@@ -41968,7 +41888,7 @@ class Client {
   /// Fetch the Task or use its event_id to wait for it to come down the wire
   Future<Task> waitForTask(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -41992,7 +41912,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForTask(
       tmp0,
@@ -42008,38 +41928,6 @@ class Client {
     tmp11_1._finalizer = _api._registerFinalizer(tmp11_1);
     final tmp10 = _nativeFuture(tmp11_1, _api.__clientWaitForTaskFuturePoll);
     return tmp10;
-  }
-
-  /// the Tasks list for the client
-  Future<TaskList> taskList(
-    String key,
-  ) {
-    final tmp1 = key;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    var tmp3 = 0;
-    var tmp4 = 0;
-    tmp0 = _box.borrow();
-    final tmp1_0 = utf8.encode(tmp1);
-    tmp3 = tmp1_0.length;
-
-    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
-    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
-    tmp2_1.setAll(0, tmp1_0);
-    tmp2 = tmp2_0.address;
-    tmp4 = tmp3;
-    final tmp5 = _api._clientTaskList(
-      tmp0,
-      tmp2,
-      tmp3,
-      tmp4,
-    );
-    final tmp7 = tmp5;
-    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 = _Box(_api, tmp7_0, "__Client_task_list_future_drop");
-    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp6 = _nativeFuture(tmp7_1, _api.__clientTaskListFuturePoll);
-    return tmp6;
   }
 
   /// the Tasks lists of this Space
@@ -42124,7 +42012,7 @@ class Client {
   /// Fetch the calendar event or use its event_id to wait for it to come down the wire
   Future<CalendarEvent> waitForCalendarEvent(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -42148,7 +42036,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForCalendarEvent(
       tmp0,
@@ -42171,7 +42059,7 @@ class Client {
   /// Fetch the RSVP or use its event_id to wait for it to come down the wire
   Future<Rsvp> waitForRsvp(
     String key,
-    EfkDuration? timeout,
+    int? timeout,
   ) {
     final tmp1 = key;
     final tmp5 = timeout;
@@ -42195,7 +42083,7 @@ class Client {
     } else {
       tmp6 = 1;
       final tmp7 = tmp5;
-      tmp8 = tmp7._box.move();
+      tmp8 = tmp7;
     }
     final tmp9 = _api._clientWaitForRsvp(
       tmp0,
@@ -49273,7 +49161,7 @@ class _ClientPinFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _ClientWaitForTaskListFuturePollReturn extends ffi.Struct {
+class _ClientTaskListFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()
@@ -49304,21 +49192,6 @@ class _ClientTaskListsFuturePollReturn extends ffi.Struct {
 }
 
 class _ClientWaitForTaskFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Int64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint64()
-  external int arg4;
-  @ffi.Int64()
-  external int arg5;
-}
-
-class _ClientTaskListFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -154,7 +154,7 @@ object UserProfile {
     fn user_id() -> UserId;
 
     /// whether to have avatar
-    fn has_avatar() -> Future<Result<bool>>;
+    fn has_avatar() -> bool;
 
     /// get the binary data of avatar
     /// if thumb size is given, avatar thumbnail is returned
@@ -162,12 +162,12 @@ object UserProfile {
     fn get_avatar(thumb_size: Option<ThumbnailSize>) -> Future<Result<OptionBuffer>>;
 
     /// get the display name
-    fn get_display_name() -> Future<Result<OptionString>>;
+    fn get_display_name() -> Option<string>;
 }
 
 object RoomProfile {
     /// whether to have avatar
-    fn has_avatar() -> Result<bool>;
+    fn has_avatar() -> bool;
 
     /// get the binary data of avatar
     /// if thumb size is given, avatar thumbnail is returned

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2095,9 +2095,6 @@ object Client {
     /// get the room id of dm from user id
     fn dm_with_user(user_id: string) -> Result<OptionString>;
 
-    /// get the user profile that contains avatar and display name
-    fn get_user_profile() -> Result<UserProfile>;
-
     /// upload file and return remote url
     fn upload_media(uri: string) -> Future<Result<MxcUri>>;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2167,16 +2167,16 @@ object Client {
     fn subscribe_stream(key: string) -> Stream<bool>;
 
     /// Fetch the Comment or use its event_id to wait for it to come down the wire
-    fn wait_for_comment(key: string, timeout: Option<EfkDuration>) -> Future<Result<Comment>>;
+    fn wait_for_comment(key: string, timeout: Option<u8>) -> Future<Result<Comment>>;
 
     /// Fetch the NewsEntry or use its event_id to wait for it to come down the wire
-    fn wait_for_news(key: string, timeout: Option<EfkDuration>) -> Future<Result<NewsEntry>>;
+    fn wait_for_news(key: string, timeout: Option<u8>) -> Future<Result<NewsEntry>>;
 
     /// Get the latest News for the client
     fn latest_news_entries(count: u32) -> Future<Result<Vec<NewsEntry>>>;
 
     /// Fetch the ActerPin or use its event_id to wait for it to come down the wire
-    fn wait_for_pin(key: string, timeout: Option<EfkDuration>) -> Future<Result<ActerPin>>;
+    fn wait_for_pin(key: string, timeout: Option<u8>) -> Future<Result<ActerPin>>;
 
     /// Get the Pins for the client
     fn pins() -> Future<Result<Vec<ActerPin>>>;
@@ -2185,16 +2185,13 @@ object Client {
     fn pin(pin_id: string) -> Future<Result<ActerPin>>;
 
     /// Fetch the Tasklist or use its event_id to wait for it to come down the wire
-    fn wait_for_task_list(key: string, timeout: Option<EfkDuration>) -> Future<Result<TaskList>>;
+    fn task_list(key: string, timeout: Option<u8>) -> Future<Result<TaskList>>;
 
     /// the Tasks lists for the client
     fn task_lists() -> Future<Result<Vec<TaskList>>>;
 
     /// Fetch the Task or use its event_id to wait for it to come down the wire
-    fn wait_for_task(key: string, timeout: Option<EfkDuration>) -> Future<Result<Task>>;
-
-    /// the Tasks list for the client
-    fn task_list(key: string) -> Future<Result<TaskList>>;
+    fn wait_for_task(key: string, timeout: Option<u8>) -> Future<Result<Task>>;
 
     /// the Tasks lists of this Space
     fn my_open_tasks() -> Future<Result<Vec<Task>>>;
@@ -2209,10 +2206,10 @@ object Client {
     fn calendar_event(calendar_id: string) -> Future<Result<CalendarEvent>>;
 
     /// Fetch the calendar event or use its event_id to wait for it to come down the wire
-    fn wait_for_calendar_event(key: string, timeout: Option<EfkDuration>) -> Future<Result<CalendarEvent>>;
+    fn wait_for_calendar_event(key: string, timeout: Option<u8>) -> Future<Result<CalendarEvent>>;
 
     /// Fetch the RSVP or use its event_id to wait for it to come down the wire
-    fn wait_for_rsvp(key: string, timeout: Option<EfkDuration>) -> Future<Result<Rsvp>>;
+    fn wait_for_rsvp(key: string, timeout: Option<u8>) -> Future<Result<Rsvp>>;
 
     /// list the currently queued notifications
     fn list_notifications(since: Option<string>, only: Option<string>) -> Future<Result<NotificationListResult>>;

--- a/native/acter/src/api/account.rs
+++ b/native/acter/src/api/account.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
-use matrix_sdk::Account as SdkAccount;
+use matrix_sdk::{media::MediaRequest, Account as SdkAccount, Client as SdkClient};
 use ruma_common::{OwnedMxcUri, OwnedUserId};
-use ruma_events::ignored_user_list::IgnoredUserListEventContent;
+use ruma_events::{ignored_user_list::IgnoredUserListEventContent, room::MediaSource};
 use std::{ops::Deref, path::PathBuf, str::FromStr};
 
 use super::{
@@ -12,6 +12,7 @@ use super::{
 #[derive(Clone, Debug)]
 pub struct Account {
     account: SdkAccount,
+    client: SdkClient,
     user_id: OwnedUserId,
 }
 
@@ -23,8 +24,12 @@ impl Deref for Account {
 }
 
 impl Account {
-    pub fn new(account: SdkAccount, user_id: OwnedUserId) -> Self {
-        Account { account, user_id }
+    pub fn new(account: SdkAccount, user_id: OwnedUserId, client: SdkClient) -> Self {
+        Account {
+            account,
+            client,
+            user_id,
+        }
     }
 
     pub fn user_id(&self) -> OwnedUserId {
@@ -58,11 +63,21 @@ impl Account {
 
     pub async fn avatar(&self, thumb_size: Option<Box<ThumbnailSize>>) -> Result<OptionBuffer> {
         let account = self.account.clone();
+        let client = self.client.clone();
         RUNTIME
             .spawn(async move {
+                let source = match account.get_cached_avatar_url().await? {
+                    Some(url) => MediaSource::Plain(url.try_into()?),
+                    None => match account.get_avatar_url().await? {
+                        Some(e) => MediaSource::Plain(e.to_owned()),
+                        None => return Ok(OptionBuffer::new(None)),
+                    },
+                };
                 let format = ThumbnailSize::parse_into_media_format(thumb_size);
-                let buf = account.get_avatar(format).await?;
-                Ok(OptionBuffer::new(buf))
+                let request = MediaRequest { source, format };
+                Ok(OptionBuffer::new(Some(
+                    client.media().get_media_content(&request, true).await?,
+                )))
             })
             .await?
     }

--- a/native/acter/src/api/account.rs
+++ b/native/acter/src/api/account.rs
@@ -69,7 +69,7 @@ impl Account {
                 let source = match account.get_cached_avatar_url().await? {
                     Some(url) => MediaSource::Plain(url.try_into()?),
                     None => match account.get_avatar_url().await? {
-                        Some(e) => MediaSource::Plain(e.to_owned()),
+                        Some(e) => MediaSource::Plain(e),
                         None => return Ok(OptionBuffer::new(None)),
                     },
                 };

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -36,7 +36,7 @@ impl Client {
     pub async fn wait_for_attachment(
         &self,
         key: String,
-        timeout: Option<Box<Duration>>,
+        timeout: Option<u8>,
     ) -> Result<Attachment> {
         let me = self.clone();
         RUNTIME

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -27,7 +27,7 @@ impl Client {
     pub async fn wait_for_calendar_event(
         &self,
         key: String,
-        timeout: Option<Box<Duration>>,
+        timeout: Option<u8>,
     ) -> Result<CalendarEvent> {
         let me = self.clone();
         RUNTIME

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -932,7 +932,7 @@ impl Client {
     pub fn account(&self) -> Result<Account> {
         let account = self.core.client().account();
         let user_id = self.user_id()?;
-        Ok(Account::new(account, user_id))
+        Ok(Account::new(account, user_id, self.core.client().clone()))
     }
 
     pub fn device_id(&self) -> Result<OwnedDeviceId> {
@@ -941,15 +941,6 @@ impl Client {
             .device_id()
             .context("DeviceId not found")
             .map(|x| x.to_owned())
-    }
-
-    pub fn get_user_profile(&self) -> Result<UserProfile> {
-        let client = self.core.client();
-        let user_id = client
-            .user_id()
-            .context("You must be logged in to do that")?
-            .to_owned();
-        Ok(UserProfile::from_account(client.account(), user_id))
     }
 
     pub async fn verified_device(&self, dev_id: String) -> Result<bool> {

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -911,11 +911,7 @@ impl Client {
         self.executor().subscribe(key)
     }
 
-    pub async fn wait_for(
-        &self,
-        key: String,
-        timeout: Option<Box<Duration>>,
-    ) -> Result<AnyActerModel> {
+    pub async fn wait_for(&self, key: String, timeout: Option<u8>) -> Result<AnyActerModel> {
         let executor = self.core.executor().clone();
 
         RUNTIME
@@ -924,7 +920,7 @@ impl Client {
                 let Some(tm) = timeout else {
                     return Ok(waiter.await?);
                 };
-                Ok(time::timeout(*Box::leak(tm), waiter).await??)
+                Ok(time::timeout(Duration::from_secs(tm as u64), waiter).await??)
             })
             .await?
     }

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -627,10 +627,13 @@ impl Client {
             let room_handles = room_handles.clone();
             let notifications = notifications.clone();
 
+            // keep the sync timeout below the actual connection timeout to ensure we receive it
+            // back before the server timeout occured
+            let sync_settings = SyncSettings::new().timeout(Duration::from_secs(25));
             // fetch the events that received when offline
             client
                 .clone()
-                .sync_with_result_callback(SyncSettings::new(), |result| async {
+                .sync_with_result_callback(sync_settings, |result| async {
                     info!("received sync callback");
                     let client = client.clone();
                     let me = me.clone();

--- a/native/acter/src/api/comments.rs
+++ b/native/acter/src/api/comments.rs
@@ -15,11 +15,7 @@ use tokio_stream::{wrappers::BroadcastStream, Stream};
 use super::{client::Client, RUNTIME};
 
 impl Client {
-    pub async fn wait_for_comment(
-        &self,
-        key: String,
-        timeout: Option<Box<Duration>>,
-    ) -> Result<Comment> {
+    pub async fn wait_for_comment(&self, key: String, timeout: Option<u8>) -> Result<Comment> {
         let me = self.clone();
         RUNTIME
             .spawn(async move {

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -21,6 +21,7 @@ use ruma_events::{
     sticker::StickerEventContent,
 };
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 use super::api::FfiBuffer;
 
@@ -43,7 +44,7 @@ impl OptionString {
 }
 
 pub struct OptionBuffer {
-    data: Option<Vec<u8>>,
+    pub(crate) data: Option<Vec<u8>>,
 }
 
 impl OptionBuffer {

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -41,11 +41,7 @@ use super::{
 };
 
 impl Client {
-    pub async fn wait_for_news(
-        &self,
-        key: String,
-        timeout: Option<Box<Duration>>,
-    ) -> Result<NewsEntry> {
+    pub async fn wait_for_news(&self, key: String, timeout: Option<u8>) -> Result<NewsEntry> {
         let me = self.clone();
         RUNTIME
             .spawn(async move {

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 use super::{client::Client, spaces::Space, RUNTIME};
 
 impl Client {
-    pub async fn wait_for_pin(&self, key: String, timeout: Option<Box<Duration>>) -> Result<Pin> {
+    pub async fn wait_for_pin(&self, key: String, timeout: Option<u8>) -> Result<Pin> {
         let client = self.clone();
         RUNTIME
             .spawn(async move {

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -659,9 +659,7 @@ impl Room {
     }
 
     pub fn get_profile(&self) -> RoomProfile {
-        let client = self.room.client();
-        let room_id = self.room_id().to_owned();
-        RoomProfile::new(client, room_id)
+        RoomProfile::new(self.room.clone())
     }
 
     pub async fn upload_avatar(&self, uri: String) -> Result<OwnedMxcUri> {

--- a/native/acter/src/api/rsvp.rs
+++ b/native/acter/src/api/rsvp.rs
@@ -17,7 +17,7 @@ use tracing::{error, trace, warn};
 use super::{calendar_events::CalendarEvent, client::Client, RUNTIME};
 
 impl Client {
-    pub async fn wait_for_rsvp(&self, key: String, timeout: Option<Box<Duration>>) -> Result<Rsvp> {
+    pub async fn wait_for_rsvp(&self, key: String, timeout: Option<u8>) -> Result<Rsvp> {
         let client = self.clone();
         RUNTIME
             .spawn(async move {

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -23,11 +23,7 @@ use crate::MsgContent;
 use super::{client::Client, spaces::Space, RUNTIME};
 
 impl Client {
-    pub async fn wait_for_task_list(
-        &self,
-        key: String,
-        timeout: Option<Box<Duration>>,
-    ) -> Result<TaskList> {
+    pub async fn task_list(&self, key: String, timeout: Option<u8>) -> Result<TaskList> {
         let me = self.clone();
         RUNTIME
             .spawn(async move {
@@ -48,7 +44,7 @@ impl Client {
             .await?
     }
 
-    pub async fn wait_for_task(&self, key: String, timeout: Option<Box<Duration>>) -> Result<Task> {
+    pub async fn wait_for_task(&self, key: String, timeout: Option<u8>) -> Result<Task> {
         let me = self.clone();
         RUNTIME
             .spawn(async move {
@@ -152,28 +148,6 @@ impl Client {
         self.executor()
             .subscribe(KEYS::TASKS::MY_OPEN_TASKS.to_owned())
     }
-
-    pub async fn task_list(&self, key: String) -> Result<TaskList> {
-        let client = self.clone();
-        RUNTIME
-            .spawn(async move {
-                let mdl = client.store().get(key.as_str()).await?;
-
-                let AnyActerModel::TaskList(content) = mdl else  {
-                    bail!("Not a Tasklist model: {key}")
-                };
-                let room = client
-                    .get_room(content.room_id())
-                    .context("Room not found for task_list item")?;
-
-                Ok(TaskList {
-                    client: client.clone(),
-                    room,
-                    content,
-                })
-            })
-            .await?
-    }
 }
 
 impl Space {
@@ -213,10 +187,9 @@ impl Space {
                 let AnyActerModel::TaskList(content) = mdl else  {
                     bail!("Not a Tasklist model: {key}")
                 };
-                assert!(
-                    room_id == content.room_id(),
-                    "This task doesn't belong to this room"
-                );
+                if room_id != content.room_id() {
+                    bail!("This task doesn't belong to this room");
+                }
 
                 Ok(TaskList {
                     client: client.clone(),


### PR DESCRIPTION
Probably best reviewed commit by, as they focus on a specific thing:

- use the `cached_avatar_field` for our own account, https://github.com/acterglobal/a3/commit/b3eff237b18038ca6d92eb6f43226c9d399f0911
  removes a reloading of the _remote_ data of our own avatar whenever it was shown
- Disable Device popups, https://github.com/acterglobal/a3/commit/ffe9d2b1481f151f0376a3e40591ef62b3c4e103
  Removes the `newDevice`-Stream that send kind of pointless popups to the UI and, for every popup it shows, request all the remote devices leading to a lot of requests at startup. Fixes #1276 
- Rust refactorings to simplify the code of:
   - RoomProfile, https://github.com/acterglobal/a3/commit/8b185cd714c9442903208542634cd8d4226464c0
   - UserProfile, https://github.com/acterglobal/a3/commit/41c9fcb4b56014871512fb2dcbd237f0925f5180
- Bump the sync timeout to 25s to make it return before the 30s connection timeout kicks in, https://github.com/acterglobal/a3/commit/0755132d937b331a8d19e144321fd2cbc96ff0a4
- Refactor the way that tasklists are polled and managed to address some issue of #1285 : https://github.com/acterglobal/a3/commit/d8226a29f2eebbba7d9e1a5a4124a37d48f788eb
  The Task itself wasn't a notifier, it now is. Additionally, the `client.taskList`-API is now bound to the `wait_for`-loader to ensure we have this available.
- Replaced the CircularSpinner in several places in the UI with a proper local Skeleton-Loader, cleaning up the entire loading flow and leading to a smoother, less noisy UI, https://github.com/acterglobal/a3/commit/4ac98378e9ce2f120a037d465f3055b885fec8ea