### PR TITLE
[rust]: Updates fixes 

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -12831,6 +12831,16 @@ class Api {
             int,
             int,
           )>();
+  late final _newsEntryDraftSlidesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__NewsEntryDraft_slides");
+
+  late final _newsEntryDraftSlides = _newsEntryDraftSlidesPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _newsEntryDraftUnsetSlidesPtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -25145,6 +25155,55 @@ class Api {
 
   late final _ffiListNewsSlideInsert =
       _ffiListNewsSlideInsertPtr.asFunction<void Function(int, int, int)>();
+  FfiListNewsSlideDraft createFfiListNewsSlideDraft() {
+    final ffi.Pointer<ffi.Void> list_ptr =
+        ffi.Pointer.fromAddress(_ffiListNewsSlideDraftCreate());
+    final list_box = _Box(this, list_ptr, "drop_box_FfiListNewsSlideDraft");
+    return FfiListNewsSlideDraft._(this, list_box);
+  }
+
+  late final _ffiListNewsSlideDraftCreatePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
+          "__FfiListNewsSlideDraftCreate");
+
+  late final _ffiListNewsSlideDraftCreate =
+      _ffiListNewsSlideDraftCreatePtr.asFunction<int Function()>();
+
+  late final _ffiListNewsSlideDraftLenPtr =
+      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.IntPtr)>>(
+          "__FfiListNewsSlideDraftLen");
+
+  late final _ffiListNewsSlideDraftLen =
+      _ffiListNewsSlideDraftLenPtr.asFunction<int Function(int)>();
+
+  late final _ffiListNewsSlideDraftElementAtPtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListNewsSlideDraftElementAt");
+
+  late final _ffiListNewsSlideDraftElementAt =
+      _ffiListNewsSlideDraftElementAtPtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftRemovePtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.Uint32)>>(
+          "__FfiListNewsSlideDraftRemove");
+
+  late final _ffiListNewsSlideDraftRemove =
+      _ffiListNewsSlideDraftRemovePtr.asFunction<int Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftAddPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
+          "__FfiListNewsSlideDraftAdd");
+
+  late final _ffiListNewsSlideDraftAdd =
+      _ffiListNewsSlideDraftAddPtr.asFunction<void Function(int, int)>();
+
+  late final _ffiListNewsSlideDraftInsertPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.IntPtr, ffi.Uint32,
+              ffi.IntPtr)>>("__FfiListNewsSlideDraftInsert");
+
+  late final _ffiListNewsSlideDraftInsert = _ffiListNewsSlideDraftInsertPtr
+      .asFunction<void Function(int, int, int)>();
   FfiListNotification createFfiListNotification() {
     final ffi.Pointer<ffi.Void> list_ptr =
         ffi.Pointer.fromAddress(_ffiListNotificationCreate());
@@ -27911,6 +27970,22 @@ class NewsEntryDraft {
       tmp4,
     );
     return;
+  }
+
+  /// get news slide set for this news entry draft
+  FfiListNewsSlideDraft slides() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._newsEntryDraftSlides(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_FfiListNewsSlideDraft");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp4 = FfiListNewsSlideDraft._(_api, tmp3_1);
+    final tmp2 = tmp4;
+    return tmp2;
   }
 
   /// clear slides
