### PR TITLE
Setting the HTTP proxy via UI and CLI

### DIFF
--- a/app/lib/features/cli/commands/settings.dart
+++ b/app/lib/features/cli/commands/settings.dart
@@ -27,7 +27,7 @@ class ShowCommand extends Command {
     if (argResults != null) {
       if (argResults!['all']) {
         for (final key in supportedKeys.keys) {
-          await printSetting(supportedKeys[key!]!, key);
+          await printSetting(supportedKeys[key]!, key);
         }
         return;
       }
@@ -111,7 +111,7 @@ class ResetCommand extends Command {
     if (argResults != null) {
       if (argResults!['all']) {
         for (final key in supportedKeys.keys) {
-          await resetSetting(supportedKeys[key!]!, key);
+          await resetSetting(supportedKeys[key]!, key);
         }
         return;
       }

--- a/app/lib/features/cli/commands/settings.dart
+++ b/app/lib/features/cli/commands/settings.dart
@@ -1,0 +1,145 @@
+import 'package:args/command_runner.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+
+// ignore_for_file: avoid_print
+const supportedKeys = {
+  'http-proxy': proxyKey,
+  'rust-log': rustLogKey,
+};
+
+class ShowCommand extends Command {
+  @override
+  final name = 'show';
+  @override
+  final description = 'Show local setting';
+
+  ShowCommand() {
+    argParser.addOption(
+      'key',
+      allowed: supportedKeys.keys.toList(),
+      help: 'key to show',
+    );
+    argParser.addFlag('all', abbr: 'a', help: 'show all keys');
+  }
+
+  @override
+  Future<void> run() async {
+    if (argResults != null) {
+      if (argResults!['all']) {
+        for (final key in supportedKeys.keys) {
+          await printSetting(supportedKeys[key!]!, key);
+        }
+        return;
+      }
+      final key = argResults!['key'];
+      if (key != null) {
+        return await printSetting(supportedKeys[key!]!, key);
+      }
+    }
+
+    print('You must provide either a `key` or `--all` to show all');
+  }
+
+  Future<void> printSetting(String key, String title) async {
+    final prefs = await sharedPrefs();
+    final value = prefs.getString(key);
+    if (value != null) {
+      print('- $title ($key): $value');
+    } else {
+      print('- $title ($key) unset');
+    }
+  }
+}
+
+class SetCommand extends Command {
+  @override
+  final name = 'set';
+  @override
+  final description = 'Set local setting';
+
+  SetCommand() {
+    argParser.addOption(
+      'key',
+      allowed: supportedKeys.keys.toList(),
+      help: 'key to set',
+      mandatory: true,
+    );
+    argParser.addOption(
+      'value',
+      help: 'value to set',
+      mandatory: true,
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    if (argResults != null) {
+      final key = argResults!['key'];
+      final value = argResults!['value'];
+      if (key != null && value != null) {
+        return await setSetting(supportedKeys[key!]!, key, value);
+      }
+    }
+
+    print('You must provide a `key` and `value` to set any parameter');
+  }
+
+  Future<void> setSetting(String key, String title, String value) async {
+    final prefs = await sharedPrefs();
+    await prefs.setString(key, value);
+    print('$title ($key) set to $value');
+  }
+}
+
+class ResetCommand extends Command {
+  @override
+  final name = 'reset';
+  @override
+  final description = 'Reset local setting';
+
+  ResetCommand() {
+    argParser.addOption(
+      'key',
+      allowed: supportedKeys.keys.toList(),
+      help: 'key to reset',
+    );
+    argParser.addFlag('all', abbr: 'a', help: 'reset all keys');
+  }
+
+  @override
+  Future<void> run() async {
+    if (argResults != null) {
+      if (argResults!['all']) {
+        for (final key in supportedKeys.keys) {
+          await resetSetting(supportedKeys[key!]!, key);
+        }
+        return;
+      }
+      final key = argResults!['key'];
+      if (key != null) {
+        return await resetSetting(supportedKeys[key!]!, key);
+      }
+    }
+
+    print('You must provide either a `key` or `--all` to reset the keys');
+  }
+
+  Future<void> resetSetting(String key, String title) async {
+    final prefs = await sharedPrefs();
+    await prefs.remove(key);
+    print('$title ($key) reset');
+  }
+}
+
+class SettingsCommand extends Command {
+  @override
+  final name = 'settings';
+  @override
+  final description = 'Local Settings of your acter instance';
+
+  SettingsCommand() {
+    addSubcommand(ResetCommand());
+    addSubcommand(SetCommand());
+    addSubcommand(ShowCommand());
+  }
+}

--- a/app/lib/features/cli/main.dart
+++ b/app/lib/features/cli/main.dart
@@ -1,5 +1,6 @@
 import 'package:acter/features/cli/commands/backup-and-reset.dart';
 import 'package:acter/features/cli/commands/info.dart';
+import 'package:acter/features/cli/commands/settings.dart';
 import 'package:args/command_runner.dart';
 import 'dart:io';
 
@@ -9,6 +10,7 @@ Future<void> cliMain(List<String> args) async {
     'community communication and casual organizing platform',
   )
     ..addCommand(InfoCommand())
+    ..addCommand(SettingsCommand())
     ..addCommand(BackupAndResetCommand());
   await builder.run(args);
   exit(0);

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -207,7 +207,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
   }
 
   Future<void> _displaySettingsEditor(BuildContext context, String logKey,
-      String currentValue, String title, String fieldName) async {
+      String currentValue, String title, String fieldName,) async {
     TextEditingController textFieldController =
         TextEditingController(text: currentValue);
     return showDialog(

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -17,6 +17,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 export './acter_flutter_sdk_ffi.dart' show Client;
 
 const rustLogKey = 'RUST_LOG';
+const proxyKey = 'HTTP_PROXY';
 
 const defaultServerUrl = String.fromEnvironment(
   'DEFAULT_HOMESERVER_URL',
@@ -38,8 +39,8 @@ const defaultSessionKey = String.fromEnvironment(
   defaultValue: 'sessions',
 );
 
-const httpProxy = String.fromEnvironment(
-  'HTTP_PROXY',
+const defaultHttpProxy = String.fromEnvironment(
+  proxyKey,
   defaultValue: '',
 );
 
@@ -416,11 +417,15 @@ class ActerSdk {
     final api = Platform.isAndroid
         ? ffi.Api(await _getAndroidDynLib('libacter.so'))
         : ffi.Api.load();
-    String appPath = await appDir();
+    String logPath = await appCacheDir();
 
     final logSettings = (await sharedPrefs()).getString(rustLogKey);
     try {
-      api.initLogging(appPath, logSettings ?? defaultLogSetting);
+      // ignore: avoid_print
+      print('log settings: ${logSettings ?? defaultLogSetting}');
+      // ignore: avoid_print
+      print('logs will be found in $logPath');
+      api.initLogging(logPath, logSettings ?? defaultLogSetting);
     } catch (e) {
       developer.log(
         'Logging setup failed',
@@ -429,10 +434,14 @@ class ActerSdk {
       );
     }
 
+    final httpProxySettings =
+        (await sharedPrefs()).getString(proxyKey) ?? defaultHttpProxy;
+
     try {
-      if (httpProxy.isNotEmpty) {
-        debugPrint('Setting http proxy to $httpProxy');
-        api.setProxy(httpProxy);
+      if (httpProxySettings.isNotEmpty) {
+        // ignore: avoid_print
+        print('Setting http proxy to $httpProxySettings');
+        api.setProxy(httpProxySettings);
       }
     } catch (e) {
       developer.log(


### PR DESCRIPTION
This adds two commit that
 1. add a minimal cli command to show/set/reset local configurations (`rust-log` and `http-proxy` right now) in case the app doesn't start anymore.
 to run in def do `-a` for each param in flutter run. e.g. `flutter run -a settings -a reset -a --key=http-proxy` to reset the `http-proxy` local setting
 2. add a hidden UI flow analogous to the debug logger setting for `HTTP_PROXY` to allow for a simple overwriting 