### PR TITLE
News slide Colors

### DIFF
--- a/.changes/1359-news-slide-colors.md
+++ b/.changes/1359-news-slide-colors.md
@@ -1,0 +1,1 @@
+- [new] : User can now set background color for different news update slides

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "async-stream",
  "chrono",
  "chrono-tz",
- "csscolorparser",
  "dashmap",
  "derive-getters",
  "derive_builder",
@@ -1216,16 +1215,6 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "csscolorparser"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
-dependencies = [
- "phf 0.11.2",
- "serde",
 ]
 
 [[package]]

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -51,17 +51,13 @@ class _AddNewsState extends ConsumerState<AddNewsPage> {
           ? Colors.transparent
           : selectedNewsPost?.backgroundColor,
       actions: [
-        Visibility(
-          visible: selectedNewsPost?.type == NewsSlideType.text,
-          child: IconButton(
-            key: NewsUpdateKeys.slideBackgroundColor,
-            onPressed: () {
-              ref
-                  .read(newsStateProvider.notifier)
-                  .changeTextSlideBackgroundColor();
-            },
-            icon: const Icon(Atlas.color),
-          ),
+        IconButton(
+          onPressed: () {
+            ref
+                .read(newsStateProvider.notifier)
+                .changeTextSlideBackgroundColor();
+          },
+          icon: const Icon(Atlas.color),
         ),
       ],
     );
@@ -288,17 +284,25 @@ class _AddNewsState extends ConsumerState<AddNewsPage> {
 
   Widget slideImagePostUI(BuildContext context) {
     final imageFile = selectedNewsPost!.mediaFile;
-    return Image.file(
-      File(imageFile!.path),
-      fit: BoxFit.contain,
+    return Container(
+      alignment: Alignment.center,
+      color: selectedNewsPost!.backgroundColor,
+      child: Image.file(
+        File(imageFile!.path),
+        fit: BoxFit.contain,
+      ),
     );
   }
 
   Widget slideVideoPostUI(BuildContext context) {
     final videoFile = selectedNewsPost!.mediaFile!;
-    return ActerVideoPlayer(
-      key: Key(videoFile.name),
-      videoFile: File(videoFile.path),
+    return Container(
+      alignment: Alignment.center,
+      color: selectedNewsPost!.backgroundColor,
+      child: ActerVideoPlayer(
+        key: Key(videoFile.name),
+        videoFile: File(videoFile.path),
+      ),
     );
   }
 }

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -289,7 +289,7 @@ class _AddNewsState extends ConsumerState<AddNewsPage> {
       color: selectedNewsPost!.backgroundColor,
       child: Image.file(
         File(imageFile!.path),
-        fit: BoxFit.contain,
+        fit: BoxFit.fitWidth,
       ),
     );
   }

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -289,7 +289,7 @@ class _AddNewsState extends ConsumerState<AddNewsPage> {
       color: selectedNewsPost!.backgroundColor,
       child: Image.file(
         File(imageFile!.path),
-        fit: BoxFit.fitWidth,
+        fit: BoxFit.contain,
       ),
     );
   }

--- a/app/lib/features/news/providers/news_post_editor_providers.dart
+++ b/app/lib/features/news/providers/news_post_editor_providers.dart
@@ -22,6 +22,9 @@ class NewsStateNotifier extends StateNotifier<NewsPostState> {
     NewsSlideItem? selectedNewsSlide = state.currentNewsSlide;
     selectedNewsSlide?.backgroundColor =
         Colors.primaries[Random().nextInt(Colors.primaries.length)];
+    print("Color : ${selectedNewsSlide?.backgroundColor?.red}");
+    print("Color : ${selectedNewsSlide?.backgroundColor?.green}");
+    print("Color : ${selectedNewsSlide?.backgroundColor?.blue}");
     state = state.copyWith(
       currentNewsSlide: selectedNewsSlide,
     );

--- a/app/lib/features/news/providers/news_post_editor_providers.dart
+++ b/app/lib/features/news/providers/news_post_editor_providers.dart
@@ -22,9 +22,6 @@ class NewsStateNotifier extends StateNotifier<NewsPostState> {
     NewsSlideItem? selectedNewsSlide = state.currentNewsSlide;
     selectedNewsSlide?.backgroundColor =
         Colors.primaries[Random().nextInt(Colors.primaries.length)];
-    print("Color : ${selectedNewsSlide?.backgroundColor?.red}");
-    print("Color : ${selectedNewsSlide?.backgroundColor?.green}");
-    print("Color : ${selectedNewsSlide?.backgroundColor?.blue}");
     state = state.copyWith(
       currentNewsSlide: selectedNewsSlide,
     );

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -37,11 +37,11 @@ class _NewsItemState extends ConsumerState<NewsItem> {
     final space = ref.watch(briefSpaceItemProvider(roomId));
     final slides = widget.news.slides().toList();
     final bgColor = convertColor(
-      widget.news.colors()?.background(),
+      widget.news.getSlide(currentSlideIndex)?.colors()?.background(),
       Theme.of(context).colorScheme.background,
     );
     final fgColor = convertColor(
-      widget.news.colors()?.color(),
+      widget.news.getSlide(currentSlideIndex)?.colors()?.color(),
       Theme.of(context).colorScheme.onPrimary,
     );
 

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -16,6 +16,7 @@ class NewsItem extends ConsumerStatefulWidget {
   final Client client;
   final NewsEntry news;
   final int index;
+
   const NewsItem({
     super.key,
     required this.client,
@@ -60,11 +61,15 @@ class _NewsItemState extends ConsumerState<NewsItem> {
               case 'image':
                 return ImageSlide(
                   slide: slides[idx],
+                  bgColor: bgColor,
+                  fgColor: fgColor,
                 );
 
               case 'video':
                 return VideoSlide(
                   slide: slides[idx],
+                  bgColor: bgColor,
+                  fgColor: fgColor,
                 );
 
               case 'text':
@@ -84,7 +89,7 @@ class _NewsItemState extends ConsumerState<NewsItem> {
           },
         ),
         Padding(
-          padding: const EdgeInsets.only(left: 8, right: 80, bottom: 8),
+          padding: const EdgeInsets.all(16),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -103,20 +108,6 @@ class _NewsItemState extends ConsumerState<NewsItem> {
                   loading: () => Skeletonizer(
                     child: Text(roomId),
                   ),
-                ),
-              ),
-              Text(
-                slides[currentSlideIndex].text(),
-                softWrap: true,
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                  color: fgColor,
-                  shadows: [
-                    Shadow(
-                      color: bgColor,
-                      offset: const Offset(1, 1),
-                      blurRadius: 0,
-                    ),
-                  ],
                 ),
               ),
             ],

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -16,7 +16,6 @@ class NewsItem extends ConsumerStatefulWidget {
   final Client client;
   final NewsEntry news;
   final int index;
-
   const NewsItem({
     super.key,
     required this.client,
@@ -36,12 +35,13 @@ class _NewsItemState extends ConsumerState<NewsItem> {
     final roomId = widget.news.roomId().toString();
     final space = ref.watch(briefSpaceItemProvider(roomId));
     final slides = widget.news.slides().toList();
+    final color = slides[currentSlideIndex].colors();
     final bgColor = convertColor(
-      widget.news.getSlide(currentSlideIndex)?.colors()?.background(),
+      color?.background(),
       Theme.of(context).colorScheme.background,
     );
     final fgColor = convertColor(
-      widget.news.getSlide(currentSlideIndex)?.colors()?.color(),
+      color?.color(),
       Theme.of(context).colorScheme.onPrimary,
     );
 

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -6,10 +6,14 @@ import 'package:flutter/material.dart';
 
 class ImageSlide extends StatefulWidget {
   final NewsSlide slide;
+  final Color bgColor;
+  final Color fgColor;
 
   const ImageSlide({
     super.key,
     required this.slide,
+    required this.bgColor,
+    required this.fgColor,
   });
 
   @override
@@ -41,10 +45,12 @@ class _ImageSlideState extends State<ImageSlide> {
       builder: (BuildContext context, AsyncSnapshot<Uint8List> snapshot) {
         if (snapshot.hasData) {
           return Container(
+            color: widget.bgColor,
+            alignment: Alignment.center,
             key: NewsUpdateKeys.imageUpdateContent,
             foregroundDecoration: BoxDecoration(
               image: DecorationImage(
-                fit: BoxFit.cover,
+                fit: BoxFit.fitWidth,
                 image: MemoryImage(
                   Uint8List.fromList(snapshot.data!),
                 ),

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -50,7 +50,7 @@ class _ImageSlideState extends State<ImageSlide> {
             key: NewsUpdateKeys.imageUpdateContent,
             foregroundDecoration: BoxDecoration(
               image: DecorationImage(
-                fit: BoxFit.fitWidth,
+                fit: BoxFit.contain,
                 image: MemoryImage(
                   Uint8List.fromList(snapshot.data!),
                 ),

--- a/app/lib/features/news/widgets/news_item_slide/text_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/text_slide.dart
@@ -18,6 +18,10 @@ class TextSlide extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+
+    print("Color bg : $bgColor");
+    print("Color fg : $fgColor");
+
     return Container(
       color: bgColor,
       alignment: Alignment.center,

--- a/app/lib/features/news/widgets/news_item_slide/text_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/text_slide.dart
@@ -18,10 +18,6 @@ class TextSlide extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
-    print("Color bg : $bgColor");
-    print("Color fg : $fgColor");
-
     return Container(
       color: bgColor,
       alignment: Alignment.center,

--- a/app/lib/features/news/widgets/news_item_slide/video_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/video_slide.dart
@@ -7,10 +7,14 @@ import 'package:path_provider/path_provider.dart';
 
 class VideoSlide extends StatefulWidget {
   final NewsSlide slide;
+  final Color bgColor;
+  final Color fgColor;
 
   const VideoSlide({
     super.key,
     required this.slide,
+    required this.bgColor,
+    required this.fgColor,
   });
 
   @override
@@ -32,18 +36,21 @@ class _VideoSlideState extends State<VideoSlide> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<File>(
-      future: getNewsVideo(),
-      builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-        if (snapshot.hasData) {
-          return ActerVideoPlayer(
-            key: Key(snapshot.data!.path),
-            videoFile: snapshot.data!,
-          );
-        } else {
-          return const Center(child: Text('Loading video'));
-        }
-      },
+    return Container(
+      color: widget.bgColor,
+      alignment: Alignment.center,
+      child: FutureBuilder<Uint8List>(
+        future: newsVideo.then((value) => value.asTypedList()),
+        builder: (BuildContext context, AsyncSnapshot<Uint8List> snapshot) {
+          if (snapshot.hasData) {
+            return ActerVideoPlayer(
+              videoFile: File.fromRawPath(snapshot.data!),
+            );
+          } else {
+            return const Center(child: Text('Loading video'));
+          }
+        },
+      ),
     );
   }
 }

--- a/app/lib/features/news/widgets/news_item_slide/video_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/video_slide.dart
@@ -39,12 +39,13 @@ class _VideoSlideState extends State<VideoSlide> {
     return Container(
       color: widget.bgColor,
       alignment: Alignment.center,
-      child: FutureBuilder<Uint8List>(
-        future: newsVideo.then((value) => value.asTypedList()),
-        builder: (BuildContext context, AsyncSnapshot<Uint8List> snapshot) {
+      child: FutureBuilder<File>(
+        future: getNewsVideo(),
+        builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
           if (snapshot.hasData) {
             return ActerVideoPlayer(
-              videoFile: File.fromRawPath(snapshot.data!),
+              key: Key(snapshot.data!.path),
+              videoFile: snapshot.data!,
             );
           } else {
             return const Center(child: Text('Loading video'));

--- a/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
+++ b/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -251,6 +252,10 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
       final space = await ref.read(spaceProvider(spaceId).future);
       NewsEntryDraft draft = space.newsDraft();
       for (final slidePost in newsSlideList) {
+        final sdk = await ref.read(sdkProvider.future);
+        String slideBgColor =
+            'rgb(${slidePost.backgroundColor?.red}, ${slidePost.backgroundColor?.green}, ${slidePost.backgroundColor?.blue})';
+
         // If slide type is text
         if (slidePost.type == NewsSlideType.text && slidePost.text != null) {
           if (slidePost.text!.isEmpty) {
@@ -260,6 +265,13 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
 
           final textDraft = client.textMarkdownDraft(slidePost.text!);
           final textSlideDraft = textDraft.intoNewsSlideDraft();
+
+          textSlideDraft.color(
+            sdk.api.newColorizeBuilder(
+              null,
+              slideBgColor,
+            ),
+          );
           await draft.addSlide(textSlideDraft);
         }
 
@@ -286,6 +298,12 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
               .width(decodedImage.width)
               .height(decodedImage.height);
           final imageSlideDraft = imageDraft.intoNewsSlideDraft();
+          imageSlideDraft.color(
+            sdk.api.newColorizeBuilder(
+              null,
+              slideBgColor,
+            ),
+          );
           await draft.addSlide(imageSlideDraft);
         }
 
@@ -308,6 +326,12 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
           final videoDraft =
               client.videoDraft(file.path, mimeType).size(bytes.length);
           final videoSlideDraft = videoDraft.intoNewsSlideDraft();
+          videoSlideDraft.color(
+            sdk.api.newColorizeBuilder(
+              null,
+              slideBgColor,
+            ),
+          );
           await draft.addSlide(videoSlideDraft);
         }
       }

--- a/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
+++ b/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
@@ -253,9 +253,6 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
       NewsEntryDraft draft = space.newsDraft();
       for (final slidePost in newsSlideList) {
         final sdk = await ref.read(sdkProvider.future);
-        String slideBgColor =
-            'rgb(${slidePost.backgroundColor?.red}, ${slidePost.backgroundColor?.green}, ${slidePost.backgroundColor?.blue})';
-
         // If slide type is text
         if (slidePost.type == NewsSlideType.text && slidePost.text != null) {
           if (slidePost.text!.isEmpty) {
@@ -269,7 +266,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
           textSlideDraft.color(
             sdk.api.newColorizeBuilder(
               null,
-              slideBgColor,
+              slidePost.backgroundColor?.value,
             ),
           );
           await draft.addSlide(textSlideDraft);
@@ -301,7 +298,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
           imageSlideDraft.color(
             sdk.api.newColorizeBuilder(
               null,
-              slideBgColor,
+              slidePost.backgroundColor?.value,
             ),
           );
           await draft.addSlide(imageSlideDraft);
@@ -329,7 +326,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
           videoSlideDraft.color(
             sdk.api.newColorizeBuilder(
               null,
-              slideBgColor,
+              slidePost.backgroundColor?.value,
             ),
           );
           await draft.addSlide(videoSlideDraft);

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/space_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
 import 'package:acter/common/widgets/like_button.dart';
@@ -8,7 +7,6 @@ import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/news/providers/news_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
@@ -31,20 +29,9 @@ class NewsSideBar extends ConsumerWidget {
     final roomId = news.roomId().toString();
     final userId = ref.watch(alwaysClientProvider).userId().toString();
     final space = ref.watch(briefSpaceItemWithMembershipProvider(roomId));
-    final bgColor = convertColor(
-      news.colors()?.background(),
-      Theme.of(context).colorScheme.neutral6,
-    );
-    final fgColor = convertColor(
-      news.colors()?.color(),
-      Theme.of(context).colorScheme.neutral6,
-    );
+
     final TextStyle style = Theme.of(context).textTheme.bodyLarge!.copyWith(
       fontSize: 13,
-      color: fgColor,
-      shadows: [
-        Shadow(color: bgColor, offset: const Offset(2, 2), blurRadius: 5),
-      ],
     );
 
     return Column(
@@ -53,7 +40,7 @@ class NewsSideBar extends ConsumerWidget {
         LikeButton(
           likeCount: news.likesCount().toString(),
           style: style,
-          color: fgColor,
+          color: Colors.white,
           index: index,
         ),
         const SizedBox(height: 10),

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -68,17 +68,11 @@ String userAgent = '$appName/$versionName';
 RegExp logFileRegExp = RegExp('app_.*log');
 RegExp screenshotFileRegExp = RegExp('screenshot_.*png');
 
-Color convertColor(ffi.EfkColor? primary, Color fallback) {
+Color convertColor(int? primary, Color fallback) {
   if (primary == null) {
     return fallback;
   }
-  final data = primary.rgbaU8();
-  return Color.fromARGB(
-    data[3],
-    data[0],
-    data[1],
-    data[2],
-  );
+  return Color(primary);
 }
 
 Completer<SharedPreferences>? _sharedPrefCompl;

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -68,12 +68,8 @@ String userAgent = '$appName/$versionName';
 RegExp logFileRegExp = RegExp('app_.*log');
 RegExp screenshotFileRegExp = RegExp('screenshot_.*png');
 
-Color convertColor(int? primary, Color fallback) {
-  if (primary == null) {
-    return fallback;
-  }
-  return Color(primary);
-}
+Color convertColor(int? primary, Color fallback) =>
+    Color(primary ?? fallback.value);
 
 Completer<SharedPreferences>? _sharedPrefCompl;
 Completer<String>? _appDirCompl;
@@ -228,6 +224,7 @@ class ActerSdk {
   }
 
   String? get previousLogPath => _previousLogPath;
+
   ffi.Api get api => _api;
 
   Future<ffi.Client> getClientWithDeviceId(String deviceId) async {

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -234,6 +234,7 @@ class ActerSdk {
   }
 
   String? get previousLogPath => _previousLogPath;
+  ffi.Api get api => _api;
 
   Future<ffi.Client> getClientWithDeviceId(String deviceId) async {
     ffi.Client? client;

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1331,79 +1331,57 @@ class Api {
   }
 
   ColorizeBuilder newColorizeBuilder(
-    String? color,
-    String? background,
+    int? color,
+    int? background,
   ) {
     final tmp0 = color;
-    final tmp6 = background;
+    final tmp4 = background;
     var tmp1 = 0;
     var tmp3 = 0;
-    var tmp4 = 0;
     var tmp5 = 0;
     var tmp7 = 0;
-    var tmp9 = 0;
-    var tmp10 = 0;
-    var tmp11 = 0;
     if (tmp0 == null) {
       tmp1 = 0;
     } else {
       tmp1 = 1;
       final tmp2 = tmp0;
-      final tmp2_0 = utf8.encode(tmp2);
-      tmp4 = tmp2_0.length;
-
-      final ffi.Pointer<ffi.Uint8> tmp3_0 = this.__allocate(tmp4 * 1, 1);
-      final Uint8List tmp3_1 = tmp3_0.asTypedList(tmp4);
-      tmp3_1.setAll(0, tmp2_0);
-      tmp3 = tmp3_0.address;
-      tmp5 = tmp4;
+      tmp3 = tmp2;
     }
-    if (tmp6 == null) {
-      tmp7 = 0;
+    if (tmp4 == null) {
+      tmp5 = 0;
     } else {
-      tmp7 = 1;
-      final tmp8 = tmp6;
-      final tmp8_0 = utf8.encode(tmp8);
-      tmp10 = tmp8_0.length;
-
-      final ffi.Pointer<ffi.Uint8> tmp9_0 = this.__allocate(tmp10 * 1, 1);
-      final Uint8List tmp9_1 = tmp9_0.asTypedList(tmp10);
-      tmp9_1.setAll(0, tmp8_0);
-      tmp9 = tmp9_0.address;
-      tmp11 = tmp10;
+      tmp5 = 1;
+      final tmp6 = tmp4;
+      tmp7 = tmp6;
     }
-    final tmp12 = _newColorizeBuilder(
+    final tmp8 = _newColorizeBuilder(
       tmp1,
       tmp3,
-      tmp4,
       tmp5,
       tmp7,
-      tmp9,
-      tmp10,
-      tmp11,
     );
-    final tmp14 = tmp12.arg0;
-    final tmp15 = tmp12.arg1;
-    final tmp16 = tmp12.arg2;
-    final tmp17 = tmp12.arg3;
-    final tmp18 = tmp12.arg4;
-    if (tmp14 == 0) {
-      debugAllocation("handle error", tmp15, tmp16);
-      final ffi.Pointer<ffi.Uint8> tmp15_0 = ffi.Pointer.fromAddress(tmp15);
-      final tmp14_0 =
-          utf8.decode(tmp15_0.asTypedList(tmp16), allowMalformed: true);
-      if (tmp16 > 0) {
-        final ffi.Pointer<ffi.Void> tmp15_0;
-        tmp15_0 = ffi.Pointer.fromAddress(tmp15);
-        this.__deallocate(tmp15_0, tmp17, 1);
+    final tmp10 = tmp8.arg0;
+    final tmp11 = tmp8.arg1;
+    final tmp12 = tmp8.arg2;
+    final tmp13 = tmp8.arg3;
+    final tmp14 = tmp8.arg4;
+    if (tmp10 == 0) {
+      debugAllocation("handle error", tmp11, tmp12);
+      final ffi.Pointer<ffi.Uint8> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+      final tmp10_0 =
+          utf8.decode(tmp11_0.asTypedList(tmp12), allowMalformed: true);
+      if (tmp12 > 0) {
+        final ffi.Pointer<ffi.Void> tmp11_0;
+        tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+        this.__deallocate(tmp11_0, tmp13, 1);
       }
-      throw tmp14_0;
+      throw tmp10_0;
     }
-    final ffi.Pointer<ffi.Void> tmp18_0 = ffi.Pointer.fromAddress(tmp18);
-    final tmp18_1 = _Box(this, tmp18_0, "drop_box_ColorizeBuilder");
-    tmp18_1._finalizer = this._registerFinalizer(tmp18_1);
-    final tmp13 = ColorizeBuilder._(this, tmp18_1);
-    return tmp13;
+    final ffi.Pointer<ffi.Void> tmp14_0 = ffi.Pointer.fromAddress(tmp14);
+    final tmp14_1 = _Box(this, tmp14_0, "drop_box_ColorizeBuilder");
+    tmp14_1._finalizer = this._registerFinalizer(tmp14_1);
+    final tmp9 = ColorizeBuilder._(this, tmp14_1);
+    return tmp9;
   }
 
   /// Rotate the logging file
@@ -12216,21 +12194,13 @@ class Api {
       ffi.NativeFunction<
           _NewColorizeBuilderReturn Function(
             ffi.Uint8,
-            ffi.Int64,
-            ffi.Uint64,
-            ffi.Uint64,
+            ffi.Uint32,
             ffi.Uint8,
-            ffi.Int64,
-            ffi.Uint64,
-            ffi.Uint64,
+            ffi.Uint32,
           )>>("__new_colorize_builder");
 
   late final _newColorizeBuilder = _newColorizeBuilderPtr.asFunction<
       _NewColorizeBuilderReturn Function(
-        int,
-        int,
-        int,
-        int,
         int,
         int,
         int,
@@ -12254,16 +12224,6 @@ class Api {
 
   late final _newSpaceSettingsBuilder =
       _newSpaceSettingsBuilderPtr.asFunction<int Function()>();
-  late final _efkColorRgbaU8Ptr = _lookup<
-      ffi.NativeFunction<
-          _EfkColorRgbaU8Return Function(
-            ffi.Int64,
-          )>>("__EfkColor_rgba_u8");
-
-  late final _efkColorRgbaU8 = _efkColorRgbaU8Ptr.asFunction<
-      _EfkColorRgbaU8Return Function(
-        int,
-      )>();
   late final _utcDateTimeTimestampPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -12416,23 +12376,18 @@ class Api {
       _ColorizeBackgroundReturn Function(
         int,
       )>();
-  late final _colorizeBuilderColorFromHtmlPtr = _lookup<
+  late final _colorizeBuilderColorPtr = _lookup<
       ffi.NativeFunction<
-          _ColorizeBuilderColorFromHtmlReturn Function(
+          ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
-            ffi.Uint64,
-            ffi.Uint64,
-          )>>("__ColorizeBuilder_color_from_html");
+            ffi.Uint32,
+          )>>("__ColorizeBuilder_color");
 
-  late final _colorizeBuilderColorFromHtml =
-      _colorizeBuilderColorFromHtmlPtr.asFunction<
-          _ColorizeBuilderColorFromHtmlReturn Function(
-            int,
-            int,
-            int,
-            int,
-          )>();
+  late final _colorizeBuilderColor = _colorizeBuilderColorPtr.asFunction<
+      void Function(
+        int,
+        int,
+      )>();
   late final _colorizeBuilderUnsetColorPtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -12444,20 +12399,16 @@ class Api {
           void Function(
             int,
           )>();
-  late final _colorizeBuilderBackgroundFromHtmlPtr = _lookup<
+  late final _colorizeBuilderBackgroundPtr = _lookup<
       ffi.NativeFunction<
-          _ColorizeBuilderBackgroundFromHtmlReturn Function(
+          ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
-            ffi.Uint64,
-            ffi.Uint64,
-          )>>("__ColorizeBuilder_background_from_html");
+            ffi.Uint32,
+          )>>("__ColorizeBuilder_background");
 
-  late final _colorizeBuilderBackgroundFromHtml =
-      _colorizeBuilderBackgroundFromHtmlPtr.asFunction<
-          _ColorizeBuilderBackgroundFromHtmlReturn Function(
-            int,
-            int,
+  late final _colorizeBuilderBackground =
+      _colorizeBuilderBackgroundPtr.asFunction<
+          void Function(
             int,
             int,
           )>();
@@ -12472,36 +12423,6 @@ class Api {
           void Function(
             int,
           )>();
-  late final _tagTitlePtr = _lookup<
-      ffi.NativeFunction<
-          _TagTitleReturn Function(
-            ffi.Int64,
-          )>>("__Tag_title");
-
-  late final _tagTitle = _tagTitlePtr.asFunction<
-      _TagTitleReturn Function(
-        int,
-      )>();
-  late final _tagHashTagPtr = _lookup<
-      ffi.NativeFunction<
-          _TagHashTagReturn Function(
-            ffi.Int64,
-          )>>("__Tag_hash_tag");
-
-  late final _tagHashTag = _tagHashTagPtr.asFunction<
-      _TagHashTagReturn Function(
-        int,
-      )>();
-  late final _tagColorPtr = _lookup<
-      ffi.NativeFunction<
-          _TagColorReturn Function(
-            ffi.Int64,
-          )>>("__Tag_color");
-
-  late final _tagColor = _tagColorPtr.asFunction<
-      _TagColorReturn Function(
-        int,
-      )>();
   late final _optionStringTextPtr = _lookup<
       ffi.NativeFunction<
           _OptionStringTextReturn Function(
@@ -16279,7 +16200,7 @@ class Api {
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
+            ffi.Uint32,
           )>>("__TaskUpdateBuilder_color");
 
   late final _taskUpdateBuilderColor = _taskUpdateBuilderColorPtr.asFunction<
@@ -16659,7 +16580,7 @@ class Api {
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
+            ffi.Uint32,
           )>>("__TaskDraft_color");
 
   late final _taskDraftColor = _taskDraftColorPtr.asFunction<
@@ -17126,7 +17047,7 @@ class Api {
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
+            ffi.Uint32,
           )>>("__TaskListDraft_color");
 
   late final _taskListDraftColor = _taskListDraftColorPtr.asFunction<
@@ -17273,7 +17194,7 @@ class Api {
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.Int64,
-            ffi.Int64,
+            ffi.Uint32,
           )>>("__TaskListUpdateBuilder_color");
 
   late final _taskListUpdateBuilderColor =
@@ -26290,42 +26211,6 @@ class EfkDuration {
   }
 }
 
-/// Representing a color
-class EfkColor {
-  final Api _api;
-  final _Box _box;
-
-  EfkColor._(this._api, this._box);
-
-  /// as rgba in u8
-  List<dynamic> rgbaU8() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._efkColorRgbaU8(
-      tmp0,
-    );
-    final tmp4 = tmp1.arg0;
-    final tmp6 = tmp1.arg1;
-    final tmp8 = tmp1.arg2;
-    final tmp10 = tmp1.arg3;
-    final tmp3 = tmp4;
-    final tmp5 = tmp6;
-    final tmp7 = tmp8;
-    final tmp9 = tmp10;
-    final List tmp2 = [];
-    tmp2.add(tmp3);
-    tmp2.add(tmp5);
-    tmp2.add(tmp7);
-    tmp2.add(tmp9);
-    return tmp2;
-  }
-
-  /// Manually drops the object and unregisters the FinalizableHandle.
-  void drop() {
-    _box.drop();
-  }
-}
-
 class UtcDateTime {
   final Api _api;
   final _Box _box;
@@ -26730,7 +26615,7 @@ class Colorize {
   Colorize._(this._api, this._box);
 
   /// Foreground or text color
-  EfkColor? color() {
+  int? color() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._colorizeColor(
@@ -26741,15 +26626,12 @@ class Colorize {
     if (tmp3 == 0) {
       return null;
     }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 
   /// Background color
-  EfkColor? background() {
+  int? background() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._colorizeBackground(
@@ -26760,10 +26642,7 @@ class Colorize {
     if (tmp3 == 0) {
       return null;
     }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 
@@ -26780,49 +26659,20 @@ class ColorizeBuilder {
 
   ColorizeBuilder._(this._api, this._box);
 
-  /// parse html css-style string to set the color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
-  bool colorFromHtml(
-    String color,
+  /// RGBA color representation as int for the foreground color
+  void color(
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
-    var tmp3 = 0;
-    var tmp4 = 0;
     tmp0 = _box.borrow();
-    final tmp1_0 = utf8.encode(tmp1);
-    tmp3 = tmp1_0.length;
-
-    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
-    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
-    tmp2_1.setAll(0, tmp1_0);
-    tmp2 = tmp2_0.address;
-    tmp4 = tmp3;
-    final tmp5 = _api._colorizeBuilderColorFromHtml(
+    tmp2 = tmp1;
+    _api._colorizeBuilderColor(
       tmp0,
       tmp2,
-      tmp3,
-      tmp4,
     );
-    final tmp7 = tmp5.arg0;
-    final tmp8 = tmp5.arg1;
-    final tmp9 = tmp5.arg2;
-    final tmp10 = tmp5.arg3;
-    final tmp11 = tmp5.arg4;
-    if (tmp7 == 0) {
-      debugAllocation("handle error", tmp8, tmp9);
-      final ffi.Pointer<ffi.Uint8> tmp8_0 = ffi.Pointer.fromAddress(tmp8);
-      final tmp7_0 =
-          utf8.decode(tmp8_0.asTypedList(tmp9), allowMalformed: true);
-      if (tmp9 > 0) {
-        final ffi.Pointer<ffi.Void> tmp8_0;
-        tmp8_0 = ffi.Pointer.fromAddress(tmp8);
-        _api.__deallocate(tmp8_0, tmp10, 1);
-      }
-      throw tmp7_0;
-    }
-    final tmp6 = tmp11 > 0;
-    return tmp6;
+    return;
   }
 
   /// unset the color
@@ -26835,49 +26685,20 @@ class ColorizeBuilder {
     return;
   }
 
-  /// parse html css-style string to set the background color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
-  bool backgroundFromHtml(
-    String color,
+  /// RGBA color representation as int for the background color
+  void background(
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
-    var tmp3 = 0;
-    var tmp4 = 0;
     tmp0 = _box.borrow();
-    final tmp1_0 = utf8.encode(tmp1);
-    tmp3 = tmp1_0.length;
-
-    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
-    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
-    tmp2_1.setAll(0, tmp1_0);
-    tmp2 = tmp2_0.address;
-    tmp4 = tmp3;
-    final tmp5 = _api._colorizeBuilderBackgroundFromHtml(
+    tmp2 = tmp1;
+    _api._colorizeBuilderBackground(
       tmp0,
       tmp2,
-      tmp3,
-      tmp4,
     );
-    final tmp7 = tmp5.arg0;
-    final tmp8 = tmp5.arg1;
-    final tmp9 = tmp5.arg2;
-    final tmp10 = tmp5.arg3;
-    final tmp11 = tmp5.arg4;
-    if (tmp7 == 0) {
-      debugAllocation("handle error", tmp8, tmp9);
-      final ffi.Pointer<ffi.Uint8> tmp8_0 = ffi.Pointer.fromAddress(tmp8);
-      final tmp7_0 =
-          utf8.decode(tmp8_0.asTypedList(tmp9), allowMalformed: true);
-      if (tmp9 > 0) {
-        final ffi.Pointer<ffi.Void> tmp8_0;
-        tmp8_0 = ffi.Pointer.fromAddress(tmp8);
-        _api.__deallocate(tmp8_0, tmp10, 1);
-      }
-      throw tmp7_0;
-    }
-    final tmp6 = tmp11 > 0;
-    return tmp6;
+    return;
   }
 
   /// unset the background color
@@ -26888,97 +26709,6 @@ class ColorizeBuilder {
       tmp0,
     );
     return;
-  }
-
-  /// Manually drops the object and unregisters the FinalizableHandle.
-  void drop() {
-    _box.drop();
-  }
-}
-
-class Tag {
-  final Api _api;
-  final _Box _box;
-
-  Tag._(this._api, this._box);
-
-  /// the title of the tag
-  String title() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._tagTitle(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    if (tmp4 == 0) {
-      print("returning empty string");
-      return "";
-    }
-    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
-    List<int> tmp3_buf = [];
-    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
-    for (int i = 0; i < tmp4; i++) {
-      int char = tmp3_precast.elementAt(i).value;
-      tmp3_buf.add(char);
-    }
-    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
-    if (tmp5 > 0) {
-      final ffi.Pointer<ffi.Void> tmp3_0;
-      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
-    }
-    return tmp2;
-  }
-
-  /// dash-cased-ascii-version for usage in hashtags (no `#` at the front)
-  String hashTag() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._tagHashTag(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    if (tmp4 == 0) {
-      print("returning empty string");
-      return "";
-    }
-    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
-    List<int> tmp3_buf = [];
-    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
-    for (int i = 0; i < tmp4; i++) {
-      int char = tmp3_precast.elementAt(i).value;
-      tmp3_buf.add(char);
-    }
-    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
-    if (tmp5 > 0) {
-      final ffi.Pointer<ffi.Void> tmp3_0;
-      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
-    }
-    return tmp2;
-  }
-
-  /// if given, the specific color for this tag
-  EfkColor? color() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._tagColor(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    if (tmp3 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
-    return tmp2;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
@@ -28804,7 +28534,7 @@ class ActerPin {
   }
 
   /// get the link color settings
-  EfkColor? color() {
+  int? color() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._acterPinColor(
@@ -28815,10 +28545,7 @@ class ActerPin {
     if (tmp3 == 0) {
       return null;
     }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 
@@ -34666,7 +34393,7 @@ class Task {
   }
 
   /// Has this been colored in?
-  EfkColor? color() {
+  int? color() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._taskColor(
@@ -34677,10 +34404,7 @@ class Task {
     if (tmp3 == 0) {
       return null;
     }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 
@@ -34983,13 +34707,13 @@ class TaskUpdateBuilder {
 
   /// set the color for this task list
   void color(
-    EfkColor color,
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
+    tmp2 = tmp1;
     _api._taskUpdateBuilderColor(
       tmp0,
       tmp2,
@@ -35487,13 +35211,13 @@ class TaskDraft {
 
   /// set the color for this task
   void color(
-    EfkColor color,
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
+    tmp2 = tmp1;
     _api._taskDraftColor(
       tmp0,
       tmp2,
@@ -35952,7 +35676,7 @@ class TaskList {
   }
 
   /// Has this been colored in?
-  EfkColor? color() {
+  int? color() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._taskListColor(
@@ -35963,10 +35687,7 @@ class TaskList {
     if (tmp3 == 0) {
       return null;
     }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_EfkColor");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = EfkColor._(_api, tmp4_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 
@@ -36341,13 +36062,13 @@ class TaskListDraft {
 
   /// set the color for this task list
   void color(
-    EfkColor color,
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
+    tmp2 = tmp1;
     _api._taskListDraftColor(
       tmp0,
       tmp2,
@@ -36531,13 +36252,13 @@ class TaskListUpdateBuilder {
 
   /// set the color for this task list
   void color(
-    EfkColor color,
+    int color,
   ) {
     final tmp1 = color;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
+    tmp2 = tmp1;
     _api._taskListUpdateBuilderColor(
       tmp0,
       tmp2,
@@ -45224,17 +44945,6 @@ class _NewColorizeBuilderReturn extends ffi.Struct {
   external int arg4;
 }
 
-class _EfkColorRgbaU8Return extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.Uint8()
-  external int arg2;
-  @ffi.Uint8()
-  external int arg3;
-}
-
 class _UtcDateTimeToRfc2822Return extends ffi.Struct {
   @ffi.Int64()
   external int arg0;
@@ -45340,65 +45050,14 @@ class _ObjRefPositionStrReturn extends ffi.Struct {
 class _ColorizeColorReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Int64()
+  @ffi.Uint32()
   external int arg1;
 }
 
 class _ColorizeBackgroundReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
-class _ColorizeBuilderColorFromHtmlReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint8()
-  external int arg4;
-}
-
-class _ColorizeBuilderBackgroundFromHtmlReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
-  @ffi.Uint8()
-  external int arg4;
-}
-
-class _TagTitleReturn extends ffi.Struct {
-  @ffi.Int64()
-  external int arg0;
-  @ffi.Uint64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-}
-
-class _TagHashTagReturn extends ffi.Struct {
-  @ffi.Int64()
-  external int arg0;
-  @ffi.Uint64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-}
-
-class _TagColorReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -45655,7 +45314,7 @@ class _ActerPinUrlReturn extends ffi.Struct {
 class _ActerPinColorReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Int64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -46397,7 +46056,7 @@ class _TaskUtcStartRfc3339Return extends ffi.Struct {
 class _TaskColorReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Int64()
+  @ffi.Uint32()
   external int arg1;
 }
 
@@ -46526,7 +46185,7 @@ class _TaskListRoleReturn extends ffi.Struct {
 class _TaskListColorReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
-  @ffi.Int64()
+  @ffi.Uint32()
   external int arg1;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1330,6 +1330,82 @@ class Api {
     return tmp5;
   }
 
+  ColorizeBuilder newColorizeBuilder(
+    String? color,
+    String? background,
+  ) {
+    final tmp0 = color;
+    final tmp6 = background;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp5 = 0;
+    var tmp7 = 0;
+    var tmp9 = 0;
+    var tmp10 = 0;
+    var tmp11 = 0;
+    if (tmp0 == null) {
+      tmp1 = 0;
+    } else {
+      tmp1 = 1;
+      final tmp2 = tmp0;
+      final tmp2_0 = utf8.encode(tmp2);
+      tmp4 = tmp2_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp3_0 = this.__allocate(tmp4 * 1, 1);
+      final Uint8List tmp3_1 = tmp3_0.asTypedList(tmp4);
+      tmp3_1.setAll(0, tmp2_0);
+      tmp3 = tmp3_0.address;
+      tmp5 = tmp4;
+    }
+    if (tmp6 == null) {
+      tmp7 = 0;
+    } else {
+      tmp7 = 1;
+      final tmp8 = tmp6;
+      final tmp8_0 = utf8.encode(tmp8);
+      tmp10 = tmp8_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp9_0 = this.__allocate(tmp10 * 1, 1);
+      final Uint8List tmp9_1 = tmp9_0.asTypedList(tmp10);
+      tmp9_1.setAll(0, tmp8_0);
+      tmp9 = tmp9_0.address;
+      tmp11 = tmp10;
+    }
+    final tmp12 = _newColorizeBuilder(
+      tmp1,
+      tmp3,
+      tmp4,
+      tmp5,
+      tmp7,
+      tmp9,
+      tmp10,
+      tmp11,
+    );
+    final tmp14 = tmp12.arg0;
+    final tmp15 = tmp12.arg1;
+    final tmp16 = tmp12.arg2;
+    final tmp17 = tmp12.arg3;
+    final tmp18 = tmp12.arg4;
+    if (tmp14 == 0) {
+      debugAllocation("handle error", tmp15, tmp16);
+      final ffi.Pointer<ffi.Uint8> tmp15_0 = ffi.Pointer.fromAddress(tmp15);
+      final tmp14_0 =
+          utf8.decode(tmp15_0.asTypedList(tmp16), allowMalformed: true);
+      if (tmp16 > 0) {
+        final ffi.Pointer<ffi.Void> tmp15_0;
+        tmp15_0 = ffi.Pointer.fromAddress(tmp15);
+        this.__deallocate(tmp15_0, tmp17, 1);
+      }
+      throw tmp14_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp18_0 = ffi.Pointer.fromAddress(tmp18);
+    final tmp18_1 = _Box(this, tmp18_0, "drop_box_ColorizeBuilder");
+    tmp18_1._finalizer = this._registerFinalizer(tmp18_1);
+    final tmp13 = ColorizeBuilder._(this, tmp18_1);
+    return tmp13;
+  }
+
   /// Rotate the logging file
   JoinRuleBuilder newJoinRuleBuilder() {
     final tmp0 = _newJoinRuleBuilder();
@@ -12136,6 +12212,30 @@ class Api {
         int,
         int,
       )>();
+  late final _newColorizeBuilderPtr = _lookup<
+      ffi.NativeFunction<
+          _NewColorizeBuilderReturn Function(
+            ffi.Uint8,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Uint8,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__new_colorize_builder");
+
+  late final _newColorizeBuilder = _newColorizeBuilderPtr.asFunction<
+      _NewColorizeBuilderReturn Function(
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+      )>();
   late final _newJoinRuleBuilderPtr =
       _lookup<ffi.NativeFunction<ffi.Int64 Function()>>(
           "__new_join_rule_builder");
@@ -12316,6 +12416,62 @@ class Api {
       _ColorizeBackgroundReturn Function(
         int,
       )>();
+  late final _colorizeBuilderColorFromHtmlPtr = _lookup<
+      ffi.NativeFunction<
+          _ColorizeBuilderColorFromHtmlReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__ColorizeBuilder_color_from_html");
+
+  late final _colorizeBuilderColorFromHtml =
+      _colorizeBuilderColorFromHtmlPtr.asFunction<
+          _ColorizeBuilderColorFromHtmlReturn Function(
+            int,
+            int,
+            int,
+            int,
+          )>();
+  late final _colorizeBuilderUnsetColorPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+          )>>("__ColorizeBuilder_unset_color");
+
+  late final _colorizeBuilderUnsetColor =
+      _colorizeBuilderUnsetColorPtr.asFunction<
+          void Function(
+            int,
+          )>();
+  late final _colorizeBuilderBackgroundFromHtmlPtr = _lookup<
+      ffi.NativeFunction<
+          _ColorizeBuilderBackgroundFromHtmlReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__ColorizeBuilder_background_from_html");
+
+  late final _colorizeBuilderBackgroundFromHtml =
+      _colorizeBuilderBackgroundFromHtmlPtr.asFunction<
+          _ColorizeBuilderBackgroundFromHtmlReturn Function(
+            int,
+            int,
+            int,
+            int,
+          )>();
+  late final _colorizeBuilderUnsetBackgroundPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+          )>>("__ColorizeBuilder_unset_background");
+
+  late final _colorizeBuilderUnsetBackground =
+      _colorizeBuilderUnsetBackgroundPtr.asFunction<
+          void Function(
+            int,
+          )>();
   late final _tagTitlePtr = _lookup<
       ffi.NativeFunction<
           _TagTitleReturn Function(
@@ -12732,6 +12888,16 @@ class Api {
       int Function(
         int,
       )>();
+  late final _newsSlideColorsPtr = _lookup<
+      ffi.NativeFunction<
+          _NewsSlideColorsReturn Function(
+            ffi.Int64,
+          )>>("__NewsSlide_colors");
+
+  late final _newsSlideColors = _newsSlideColorsPtr.asFunction<
+      _NewsSlideColorsReturn Function(
+        int,
+      )>();
   late final _newsSlideMsgContentPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -12769,6 +12935,18 @@ class Api {
             int,
             int,
           )>();
+  late final _newsSlideDraftColorPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__NewsSlideDraft_color");
+
+  late final _newsSlideDraftColor = _newsSlideDraftColorPtr.asFunction<
+      void Function(
+        int,
+        int,
+      )>();
   late final _newsSlideDraftUnsetReferencesPtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -12810,16 +12988,6 @@ class Api {
 
   late final _newsEntrySlides = _newsEntrySlidesPtr.asFunction<
       int Function(
-        int,
-      )>();
-  late final _newsEntryColorsPtr = _lookup<
-      ffi.NativeFunction<
-          _NewsEntryColorsReturn Function(
-            ffi.Int64,
-          )>>("__NewsEntry_colors");
-
-  late final _newsEntryColors = _newsEntryColorsPtr.asFunction<
-      _NewsEntryColorsReturn Function(
         int,
       )>();
   late final _newsEntryCommentsCountPtr = _lookup<
@@ -12920,29 +13088,6 @@ class Api {
           void Function(
             int,
           )>();
-  late final _newsEntryDraftColorsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__NewsEntryDraft_colors");
-
-  late final _newsEntryDraftColors = _newsEntryDraftColorsPtr.asFunction<
-      void Function(
-        int,
-        int,
-      )>();
-  late final _newsEntryDraftUnsetColorsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-          )>>("__NewsEntryDraft_unset_colors");
-
-  late final _newsEntryDraftUnsetColors =
-      _newsEntryDraftUnsetColorsPtr.asFunction<
-          void Function(
-            int,
-          )>();
   late final _newsEntryDraftSendPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -13001,41 +13146,6 @@ class Api {
           void Function(
             int,
             int,
-            int,
-          )>();
-  late final _newsEntryUpdateBuilderColorsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.Int64,
-          )>>("__NewsEntryUpdateBuilder_colors");
-
-  late final _newsEntryUpdateBuilderColors =
-      _newsEntryUpdateBuilderColorsPtr.asFunction<
-          void Function(
-            int,
-            int,
-          )>();
-  late final _newsEntryUpdateBuilderUnsetColorsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-          )>>("__NewsEntryUpdateBuilder_unset_colors");
-
-  late final _newsEntryUpdateBuilderUnsetColors =
-      _newsEntryUpdateBuilderUnsetColorsPtr.asFunction<
-          void Function(
-            int,
-          )>();
-  late final _newsEntryUpdateBuilderUnsetColorsUpdatePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-          )>>("__NewsEntryUpdateBuilder_unset_colors_update");
-
-  late final _newsEntryUpdateBuilderUnsetColorsUpdate =
-      _newsEntryUpdateBuilderUnsetColorsUpdatePtr.asFunction<
-          void Function(
             int,
           )>();
   late final _newsEntryUpdateBuilderSendPtr = _lookup<
@@ -26663,6 +26773,129 @@ class Colorize {
   }
 }
 
+/// A builder for Colorize. Allowing you to set (foreground) color and background
+class ColorizeBuilder {
+  final Api _api;
+  final _Box _box;
+
+  ColorizeBuilder._(this._api, this._box);
+
+  /// parse html css-style string to set the color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
+  bool colorFromHtml(
+    String color,
+  ) {
+    final tmp1 = color;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._colorizeBuilderColorFromHtml(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+    );
+    final tmp7 = tmp5.arg0;
+    final tmp8 = tmp5.arg1;
+    final tmp9 = tmp5.arg2;
+    final tmp10 = tmp5.arg3;
+    final tmp11 = tmp5.arg4;
+    if (tmp7 == 0) {
+      debugAllocation("handle error", tmp8, tmp9);
+      final ffi.Pointer<ffi.Uint8> tmp8_0 = ffi.Pointer.fromAddress(tmp8);
+      final tmp7_0 =
+          utf8.decode(tmp8_0.asTypedList(tmp9), allowMalformed: true);
+      if (tmp9 > 0) {
+        final ffi.Pointer<ffi.Void> tmp8_0;
+        tmp8_0 = ffi.Pointer.fromAddress(tmp8);
+        _api.__deallocate(tmp8_0, tmp10, 1);
+      }
+      throw tmp7_0;
+    }
+    final tmp6 = tmp11 > 0;
+    return tmp6;
+  }
+
+  /// unset the color
+  void unsetColor() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    _api._colorizeBuilderUnsetColor(
+      tmp0,
+    );
+    return;
+  }
+
+  /// parse html css-style string to set the background color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
+  bool backgroundFromHtml(
+    String color,
+  ) {
+    final tmp1 = color;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._colorizeBuilderBackgroundFromHtml(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+    );
+    final tmp7 = tmp5.arg0;
+    final tmp8 = tmp5.arg1;
+    final tmp9 = tmp5.arg2;
+    final tmp10 = tmp5.arg3;
+    final tmp11 = tmp5.arg4;
+    if (tmp7 == 0) {
+      debugAllocation("handle error", tmp8, tmp9);
+      final ffi.Pointer<ffi.Uint8> tmp8_0 = ffi.Pointer.fromAddress(tmp8);
+      final tmp7_0 =
+          utf8.decode(tmp8_0.asTypedList(tmp9), allowMalformed: true);
+      if (tmp9 > 0) {
+        final ffi.Pointer<ffi.Void> tmp8_0;
+        tmp8_0 = ffi.Pointer.fromAddress(tmp8);
+        _api.__deallocate(tmp8_0, tmp10, 1);
+      }
+      throw tmp7_0;
+    }
+    final tmp6 = tmp11 > 0;
+    return tmp6;
+  }
+
+  /// unset the background color
+  void unsetBackground() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    _api._colorizeBuilderUnsetBackground(
+      tmp0,
+    );
+    return;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
 class Tag {
   final Api _api;
   final _Box _box;
@@ -27807,6 +28040,25 @@ class NewsSlide {
     return tmp2;
   }
 
+  /// The color setting
+  Colorize? colors() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._newsSlideColors(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_Colorize");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = Colorize._(_api, tmp4_1);
+    return tmp2;
+  }
+
   /// if this is a media, hand over the description
   MsgContent msgContent() {
     var tmp0 = 0;
@@ -27875,6 +28127,22 @@ class NewsSlideDraft {
     tmp0 = _box.borrow();
     tmp2 = tmp1._box.move();
     _api._newsSlideDraftAddReference(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set the color according to the colorize builder
+  void color(
+    ColorizeBuilder color,
+  ) {
+    final tmp1 = color;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1._box.move();
+    _api._newsSlideDraftColor(
       tmp0,
       tmp2,
     );
@@ -27953,25 +28221,6 @@ class NewsEntry {
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp4 = FfiListNewsSlide._(_api, tmp3_1);
     final tmp2 = tmp4;
-    return tmp2;
-  }
-
-  /// The color setting
-  Colorize? colors() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._newsEntryColors(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    if (tmp3 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_Colorize");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = Colorize._(_api, tmp4_1);
     return tmp2;
   }
 
@@ -28124,31 +28373,6 @@ class NewsEntryDraft {
     return;
   }
 
-  /// set the color for this news entry
-  void colors(
-    Colorize colors,
-  ) {
-    final tmp1 = colors;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
-    _api._newsEntryDraftColors(
-      tmp0,
-      tmp2,
-    );
-    return;
-  }
-
-  void unsetColors() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._newsEntryDraftUnsetColors(
-      tmp0,
-    );
-    return;
-  }
-
   /// create this news entry
   Future<EventId> send() {
     var tmp0 = 0;
@@ -28235,40 +28459,6 @@ class NewsEntryUpdateBuilder {
       tmp0,
       tmp2,
       tmp4,
-    );
-    return;
-  }
-
-  /// set the color for this news entry
-  void colors(
-    Colorize colors,
-  ) {
-    final tmp1 = colors;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    tmp0 = _box.borrow();
-    tmp2 = tmp1._box.move();
-    _api._newsEntryUpdateBuilderColors(
-      tmp0,
-      tmp2,
-    );
-    return;
-  }
-
-  void unsetColors() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._newsEntryUpdateBuilderUnsetColors(
-      tmp0,
-    );
-    return;
-  }
-
-  void unsetColorsUpdate() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    _api._newsEntryUpdateBuilderUnsetColorsUpdate(
-      tmp0,
     );
     return;
   }
@@ -45021,6 +45211,19 @@ class _NewThumbSizeReturn extends ffi.Struct {
   external int arg4;
 }
 
+class _NewColorizeBuilderReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Int64()
+  external int arg4;
+}
+
 class _EfkColorRgbaU8Return extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -45146,6 +45349,32 @@ class _ColorizeBackgroundReturn extends ffi.Struct {
   external int arg0;
   @ffi.Int64()
   external int arg1;
+}
+
+class _ColorizeBuilderColorFromHtmlReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint8()
+  external int arg4;
+}
+
+class _ColorizeBuilderBackgroundFromHtmlReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Int64()
+  external int arg1;
+  @ffi.Uint64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint8()
+  external int arg4;
 }
 
 class _TagTitleReturn extends ffi.Struct {
@@ -45367,14 +45596,14 @@ class _NewsSlideTextReturn extends ffi.Struct {
   external int arg2;
 }
 
-class _NewsEntryGetSlideReturn extends ffi.Struct {
+class _NewsSlideColorsReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()
   external int arg1;
 }
 
-class _NewsEntryColorsReturn extends ffi.Struct {
+class _NewsEntryGetSlideReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -43,7 +43,7 @@ fn parse_markdown(text: string) -> Option<string>;
 fn new_thumb_size(width: u64, height: u64) -> Result<ThumbnailSize>;
 
 // create a new colorize builder
-fn new_colorize_builder(color: Option<string>, background: Option<string>) -> Result<ColorizeBuilder>;
+fn new_colorize_builder(color: Option<u32>, background: Option<u32>) -> Result<ColorizeBuilder>;
 
 
 //  ########  ########  #### ##     ## #### ######## #### ##     ## ########  ######  
@@ -57,12 +57,6 @@ fn new_colorize_builder(color: Option<string>, background: Option<string>) -> Re
 
 /// Representing a time frame
 object EfkDuration {}
-
-/// Representing a color
-object EfkColor {
-    /// as rgba in u8
-    fn rgba_u8() -> (u8, u8, u8, u8);
-}
 
 object UtcDateTime {
     fn timestamp() -> i64;
@@ -99,32 +93,22 @@ object ObjRef {
 /// A foreground and background color setting
 object Colorize {
     /// Foreground or text color
-    fn color() -> Option<EfkColor>;
+    fn color() -> Option<u32>;
     /// Background color
-    fn background() -> Option<EfkColor>;
+    fn background() -> Option<u32>;
 }
 
 /// A builder for Colorize. Allowing you to set (foreground) color and background
 object ColorizeBuilder {
-    /// parse html css-style string to set the color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
-    fn color_from_html(color: string) -> Result<bool>;
+    /// RGBA color representation as int for the foreground color 
+    fn color(color: u32);
     /// unset the color
     fn unset_color();
-    /// parse html css-style string to set the background color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
-    fn background_from_html(color: string) -> Result<bool>;
+    /// RGBA color representation as int for the background color
+    fn background(color: u32);
     /// unset the background color
     fn unset_background();
 }
-
-object Tag {
-    /// the title of the tag
-    fn title() -> string;
-    /// dash-cased-ascii-version for usage in hashtags (no `#` at the front)
-    fn hash_tag() -> string;
-    /// if given, the specific color for this tag
-    fn color() -> Option<EfkColor>;
-}
-
 
 // enum LocationType {
 //    Physical,
@@ -139,8 +123,6 @@ object Tag {
 //    fn coordinates() -> Option<string>;
 //    fn uri() -> Option<string>;
 //}
-
-
 
 
 
@@ -430,7 +412,7 @@ object ActerPin {
     /// get the link content
     fn url() -> Option<string>;
     /// get the link color settings
-    fn color() -> Option<EfkColor>;
+    fn color() -> Option<u32>;
     /// The room this Pin belongs to
     //fn team() -> Room;
 
@@ -1238,7 +1220,7 @@ object Task {
     fn utc_start_rfc3339() -> Option<string>;
 
     /// Has this been colored in?
-    fn color() -> Option<EfkColor>;
+    fn color() -> Option<u32>;
 
     /// is this task already done?
     fn is_done() -> bool;
@@ -1290,7 +1272,7 @@ object TaskUpdateBuilder {
     fn unset_sort_order_update();
 
     /// set the color for this task list
-    fn color(color: EfkColor);
+    fn color(color: u32);
     fn unset_color();
     fn unset_color_update();
 
@@ -1351,7 +1333,7 @@ object TaskDraft {
     fn sort_order(sort_order: u32);
 
     /// set the color for this task
-    fn color(color: EfkColor);
+    fn color(color: u32);
     fn unset_color();
 
     /// set the due day for this task
@@ -1402,7 +1384,7 @@ object TaskList {
     fn sort_order() -> u32;
 
     /// Has this been colored in?
-    fn color() -> Option<EfkColor>;
+    fn color() -> Option<u32>;
 
     /// Does this have any special time zone
     fn time_zone() -> Option<string>;
@@ -1451,7 +1433,7 @@ object TaskListDraft {
     fn sort_order(sort_order: u32);
 
     /// set the color for this task list
-    fn color(color: EfkColor);
+    fn color(color: u32);
     fn unset_color();
 
     /// set the keywords for this task list
@@ -1479,7 +1461,7 @@ object TaskListUpdateBuilder {
     fn sort_order(sort_order: u32);
 
     /// set the color for this task list
-    fn color(color: EfkColor);
+    fn color(color: u32);
     fn unset_color();
     fn unset_color_update();
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -42,6 +42,9 @@ fn parse_markdown(text: string) -> Option<string>;
 /// create size object to be used for thumbnail download
 fn new_thumb_size(width: u64, height: u64) -> Result<ThumbnailSize>;
 
+// create a new colorize builder
+fn new_colorize_builder(color: Option<string>, background: Option<string>) -> Result<ColorizeBuilder>;
+
 
 //  ########  ########  #### ##     ## #### ######## #### ##     ## ########  ######  
 //  ##     ## ##     ##  ##  ###   ###  ##     ##     ##  ##     ## ##       ##    ## 
@@ -99,6 +102,18 @@ object Colorize {
     fn color() -> Option<EfkColor>;
     /// Background color
     fn background() -> Option<EfkColor>;
+}
+
+/// A builder for Colorize. Allowing you to set (foreground) color and background
+object ColorizeBuilder {
+    /// parse html css-style string to set the color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
+    fn color_from_html(color: string) -> Result<bool>;
+    /// unset the color
+    fn unset_color();
+    /// parse html css-style string to set the background color. see https://docs.rs/csscolorparser/latest/csscolorparser/struct.Color.html#method.from_html
+    fn background_from_html(color: string) -> Result<bool>;
+    /// unset the background color
+    fn unset_background();
 }
 
 object Tag {
@@ -293,6 +308,9 @@ object NewsSlide {
     /// the references linked in this slide
     fn references() -> Vec<ObjRef>;
 
+    /// The color setting
+    fn colors() -> Option<Colorize>;
+
     /// if this is a media, hand over the description
     fn msg_content() -> MsgContent;
     /// if this is a media, hand over the data
@@ -305,6 +323,9 @@ object NewsSlideDraft {
     /// add reference for this slide draft
     fn add_reference(reference: ObjRef);
 
+    /// set the color according to the colorize builder
+    fn color(color: ColorizeBuilder);
+
     /// unset references for this slide draft
     fn unset_references();
 }
@@ -316,8 +337,6 @@ object NewsEntry {
     fn get_slide(pos: u8) -> Option<NewsSlide>;
     /// get all slides of this news item
     fn slides() -> Vec<NewsSlide>;
-    /// The color setting
-    fn colors() -> Option<Colorize>;
 
     /// how many comments on this news entry
     fn comments_count() -> u32;
@@ -347,10 +366,6 @@ object NewsEntryDraft {
     /// clear slides
     fn unset_slides();
 
-    /// set the color for this news entry
-    fn colors(colors: Colorize);
-    fn unset_colors();
-
     /// create this news entry
     fn send() -> Future<Result<EventId>>;
 }
@@ -365,11 +380,6 @@ object NewsEntryUpdateBuilder {
 
     /// set position of slides for this news entry
     fn swap_slides(from: u8, to: u8);
-
-    /// set the color for this news entry
-    fn colors(colors: Colorize);
-    fn unset_colors();
-    fn unset_colors_update();
 
     /// update this news entry
     fn send() -> Future<Result<EventId>>;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -57,7 +57,7 @@ pub use uniffi_api::*;
 pub use account::Account;
 pub use acter_core::{
     events::{news::NewsContent, Colorize, ColorizeBuilder, ObjRef, RefDetails, UtcDateTime},
-    models::{ActerModel, Color as EfkColor, Tag, TextMessageContent},
+    models::{ActerModel, Tag, TextMessageContent},
 };
 pub use attachments::{Attachment, AttachmentDraft, AttachmentsManager};
 pub use auth::{

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -56,7 +56,7 @@ pub use uniffi_api::*;
 
 pub use account::Account;
 pub use acter_core::{
-    events::{news::NewsContent, Colorize, ObjRef, RefDetails, UtcDateTime},
+    events::{news::NewsContent, Colorize, ColorizeBuilder, ObjRef, RefDetails, UtcDateTime},
     models::{ActerModel, Color as EfkColor, Tag, TextMessageContent},
 };
 pub use attachments::{Attachment, AttachmentDraft, AttachmentsManager};
@@ -73,8 +73,8 @@ pub use calendar_events::{CalendarEvent, CalendarEventDraft, CalendarEventUpdate
 pub use client::{Client, ClientStateBuilder, HistoryLoadState, SyncState};
 pub use comments::{Comment, CommentDraft, CommentsManager};
 pub use common::{
-    duration_from_secs, new_thumb_size, DeviceRecord, MediaSource, MsgContent, OptionBuffer,
-    OptionString, ReactionRecord, ThumbnailInfo, ThumbnailSize,
+    duration_from_secs, new_colorize_builder, new_thumb_size, DeviceRecord, MediaSource,
+    MsgContent, OptionBuffer, OptionString, ReactionRecord, ThumbnailInfo, ThumbnailSize,
 };
 pub use convo::{
     new_convo_settings_builder, Convo, ConvoDiff, CreateConvoSettings, CreateConvoSettingsBuilder,

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -1,4 +1,4 @@
-use acter_core::events::attachments::AttachmentContent;
+use acter_core::events::{attachments::AttachmentContent, ColorizeBuilder};
 use anyhow::{Context, Result};
 use core::time::Duration;
 use matrix_sdk::media::{MediaFormat, MediaThumbnailSize};
@@ -552,4 +552,18 @@ impl From<Box<ThumbnailSize>> for MediaFormat {
 
 pub fn new_thumb_size(width: u64, height: u64) -> Result<ThumbnailSize> {
     ThumbnailSize::new(width, height)
+}
+
+pub fn new_colorize_builder(
+    color: Option<String>,
+    background: Option<String>,
+) -> Result<ColorizeBuilder> {
+    let mut builder = ColorizeBuilder::default();
+    if let Some(color) = color {
+        builder.color_from_html(color)?;
+    }
+    if let Some(background) = background {
+        builder.background_from_html(background)?;
+    }
+    Ok(builder)
 }

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -555,15 +555,15 @@ pub fn new_thumb_size(width: u64, height: u64) -> Result<ThumbnailSize> {
 }
 
 pub fn new_colorize_builder(
-    color: Option<String>,
-    background: Option<String>,
+    color: Option<u32>,
+    background: Option<u32>,
 ) -> Result<ColorizeBuilder> {
     let mut builder = ColorizeBuilder::default();
     if let Some(color) = color {
-        builder.color_from_html(color)?;
+        builder.color(color);
     }
     if let Some(background) = background {
-        builder.background_from_html(background)?;
+        builder.background(background);
     }
     Ok(builder)
 }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -320,6 +320,7 @@ impl NewsSlideDraft {
             colorize_builder: ColorizeBuilder::default(),
         }
     }
+    #[allow(clippy::boxed_local)]
     pub fn color(&mut self, colors: Box<ColorizeBuilder>) {
         self.colorize_builder = *colors;
     }

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -1,7 +1,7 @@
 use acter_core::{
     events::{
         news::{self, FallbackNewsContent, NewsContent, NewsEntryBuilder, NewsSlideBuilder},
-        Colorize, ObjRef,
+        Colorize, ColorizeBuilder, ObjRef,
     },
     models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
@@ -174,6 +174,10 @@ impl NewsSlide {
         )
     }
 
+    pub fn colors(&self) -> Option<Colorize> {
+        self.inner.colors.to_owned()
+    }
+
     pub fn text(&self) -> String {
         self.inner.content.text_str()
     }
@@ -305,6 +309,7 @@ impl NewsSlide {
 pub struct NewsSlideDraft {
     content: MsgContentDraft,
     references: Vec<ObjRef>,
+    colorize_builder: ColorizeBuilder,
 }
 
 impl NewsSlideDraft {
@@ -312,8 +317,13 @@ impl NewsSlideDraft {
         NewsSlideDraft {
             content,
             references: vec![],
+            colorize_builder: ColorizeBuilder::default(),
         }
     }
+    pub fn color(&mut self, colors: Box<ColorizeBuilder>) {
+        self.colorize_builder = *colors;
+    }
+
     async fn build(self, client: &Client, room: &Room) -> Result<news::NewsSlide> {
         let content = match self.content {
             MsgContentDraft::TextPlain { body } => {
@@ -464,6 +474,7 @@ impl NewsSlideDraft {
         Ok(NewsSlideBuilder::default()
             .content(content)
             .references(self.references)
+            .colors(self.colorize_builder.build())
             .build()?)
     }
     #[allow(clippy::boxed_local)]
@@ -600,10 +611,6 @@ impl NewsEntry {
     pub fn event_id(&self) -> OwnedEventId {
         self.content.event_id().to_owned()
     }
-
-    pub fn colors(&self) -> Option<Colorize> {
-        self.content.colors().to_owned()
-    }
 }
 
 #[derive(Clone)]
@@ -634,16 +641,6 @@ impl NewsEntryDraft {
 
     pub fn unset_slides(&mut self) -> &mut Self {
         self.slides.clear();
-        self
-    }
-
-    pub fn colors(&mut self, colors: Box<Colorize>) -> &mut Self {
-        self.content.colors(Some(Box::into_inner(colors)));
-        self
-    }
-
-    pub fn unset_colors(&mut self) -> &mut Self {
-        self.content.colors(None);
         self
     }
 
@@ -717,21 +714,6 @@ impl NewsEntryUpdateBuilder {
 
     pub fn unset_slides_update(&mut self) -> &mut Self {
         self.content.slides(None);
-        self
-    }
-
-    pub fn colors(&mut self, colors: Box<Colorize>) -> &mut Self {
-        self.content.colors(Some(Some(Box::into_inner(colors))));
-        self
-    }
-
-    pub fn unset_colors(&mut self) -> &mut Self {
-        self.content.colors(Some(None));
-        self
-    }
-
-    pub fn unset_colors_update(&mut self) -> &mut Self {
-        self.content.colors(None::<Option<Colorize>>);
         self
     }
 

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -1,9 +1,9 @@
 use acter_core::{
     events::{
         pins::{self, PinBuilder},
-        Icon,
+        Color, Icon,
     },
-    models::{self, ActerModel, AnyActerModel, Color},
+    models::{self, ActerModel, AnyActerModel},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -232,8 +232,8 @@ impl Pin {
         self.content.url.clone()
     }
 
-    pub fn color(&self) -> Option<Color> {
-        self.content.display.as_ref().and_then(|t| t.color.clone())
+    pub fn color(&self) -> Option<u32> {
+        self.content.display.as_ref().and_then(|t| t.color)
     }
 
     pub fn icon(&self) -> Option<Icon> {

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -1,6 +1,9 @@
 use acter_core::{
-    events::tasks::{self, Priority, TaskBuilder, TaskListBuilder},
-    models::{self, ActerModel, AnyActerModel, Color, TaskStats},
+    events::{
+        tasks::{self, Priority, TaskBuilder, TaskListBuilder},
+        Color,
+    },
+    models::{self, ActerModel, AnyActerModel, TaskStats},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -236,8 +239,8 @@ impl TaskListDraft {
         self
     }
 
-    pub fn color(&mut self, color: Box<Color>) -> &mut Self {
-        self.content.color(Some(Box::into_inner(color)));
+    pub fn color(&mut self, color: Color) -> &mut Self {
+        self.content.color(Some(color));
         self
     }
 
@@ -313,6 +316,10 @@ impl TaskList {
 
     pub fn sort_order(&self) -> u32 {
         self.content.sort_order
+    }
+
+    pub fn color(&self) -> Option<u32> {
+        self.content.color
     }
 
     pub fn event_id_str(&self) -> String {
@@ -521,6 +528,10 @@ impl Task {
         self.content.sort_order
     }
 
+    pub fn color(&self) -> Option<u32> {
+        self.content.color
+    }
+
     pub fn room_id_str(&self) -> String {
         self.content.room_id().to_string()
     }
@@ -716,8 +727,8 @@ impl TaskDraft {
         self
     }
 
-    pub fn color(&mut self, color: Box<Color>) -> &mut Self {
-        self.content.color(Some(Box::into_inner(color)));
+    pub fn color(&mut self, color: Color) -> &mut Self {
+        self.content.color(Some(color));
         self
     }
 
@@ -862,8 +873,8 @@ impl TaskUpdateBuilder {
         self
     }
 
-    pub fn color(&mut self, color: Box<Color>) -> &mut Self {
-        self.content.color(Some(Some(Box::into_inner(color))));
+    pub fn color(&mut self, color: u32) -> &mut Self {
+        self.content.color(Some(Some(color)));
         self
     }
 
@@ -1046,8 +1057,8 @@ impl TaskListUpdateBuilder {
         self
     }
 
-    pub fn color(&mut self, color: Box<Color>) -> &mut Self {
-        self.content.color(Some(Box::into_inner(color)));
+    pub fn color(&mut self, color: Color) -> &mut Self {
+        self.content.color(Some(color));
         self
     }
 

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 async-recursion = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 chrono-tz = { version = "0.8", default-features = false, features = ["serde"] }
-csscolorparser = { version = "0.6.2", features = ["serde"] }
 dashmap = "5.5.3"
 derive-getters = "0.3.0"
 derive_builder = "0.13.0"

--- a/native/core/src/error.rs
+++ b/native/core/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     #[error("Error De/serializing: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    #[error("Error Parsing color: {0}")]
+    ColorParsing(#[from] csscolorparser::ParseColorError),
+
     #[error("Error with the matrix sdk Store")]
     Store(#[from] matrix_sdk::StoreError),
 

--- a/native/core/src/error.rs
+++ b/native/core/src/error.rs
@@ -16,9 +16,6 @@ pub enum Error {
     #[error("Error De/serializing: {0}")]
     Serialization(#[from] serde_json::Error),
 
-    #[error("Error Parsing color: {0}")]
-    ColorParsing(#[from] csscolorparser::ParseColorError),
-
     #[error("Error with the matrix sdk Store")]
     Store(#[from] matrix_sdk::StoreError),
 

--- a/native/core/src/events.rs
+++ b/native/core/src/events.rs
@@ -10,8 +10,8 @@ pub mod tasks;
 pub mod three_pid;
 
 pub use common::{
-    BelongsTo, BrandIcon, Color, Colorize, Date, Icon, Labels, ObjRef, Position, RefDetails,
-    Reference, References, Update, UtcDateTime,
+    BelongsTo, BrandIcon, Color, Colorize, ColorizeBuilder, Date, Icon, Labels, ObjRef, Position,
+    RefDetails, Reference, References, Update, UtcDateTime,
 };
 use ruma_common::exports::{serde::de::Error as SerdeDeError, serde_json as smart_serde_json};
 use ruma_events::{EventTypeDeHelper, StaticEventContent};

--- a/native/core/src/events/calendar.rs
+++ b/native/core/src/events/calendar.rs
@@ -245,7 +245,7 @@ impl CalendarEventUpdateEventContent {
         }
 
         if let Some(color) = &self.color {
-            calendar_event.color = color.clone();
+            calendar_event.color = *color;
             updated = true;
         }
 

--- a/native/core/src/events/common.rs
+++ b/native/core/src/events/common.rs
@@ -2,13 +2,15 @@ use chrono::{DateTime, Utc};
 use ruma_common::OwnedEventId;
 use serde::{Deserialize, Serialize};
 
+mod color;
 mod labels;
 mod object_reference;
 mod rendering;
 
+pub use color::Color;
 pub use labels::Labels;
 pub use object_reference::{ObjRef, RefDetails};
-pub use rendering::{BrandIcon, Color, Colorize, ColorizeBuilder, Icon, Position};
+pub use rendering::{BrandIcon, Colorize, ColorizeBuilder, Icon, Position};
 
 /// Default UTC DateTime Object
 pub type UtcDateTime = DateTime<Utc>;

--- a/native/core/src/events/common.rs
+++ b/native/core/src/events/common.rs
@@ -8,7 +8,7 @@ mod rendering;
 
 pub use labels::Labels;
 pub use object_reference::{ObjRef, RefDetails};
-pub use rendering::{BrandIcon, Color, Colorize, Icon, Position};
+pub use rendering::{BrandIcon, Color, Colorize, ColorizeBuilder, Icon, Position};
 
 /// Default UTC DateTime Object
 pub type UtcDateTime = DateTime<Utc>;

--- a/native/core/src/events/common/color.rs
+++ b/native/core/src/events/common/color.rs
@@ -1,0 +1,11 @@
+/// ARGB int representation of a color as used in dart::ui
+/// The bits are interpreted as follows:
+///     Bits 24-31 are the alpha value.
+///     Bits 16-23 are the red value.
+///     Bits 8-15 are the green value.
+///     Bits 0-7 are the blue value.
+///
+/// In other words, if AA is the alpha value in hex, RR the red value in hex, GG the green value in hex, and BB the blue value in hex, a color can be expressed as 0xAARRGGBB.
+//
+/// For example, to get a fully opaque orange, you would use 0xFFFF9000 (FF for the alpha, FF for the red, 90 for the green, and 00 for the blue).
+pub type Color = u32;

--- a/native/core/src/events/common/rendering.rs
+++ b/native/core/src/events/common/rendering.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 pub use csscolorparser::Color;
 use derive_getters::Getters;
 use ruma_events::room::ImageInfo;
@@ -20,12 +21,45 @@ pub enum Position {
 }
 
 /// Customize the color scheme
-#[derive(Clone, Debug, Getters, Deserialize, Serialize)]
+#[derive(Clone, Debug, Getters, Deserialize, Serialize, Default)]
 pub struct Colorize {
     /// The foreground color to be used, as HEX
     color: Option<Color>,
     /// The background color to be used, as HEX
     background: Option<Color>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ColorizeBuilder {
+    colorize: Colorize,
+}
+
+impl ColorizeBuilder {
+    pub fn color_from_html(&mut self, color: String) -> Result<bool> {
+        let color = Color::from_html(color)?;
+        self.colorize.color = Some(color);
+        Ok(true)
+    }
+
+    pub fn background_from_html(&mut self, color: String) -> Result<bool> {
+        let color = Color::from_html(color)?;
+        self.colorize.background = Some(color);
+        Ok(true)
+    }
+
+    pub fn unset_color(&mut self) {
+        self.colorize.color = None;
+    }
+    pub fn unset_background(&mut self) {
+        self.colorize.background = None;
+    }
+    pub fn build(self) -> Option<Colorize> {
+        let ColorizeBuilder { colorize } = self;
+        if colorize.color.is_some() || colorize.background.is_some() {
+            return Some(colorize);
+        }
+        None
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/native/core/src/events/common/rendering.rs
+++ b/native/core/src/events/common/rendering.rs
@@ -1,6 +1,4 @@
-use crate::Result;
-pub use csscolorparser::Color;
-use derive_getters::Getters;
+use super::color::Color;
 use ruma_events::room::ImageInfo;
 use serde::{Deserialize, Serialize};
 use strum::Display;
@@ -19,14 +17,22 @@ pub enum Position {
     BottomMiddle,
     BottomRight,
 }
-
 /// Customize the color scheme
-#[derive(Clone, Debug, Getters, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Colorize {
     /// The foreground color to be used, as HEX
     color: Option<Color>,
     /// The background color to be used, as HEX
     background: Option<Color>,
+}
+
+impl Colorize {
+    pub fn color(&self) -> Option<Color> {
+        self.color
+    }
+    pub fn background(&self) -> Option<Color> {
+        self.background
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -35,16 +41,12 @@ pub struct ColorizeBuilder {
 }
 
 impl ColorizeBuilder {
-    pub fn color_from_html(&mut self, color: String) -> Result<bool> {
-        let color = Color::from_html(color)?;
+    pub fn color(&mut self, color: u32) {
         self.colorize.color = Some(color);
-        Ok(true)
     }
 
-    pub fn background_from_html(&mut self, color: String) -> Result<bool> {
-        let color = Color::from_html(color)?;
+    pub fn background(&mut self, color: u32) {
         self.colorize.background = Some(color);
-        Ok(true)
     }
 
     pub fn unset_color(&mut self) {

--- a/native/core/src/events/news.rs
+++ b/native/core/src/events/news.rs
@@ -220,6 +220,15 @@ pub struct NewsSlide {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub references: Vec<ObjRef>,
+
+    /// You can define custom background and foreground colors
+    #[builder(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_some"
+    )]
+    pub colors: Option<Colorize>,
 }
 
 /// The payload for our news creation event.
@@ -230,15 +239,6 @@ pub struct NewsEntryEventContent {
     /// A news entry may have one or more slides of news
     /// which are scrolled through horizontally
     slides: Vec<NewsSlide>,
-
-    /// You can define custom background and foreground colors
-    #[builder(default)]
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_some"
-    )]
-    colors: Option<Colorize>,
 }
 
 /// The payload for our news update event.
@@ -259,15 +259,6 @@ pub struct NewsEntryUpdateEventContent {
         deserialize_with = "deserialize_some"
     )]
     pub slides: Option<Vec<NewsSlide>>,
-
-    /// You can define custom background and foreground colors
-    #[builder(default)]
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_some"
-    )]
-    pub colors: Option<Option<Colorize>>,
 }
 
 impl NewsEntryUpdateEventContent {
@@ -275,10 +266,6 @@ impl NewsEntryUpdateEventContent {
         let mut updated = false;
         if let Some(slides) = &self.slides {
             task.slides = slides.clone();
-            updated = true;
-        }
-        if let Some(colors) = &self.colors {
-            task.colors = colors.clone();
             updated = true;
         }
         Ok(updated)

--- a/native/core/src/events/pins.rs
+++ b/native/core/src/events/pins.rs
@@ -62,7 +62,7 @@ impl PinDisplayInfoUpdate {
     pub fn apply(&self, info: &mut PinDisplayInfo) -> Result<bool> {
         let mut updated = false;
         if let Some(color) = &self.color {
-            info.color = color.clone();
+            info.color = *color;
             updated = true;
         }
         if let Some(icon) = &self.icon {
@@ -83,7 +83,7 @@ impl PinDisplayInfoUpdate {
 impl From<&PinDisplayInfoUpdate> for PinDisplayInfo {
     fn from(val: &PinDisplayInfoUpdate) -> Self {
         PinDisplayInfo {
-            color: val.color.clone().unwrap_or_default(),
+            color: val.color.unwrap_or_default(),
             icon: val.icon.clone().unwrap_or_default(),
             section: val.section.clone().unwrap_or_default(),
         }

--- a/native/core/src/events/tasks.rs
+++ b/native/core/src/events/tasks.rs
@@ -181,7 +181,7 @@ impl TaskListUpdateEventContent {
             updated = true;
         }
         if let Some(color) = &self.color {
-            task_list.color = color.clone();
+            task_list.color = *color;
             updated = true;
         }
         if let Some(sort_order) = &self.sort_order {
@@ -439,7 +439,7 @@ impl TaskUpdateEventContent {
             updated = true;
         }
         if let Some(color) = &self.color {
-            task.color = color.clone();
+            task.color = *color;
             updated = true;
         }
         if let Some(keywords) = &self.keywords {

--- a/native/core/src/models.rs
+++ b/native/core/src/models.rs
@@ -1,6 +1,5 @@
 mod attachments;
 mod calendar;
-mod color;
 mod comments;
 mod common;
 mod news;
@@ -14,7 +13,6 @@ mod test;
 use async_recursion::async_recursion;
 pub use attachments::{Attachment, AttachmentUpdate, AttachmentsManager, AttachmentsStats};
 pub use calendar::{CalendarEvent, CalendarEventUpdate};
-pub use color::Color;
 pub use comments::{Comment, CommentUpdate, CommentsManager, CommentsStats};
 pub use common::*;
 pub use core::fmt::Debug;

--- a/native/core/src/models/color.rs
+++ b/native/core/src/models/color.rs
@@ -1,1 +1,0 @@
-pub use csscolorparser::Color;

--- a/native/core/src/models/pins.rs
+++ b/native/core/src/models/pins.rs
@@ -34,7 +34,6 @@ impl Pin {
     pub fn sender(&self) -> &UserId {
         &self.meta.sender
     }
-
     pub fn is_link(&self) -> bool {
         self.inner.url.is_some()
     }

--- a/native/core/src/models/tag.rs
+++ b/native/core/src/models/tag.rs
@@ -1,4 +1,4 @@
-use super::Color;
+use crate::events::Color;
 
 #[derive(Clone)]
 pub struct Tag {
@@ -15,7 +15,7 @@ impl Tag {
         self.title.to_lowercase()
     }
 
-    pub fn color(&self) -> Option<Color> {
-        self.color.clone()
+    pub fn color(&self) -> Option<u32> {
+        self.color
     }
 }

--- a/native/test/src/tests/news.rs
+++ b/native/test/src/tests/news.rs
@@ -173,10 +173,7 @@ async fn news_slide_color_test() -> Result<()> {
     let mut slide_draft = user
         .text_plain_draft("This is a simple text".to_owned())
         .into_news_slide_draft();
-    slide_draft.color(Box::new(new_colorize_builder(
-        None,
-        Some("rgb(255, 0, 255)".to_owned()),
-    )?));
+    slide_draft.color(Box::new(new_colorize_builder(None, Some(0xFF112233))?));
     draft.add_slide(Box::new(slide_draft)).await?;
     draft.send().await?;
 
@@ -204,11 +201,8 @@ async fn news_slide_color_test() -> Result<()> {
     );
     // the correct background color
     assert_eq!(
-        text_slide
-            .colors()
-            .map(|e| e.background().as_ref().map(|b| b.to_hex_string()))
-            .flatten(),
-        Some("#ff00ff".to_owned())
+        text_slide.colors().and_then(|e| e.background()),
+        Some(0xFF112233)
     );
 
     Ok(())


### PR DESCRIPTION
- Now news slide can show the background color which selected by user at the time of the news posting
- Fixed image scaling issue
- Removed unwanted caption text
- changed the internal color-code from a complex struct to an ARGB-encoding `u32` as it is much simpler, takes less bandwidth and it is directly compatible with flutter.

Reference Video:
https://github.com/acterglobal/a3/assets/51526480/df5b9f67-b837-4891-ad76-4969d3ccdf56