@@ -50807,6 +50882,67 @@ class FfiListNewsSlide extends Iterable<NewsSlide>
   /// Although you can use the "elementAt" method to get a reference to the added element
   void insert(int index, NewsSlide element) {
     _api._ffiListNewsSlideInsert(_box.borrow(), index, element._box.borrow());
+    element._box.move();
+  }
+
+  void drop() {
+    _box.drop();
+  }
+}
+
+class FfiListNewsSlideDraft extends Iterable<NewsSlideDraft>
+    implements CustomIterable<NewsSlideDraft> {
+  final Api _api;
+  final _Box _box;
+
+  FfiListNewsSlideDraft._(this._api, this._box);
+
+  @override
+  Iterator<NewsSlideDraft> get iterator => CustomIterator(this);
+
+  @override
+  int get length {
+    return _api._ffiListNewsSlideDraftLen(_box.borrow());
+  }
+
+  /// List object owns the elements, and objects returned by this method hold onto the list object ensuring the pointed to element isn/t dropped.
+  @override
+  NewsSlideDraft elementAt(int index) {
+    final address = _api._ffiListNewsSlideDraftElementAt(_box.borrow(), index);
+    final reference = _Box(
+      _api,
+      ffi.Pointer.fromAddress(address),
+      "drop_box_Leak",
+      context: this,
+    );
+    return NewsSlideDraft._(_api, reference);
+  }
+
+  NewsSlideDraft operator [](int index) {
+    return elementAt(index);
+  }
+
+  /// Moves the element out of this list and returns it
+  NewsSlideDraft remove(int index) {
+    final address = _api._ffiListNewsSlideDraftRemove(_box.borrow(), index);
+    final reference =
+        _Box(_api, ffi.Pointer.fromAddress(address), "drop_box_NewsSlideDraft");
+    reference._finalizer = _api._registerFinalizer(reference);
+    return NewsSlideDraft._(_api, reference);
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void add(NewsSlideDraft element) {
+    _api._ffiListNewsSlideDraftAdd(_box.borrow(), element._box.borrow());
+    element._box.move();
+  }
+
+  /// The inserted element is moved into the list and must not be used again
+  /// Although you can use the "elementAt" method to get a reference to the added element
+  void insert(int index, NewsSlideDraft element) {
+    _api._ffiListNewsSlideDraftInsert(
+        _box.borrow(), index, element._box.borrow());
     element._box.move();
   }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -12712,6 +12712,30 @@ class Api {
         int,
         int,
       )>();
+  late final _newsSlideDraftAddReferencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__NewsSlideDraft_add_reference");
+
+  late final _newsSlideDraftAddReference =
+      _newsSlideDraftAddReferencePtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _newsSlideDraftUnsetReferencesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+          )>>("__NewsSlideDraft_unset_references");
+
+  late final _newsSlideDraftUnsetReferences =
+      _newsSlideDraftUnsetReferencesPtr.asFunction<
+          void Function(
+            int,
+          )>();
   late final _newsEntrySlidesCountPtr = _lookup<
       ffi.NativeFunction<
           ffi.Uint8 Function(
@@ -27764,6 +27788,32 @@ class NewsSlideDraft {
   final _Box _box;
 
   NewsSlideDraft._(this._api, this._box);
+
+  /// add reference for this slide draft
+  void addReference(
+    ObjRef reference,
+  ) {
+    final tmp1 = reference;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1._box.move();
+    _api._newsSlideDraftAddReference(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// unset references for this slide draft
+  void unsetReferences() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    _api._newsSlideDraftUnsetReferences(
+      tmp0,
+    );
+    return;
+  }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -337,6 +337,9 @@ object NewsEntryDraft {
     /// change position of slides draft of this news entry
     fn swap_slides(from: u8, to:u8);
 
+    /// get news slide set for this news entry draft
+    fn slides() -> Vec<NewsSlideDraft>;
+
     /// clear slides
     fn unset_slides();
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -302,7 +302,11 @@ object NewsSlide {
 }
 
 object NewsSlideDraft {
-    
+    /// add reference for this slide draft
+    fn add_reference(reference: ObjRef);
+
+    /// unset references for this slide draft
+    fn unset_references();
 }
 
 /// A news entry

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -286,7 +286,6 @@ impl NewsSlide {
 }
 
 #[derive(Clone)]
-#[allow(clippy::boxed_local)]
 pub struct NewsSlideDraft {
     content: news::NewsSlideBuilder,
     references: Vec<ObjRef>,
@@ -297,7 +296,7 @@ impl NewsSlideDraft {
         let content = self.content.build()?;
         Ok(content)
     }
-
+    #[allow(clippy::boxed_local)]
     pub fn add_reference(&mut self, reference: Box<ObjRef>) -> &Self {
         self.references.push(*reference);
         self.content.references(self.references.clone());

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -279,17 +279,33 @@ impl NewsSlide {
             }
         }
     }
+
+    pub fn references(&mut self) -> Vec<ObjRef> {
+        self.inner.references().clone()
+    }
 }
 
 #[derive(Clone)]
 pub struct NewsSlideDraft {
     content: news::NewsSlideBuilder,
+    references: Vec<ObjRef>,
 }
 
 impl NewsSlideDraft {
     pub fn save(&self) -> Result<news::NewsSlide> {
         let content = self.content.build()?;
         Ok(content)
+    }
+
+    pub fn add_reference(&mut self, reference: Box<ObjRef>) -> &Self {
+        self.references.push(*reference);
+        self.content.references(self.references.clone());
+        self
+    }
+
+    pub fn unset_references(&mut self) -> &Self {
+        self.references.clear();
+        self
     }
 }
 
@@ -610,7 +626,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Text(text_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::TextMarkdown { body } => {
                 let text_content = TextMessageEventContent::markdown(body);
@@ -618,7 +637,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Text(text_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::Image { source, info } => {
                 let info = info.expect("image info needed");
@@ -652,7 +674,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Image(image_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::Audio { source, info } => {
                 let info = info.expect("audio info needed");
@@ -686,7 +711,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Audio(audio_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::Video { source, info } => {
                 let info = info.expect("image info needed");
@@ -720,7 +748,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Video(video_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::File {
                 source,
@@ -759,7 +790,10 @@ impl MsgContentDraft {
                     .content(NewsContent::File(file_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
             MsgContentDraft::Location {
                 body,
@@ -775,7 +809,10 @@ impl MsgContentDraft {
                     .content(NewsContent::Location(location_content))
                     .references(Default::default())
                     .clone();
-                Ok(NewsSlideDraft { content: builder })
+                Ok(NewsSlideDraft {
+                    content: builder,
+                    references: vec![],
+                })
             }
         }
     }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -1,7 +1,7 @@
 use acter_core::{
     events::{
         news::{self, NewsContent, NewsEntryBuilder, NewsSlideBuilder},
-        Colorize,
+        Colorize, ObjRef,
     },
     models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
@@ -450,6 +450,10 @@ impl NewsEntryDraft {
         }
         self.slides.swap(from as usize, to as usize);
         Ok(self)
+    }
+
+    pub fn slides(&mut self) -> Vec<NewsSlideDraft> {
+        self.slides.clone()
     }
 
     pub fn unset_slides(&mut self) -> &mut Self {

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -286,6 +286,7 @@ impl NewsSlide {
 }
 
 #[derive(Clone)]
+#[allow(clippy::boxed_local)]
 pub struct NewsSlideDraft {
     content: news::NewsSlideBuilder,
     references: Vec<ObjRef>,


### PR DESCRIPTION
- exposes ```slides()``` for getting list of slides draft for ```NewsEntryDraft```.
- exposes ```references()``` methods for adding attachments for ```NewsSlideDraft```.