### PR TITLE
Fix conflict in vm_service version of convenient_test_manager_dart

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -168,6 +168,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - name: Flutter info

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
       # - uses: actions-rs/cargo@v1
       #   name: Clippy
@@ -79,6 +80,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
       # - uses: actions-rs/cargo@v1
       #   name: Clippy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - name: Install supported toolchain

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -146,6 +146,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - uses: actions/setup-python@v4
@@ -297,6 +298,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - uses: actions/setup-python@v4
@@ -398,6 +400,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
       - uses: actions-rs/cargo@v1
         name: Clippy
@@ -107,6 +108,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
       - name: Install supported rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -192,6 +192,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - name: Flutter info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -210,6 +210,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - name: Flutter info

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.16.9'
           channel: 'stable'
 
       - name: version


### PR DESCRIPTION
Will fix this error from github action workflow.
```
Resolving dependencies...
Note: vm_service is pinned to version 13.0.0 by integration_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of convenient_test_manager_dart from git depends on vm_service ^[11](https://github.com/acterglobal/a3/actions/runs/7928751110/job/21647615501?pr=1401#step:5:12).3.0 and every version of integration_test from sdk depends on vm_service [13](https://github.com/acterglobal/a3/actions/runs/7928751110/job/21647615501?pr=1401#step:5:14).0.0, convenient_test_manager_dart from git is incompatible with integration_test from sdk.
So, because acter depends on both integration_test from sdk and convenient_test_manager_dart from git, version solving failed.
Error: Process completed with exit code 1.
```