### PR TITLE
tracing feature for rust (desktop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "async-stream",
  "cbindgen",
  "chrono",
+ "console-subscriber",
  "derive_builder",
  "eyeball-im",
  "fern",
@@ -50,6 +51,9 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-android",
+ "tracing-appender",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
  "tracing-wasm",
  "uniffi",
  "url",
@@ -519,6 +523,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +601,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -961,6 +1016,43 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "console-api"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2051,7 +2143,10 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
+ "base64 0.13.1",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -2061,7 +2156,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "headers-core",
  "http",
@@ -2230,6 +2325,18 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2830,6 +2937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "matrix-pickle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,7 +3106,7 @@ source = "git+https://github.com/gnunicorn/matrix-rust-sdk?rev=98df2b35c3ccb4702
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.21.4",
  "getrandom",
  "gloo-utils",
  "indexed_db_futures",
@@ -3992,6 +4105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4273,7 +4395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4435,7 +4557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd6a9c0dd0dc4986bf5fb963765f59fb0e3f462b7ca8ba466f47d217688865c"
 dependencies = [
  "as_variant",
- "base64",
+ "base64 0.21.4",
  "bytes",
  "form_urlencoded",
  "getrandom",
@@ -4621,7 +4743,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -4918,7 +5040,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5204,6 +5326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5365,7 +5493,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -5493,6 +5632,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.4",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5570,6 +5736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,6 +5780,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5613,15 +5802,15 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5632,7 +5821,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -5980,7 +6169,7 @@ checksum = "6c66c59f2218deeddfe34c0fee8a1908967f8566bafd91c3c6b9600d0b68cde1"
 dependencies = [
  "aes",
  "arrayvec",
- "base64",
+ "base64 0.21.4",
  "cbc",
  "curve25519-dalek",
  "ed25519-dalek",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -542,8 +542,6 @@ run_task = "copy-lib"
 [tasks.post-android]
 dependencies = ["ffigen"]
 
-# TODO: non linux desktops
-# TODO: release build
 [tasks.desktop]
 # Build rust SDK for desktop
 dependencies = [
@@ -554,6 +552,20 @@ dependencies = [
     "copy-desktop-lib",
     "copy-desktop-lib-release",
 ]
+
+[tasks.desktop-tracing]
+# Build rust SDK for desktop
+dependencies = [
+    "desktop-build",
+    "copy-desktop-lib",
+]
+
+[tasks.desktop-tracing-inner]
+private = true
+condition = { env_true = ["DEV"] }
+env = { RUSTFLAGS="--cfg tokio_unstable", MACOSX_DEPLOYMENT_TARGET = 11 }
+command = "cargo"
+args = ["build", "--lib", "--features", "tracing"]
 
 [tasks.desktop-build]
 private = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -556,7 +556,7 @@ dependencies = [
 [tasks.desktop-tracing]
 # Build rust SDK for desktop
 dependencies = [
-    "desktop-build",
+    "desktop-tracing-inner",
     "copy-desktop-lib",
 ]
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -416,11 +416,12 @@ class ActerSdk {
     final api = Platform.isAndroid
         ? ffi.Api(await _getAndroidDynLib('libacter.so'))
         : ffi.Api.load();
-    String appPath = await appDir();
+    String logPath = await appCacheDir();
 
     final logSettings = (await sharedPrefs()).getString(rustLogKey);
     try {
-      api.initLogging(appPath, logSettings ?? defaultLogSetting);
+      print('Logs will be found in $logPath');
+      api.initLogging(logPath, logSettings ?? defaultLogSetting);
     } catch (e) {
       developer.log(
         'Logging setup failed',

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -420,6 +420,7 @@ class ActerSdk {
 
     final logSettings = (await sharedPrefs()).getString(rustLogKey);
     try {
+      // ignore: avoid_print
       print('Logs will be found in $logPath');
       api.initLogging(logPath, logSettings ?? defaultLogSetting);
     } catch (e) {

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -12,6 +12,8 @@ license-file = "../../LICENSE.txt"
 default = ["dart"]
 testing = [ ]
 cbindgen = []
+tracing = ["dep:tracing-subscriber", "dep:tracing-appender", "dep:tracing-log"]
+tracing-console = ["tracing", "dep:console-subscriber", "tokio/tracing"]
 dart = []
 uniffi = ["dep:uniffi", "dep:thiserror"]
 proxyman = ["dep:reqwest", "dep:openssl"]
@@ -47,7 +49,7 @@ sanitize-filename-reader-friendly = "2.2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.111"
 strum = { workspace = true }
-tokio = "1"
+tokio = "1.7"
 tokio-stream = "0.1.14"
 tokio-retry = "0.3.0"
 tracing = { version = "0.1.40", default-features = false, features = ["log"] }
@@ -65,6 +67,12 @@ thiserror = { version = "1.0.56", optional = true }
 # for proxyman support
 # enable support for system native TLS certificates
 reqwest = { optional = true, version = "*", default-features = false, features = ["rustls-tls-native-roots"]}
+
+# for tracing support
+tracing-subscriber = { version = "0.3.1", optional = true, default-features = false, features = ["fmt", "std", "env-filter"] }
+tracing-appender = { version = "0.2", optional = true }
+tracing-log = { version = "0.2", optional = true }
+console-subscriber = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.9.0"


### PR DESCRIPTION
This adds a new build target `desktop-tracing` that enables the internal `tracing`-feature and replaces the logging system with a `tokio-tracer`-system with more in-depth analysis capabilities.

Also moves the logs from the application data dir into the application cache dir - for both regular logs and tracing logs.