### PR TITLE
Refactoring of ref.watch & ref.read

### DIFF
--- a/app/integration_test/tests/tasks.dart
+++ b/app/integration_test/tests/tasks.dart
@@ -124,7 +124,7 @@ extension ActerTasks on ConvenientTest {
       listTitle ?? 'Errands',
       tasks: tasks,
     );
-    return ((spaceId: spaceId, taskListId: taskListId));
+    return (spaceId: spaceId, taskListId: taskListId);
   }
 
   Future<void> renameTask(String newTitle) async {

--- a/app/lib/common/dialogs/invite_to_room_dialog.dart
+++ b/app/lib/common/dialogs/invite_to_room_dialog.dart
@@ -105,8 +105,8 @@ final filteredSuggestedUsersProvider =
     if (element.userId.toLowerCase().contains(lowered)) {
       return true;
     }
-    return (element.profile.displayName != null &&
-        element.profile.displayName!.toLowerCase().contains(lowered));
+    return element.profile.displayName != null &&
+        element.profile.displayName!.toLowerCase().contains(lowered);
   }).toList();
 });
 

--- a/app/lib/common/dialogs/invite_to_room_dialog.dart
+++ b/app/lib/common/dialogs/invite_to_room_dialog.dart
@@ -66,7 +66,7 @@ final searchResultProvider = FutureProvider<List<UserProfile>>((ref) async {
     // ignore we got cancelled
     return [];
   }
-  final client = ref.read(alwaysClientProvider);
+  final client = ref.watch(alwaysClientProvider);
   return (await client.searchUsers(newSearchValue)).toList();
 });
 

--- a/app/lib/common/notifications/notifications.dart
+++ b/app/lib/common/notifications/notifications.dart
@@ -407,7 +407,7 @@ Future<void> _showNotification(
 Future<bool> wasRejected(String deviceId) async {
   final SharedPreferences preferences = await sharedPrefs();
   final prefKey = '$deviceId.rejected_notifications';
-  return (preferences.getBool(prefKey) ?? false);
+  return preferences.getBool(prefKey) ?? false;
 }
 
 Future<void> setRejected(String deviceId, bool value) async {

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -42,7 +42,7 @@ final latestMessageProvider =
 final chatProfileDataProviderById =
     FutureProvider.family<ProfileData, String>((ref, roomId) async {
   final chat = await ref.watch(chatProvider(roomId).future);
-  return (await ref.watch(chatProfileDataProvider(chat).future));
+  return await ref.watch(chatProfileDataProvider(chat).future);
 });
 
 /// Provider the profile data of a the given space, keeps up to date with underlying client

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -80,10 +80,7 @@ final selectedChatIdProvider =
 // Member Providers
 final memberProfileByInfoProvider =
     FutureProvider.family<ProfileData, MemberInfo>((ref, memberInfo) async {
-  final member = await ref.read(
-    memberProvider((roomId: memberInfo.roomId, userId: memberInfo.userId))
-        .future,
-  );
+  final member = await ref.read(memberProvider(memberInfo).future);
   if (member == null) {
     throw 'Member not found';
   }
@@ -103,7 +100,7 @@ final memberProfileProvider =
 final memberProvider =
     FutureProvider.family<Member?, MemberInfo>((ref, memberInfo) async {
   try {
-    final convo = await ref.read(chatProvider((memberInfo.roomId!)).future);
+    final convo = await ref.watch(chatProvider((memberInfo.roomId!)).future);
     return await convo.getMember(memberInfo.userId);
   } catch (e) {
     throw e.toString();

--- a/app/lib/common/providers/notifiers/space_notifiers.dart
+++ b/app/lib/common/providers/notifiers/space_notifiers.dart
@@ -18,7 +18,7 @@ class AsyncSpaceProfileDataNotifier
     final space = arg;
     final profile = space.getProfile();
     OptionString displayName = await profile.getDisplayName();
-    final sdk = await ref.watch(sdkProvider.future);
+    final sdk = await ref.read(sdkProvider.future);
     final size = sdk.api.newThumbSize(48, 48);
     final avatar = await profile.getAvatar(size);
     return ProfileData(displayName.text(), avatar.data());

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -212,8 +212,8 @@ final roomDefaultNotificationStatusProvider =
 /// Get the default RoomNotificationsStatus for this room type
 final roomIsMutedProvider =
     FutureProvider.autoDispose.family<bool, String>((ref, roomId) async {
-  return (await ref.watch(roomNotificationStatusProvider(roomId).future)) ==
-      'muted';
+  final status = await ref.watch(roomNotificationStatusProvider(roomId).future);
+  return status == 'muted';
 });
 
 class MemberNotFound extends Error {}

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -188,7 +188,7 @@ final spaceSearchValueProvider =
 final searchedSpacesProvider =
     FutureProvider.autoDispose<List<SpaceItem>>((ref) async {
   final allSpaces =
-      await ref.read(briefSpaceItemsProviderWithMembership.future);
+      await ref.watch(briefSpaceItemsProviderWithMembership.future);
   final searchValue = ref.watch(spaceSearchValueProvider);
   if (searchValue == null || searchValue.isEmpty) {
     return allSpaces;

--- a/app/lib/features/chat/chat_utils/chat_utils.dart
+++ b/app/lib/features/chat/chat_utils/chat_utils.dart
@@ -93,7 +93,7 @@ Future<void> navigateToRoomOrAskToJoin(
   String roomId,
 ) async {
   ///Get room from roomId
-  final room = await ref.watch(maybeRoomProvider(roomId).future);
+  final room = await ref.read(maybeRoomProvider(roomId).future);
   if (!context.mounted) return;
 
   /// Navigate to Room is already joined

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -73,7 +73,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
       }
     }
     final inputNotifier = ref.read(chatInputProvider(roomId).notifier);
-    final userId = ref.watch(myUserIdStrProvider);
+    final userId = ref.read(myUserIdStrProvider);
     if (userId == message.author.id && message is types.TextMessage) {
       inputNotifier.showEditButton(true);
     } else {
@@ -126,8 +126,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
                     )
                   : null,
               flexibleSpace: FrostEffect(
-                child: Container(
-                ),
+                child: Container(),
               ),
               title: GestureDetector(
                 onTap: () {

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -121,7 +121,7 @@ class _CreateChatWidgetState extends ConsumerState<CreateChatPage> {
     try {
       final sdk = await ref.read(sdkProvider.future);
       final config = sdk.api.newConvoSettingsBuilder();
-      final selectedUsers = ref.watch(_selectedUsersProvider);
+      final selectedUsers = ref.read(_selectedUsersProvider);
       // we check whether user has selected participants for DM/Group DM.
       if (selectedUsers.isNotEmpty) {
         if (selectedUsers.length > 1) {
@@ -324,9 +324,10 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
                           );
                         }
                       } else {
+                        final client = ref.read(alwaysClientProvider);
                         String? id = checkUserDMExists(
                           selectedUsers[0].userId().toString(),
-                          ref,
+                          client,
                         );
                         if (id != null) {
                           Navigator.of(context).pop();
@@ -431,7 +432,8 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
     } else if (selectedUsers.length > 1) {
       return 'Start Group DM';
     } else {
-      if (checkUserDMExists(selectedUsers[0].userId().toString(), ref) !=
+      final client = ref.watch(alwaysClientProvider);
+      if (checkUserDMExists(selectedUsers[0].userId().toString(), client) !=
           null) {
         return 'Go to DM';
       } else {
@@ -440,9 +442,8 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
     }
   }
 
-// checks whether user DM already exists or needs created
-  String? checkUserDMExists(String userId, WidgetRef ref) {
-    final client = ref.watch(alwaysClientProvider);
+  // checks whether user DM already exists or needs created
+  String? checkUserDMExists(String userId, ffi.Client client) {
     final id = client.dmWithUser(userId).text();
     if (id != null) return id;
     return null;

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -491,7 +491,7 @@ class _CreateRoomFormWidgetConsumerState
   Widget build(BuildContext context) {
     final titleInput = ref.watch(_titleProvider);
     final avatarUpload = ref.watch(_avatarProvider);
-    final currentParentSpace = ref.read(selectedSpaceIdProvider);
+    final currentParentSpace = ref.watch(selectedSpaceIdProvider);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 18),

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -39,7 +39,7 @@ class AsyncCalendarEventNotifier
   late Stream<void> _listener;
 
   Future<ffi.CalendarEvent> _getCalendarEvent() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return await client.waitForCalendarEvent(arg, null);
   }
 
@@ -63,7 +63,7 @@ class AsyncUpcomingEventsNotifier
   late Stream<void> _listener;
 
   Future<List<ffi.CalendarEvent>> _getAllUpcoming() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return (await client.allUpcomingEvents(null)).toList();
     // this might throw internally
   }
@@ -88,7 +88,7 @@ class AsyncMyUpcomingEventsNotifier
   late Stream<void> _listener;
 
   Future<List<ffi.CalendarEvent>> _getMyUpcoming() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return (await client.myUpcomingEvents(null)).toList();
     // this might throw internally
   }
@@ -113,7 +113,7 @@ class AsyncMyPastEventsNotifier
   late Stream<void> _listener;
 
   Future<List<ffi.CalendarEvent>> _getMyPast() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return (await client.myPastEvents(null)).toList();
     // this might throw internally
   }

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -132,5 +132,5 @@ class AsyncMyPastEventsNotifier
 final myRsvpStatusProvider = FutureProvider.family
     .autoDispose<ffi.OptionRsvpStatus, String>((ref, calendarId) async {
   final event = await ref.watch(calendarEventProvider(calendarId).future);
-  return (await event.myRsvpStatus());
+  return await event.myRsvpStatus();
 });

--- a/app/lib/features/events/sheets/create_event_sheet.dart
+++ b/app/lib/features/events/sheets/create_event_sheet.dart
@@ -233,8 +233,8 @@ class _CreateEventSheetConsumerState extends ConsumerState<CreateEventSheet> {
   }
 
   Future<void> _selectDateTime() async {
-    final selectedStartDate = ref.watch(_startDateProvider);
-    final selectedEndDate = ref.watch(_endDateProvider);
+    final selectedStartDate = ref.read(_startDateProvider);
+    final selectedEndDate = ref.read(_endDateProvider);
     final picked = await showOmniDateTimeRangePicker(
       context: context,
       startFirstDate: DateTime.now(),

--- a/app/lib/features/events/sheets/edit_event_sheet.dart
+++ b/app/lib/features/events/sheets/edit_event_sheet.dart
@@ -225,23 +225,26 @@ class _EditEventSheetConsumerState extends ConsumerState<EditEventSheet> {
   }
 
   void _selectDateTime() async {
-    await showOmniDateTimeRangePicker(
+    final picked = await showOmniDateTimeRangePicker(
       context: context,
-      startFirstDate: ref.watch(_startDateProvider),
-      startInitialDate: ref.watch(_startDateProvider),
-      endInitialDate: ref.watch(_endDateProvider),
-      endFirstDate: ref.watch(_endDateProvider),
+      startFirstDate: ref.read(_startDateProvider),
+      startInitialDate: ref.read(_startDateProvider),
+      endInitialDate: ref.read(_endDateProvider),
+      endFirstDate: ref.read(_endDateProvider),
       borderRadius: BorderRadius.circular(12),
       isForce2Digits: true,
-    ).then((picked) {
-      if (picked != null) {
-        ref.read(_startDateProvider.notifier).update((state) => picked[0]);
-        ref.read(_endDateProvider.notifier).update((state) => picked[1]);
-        _dateController.text =
-            '${DateFormat.yMd().format(picked[0])} - ${DateFormat.yMd().format(picked[1])}';
-        _timeController.text =
-            '${DateFormat.jm().format(picked[0])} - ${DateFormat.jm().format(picked[1])}';
-      }
-    });
+    );
+    if (picked != null) {
+      final startDate = DateFormat.yMd().format(picked[0]);
+      final endDate = DateFormat.yMd().format(picked[1]);
+      _dateController.text = '$startDate - $endDate';
+
+      final startTime = DateFormat.jm().format(picked[0]);
+      final endTime = DateFormat.jm().format(picked[1]);
+      _timeController.text = '$startTime - $endTime';
+
+      ref.read(_startDateProvider.notifier).update((state) => picked[0]);
+      ref.read(_endDateProvider.notifier).update((state) => picked[1]);
+    }
   }
 }

--- a/app/lib/features/events/widgets/calendar_widget.dart
+++ b/app/lib/features/events/widgets/calendar_widget.dart
@@ -43,8 +43,7 @@ class _CalendarWidgetConsumerState extends ConsumerState<CalendarWidget> {
 
     return events.where((ev) {
       final evDay = toDartDatetime(ev.utcStart()).toLocal();
-
-      return (DateUtils.isSameDay(evDay, day));
+      return DateUtils.isSameDay(evDay, day);
     }).toList();
   }
 

--- a/app/lib/features/events/widgets/calendar_widget.dart
+++ b/app/lib/features/events/widgets/calendar_widget.dart
@@ -37,7 +37,7 @@ class _CalendarWidgetConsumerState extends ConsumerState<CalendarWidget> {
   List<ffi.CalendarEvent> _getEventsForDay(
     DateTime day,
   ) {
-    final calendarEvents = ref.watch(myUpcomingEventsProvider);
+    final calendarEvents = ref.read(myUpcomingEventsProvider);
     final List<ffi.CalendarEvent> events =
         calendarEvents.hasValue ? calendarEvents.value! : [];
 

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -364,7 +364,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
   Future<void> sendNews(BuildContext context) async {
     final client = ref.read(alwaysClientProvider);
     final spaceId = ref.read(newsStateProvider).newsPostSpaceId;
-    final newsSlideList = ref.watch(newsStateProvider).newsSlideList;
+    final newsSlideList = ref.read(newsStateProvider).newsSlideList;
 
     if (spaceId == null) {
       customMsgSnackbar(context, 'Please first select a space');

--- a/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
+++ b/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
@@ -32,7 +32,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
   Widget newsSlideOptionsUI(BuildContext context) {
     final keyboardVisibility = ref.watch(keyboardVisibleProvider);
     return Visibility(
-      visible: ref.read(newsStateProvider).currentNewsSlide != null &&
+      visible: ref.watch(newsStateProvider).currentNewsSlide != null &&
           !(keyboardVisibility.value ?? false),
       child: Container(
         color: Theme.of(context).colorScheme.primary,
@@ -77,7 +77,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
                           color: Theme.of(context).colorScheme.background,
                           borderRadius: BorderRadius.circular(5),
                           border:
-                              ref.read(newsStateProvider).currentNewsSlide ==
+                              ref.watch(newsStateProvider).currentNewsSlide ==
                                       slidePost
                                   ? Border.all(color: Colors.white)
                                   : null,
@@ -120,7 +120,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
   }
 
   Widget parentSpaceSelector() {
-    final newsPostSpaceId = ref.read(newsStateProvider).newsPostSpaceId;
+    final newsPostSpaceId = ref.watch(newsStateProvider).newsPostSpaceId;
     return Padding(
       padding: const EdgeInsets.all(12),
       child: (newsPostSpaceId != null)

--- a/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
+++ b/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
@@ -11,7 +11,7 @@ class AsyncPinsNotifier extends AutoDisposeAsyncNotifier<List<ActerPin>> {
   late StreamSubscription<void> _poller;
 
   Future<List<ActerPin>> _getPins() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return (await client.pins()).toList(); // this might throw internally
   }
 
@@ -34,7 +34,7 @@ class AsyncPinNotifier
   late StreamSubscription<void> _poller;
 
   Future<ActerPin> _getPin() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = ref.read(alwaysClientProvider);
     return await client.waitForPin(arg, null);
   }
 

--- a/app/lib/features/settings/providers/notifications_mode_provider.dart
+++ b/app/lib/features/settings/providers/notifications_mode_provider.dart
@@ -28,8 +28,8 @@ final notificationSettingsProvider = AsyncNotifierProvider.autoDispose<
 final currentNotificationModeProvider = FutureProvider.autoDispose
     .family<String, NotificationConfiguration>((ref, config) async {
   final settings = await ref.watch(notificationSettingsProvider.future);
-  return (await settings.defaultNotificationMode(
+  return await settings.defaultNotificationMode(
     config.encrypted,
     config.oneToOne,
-  ));
+  );
 });

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -60,10 +60,10 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //Fetch known sub-rooms list of selected parent space
   void fetchKnownSubChatsData() async {
-    final selectedParentSpaceId = ref.watch(selectedSpaceIdProvider);
+    final selectedParentSpaceId = ref.read(selectedSpaceIdProvider);
     if (selectedParentSpaceId == null) return;
     final space = await ref
-        .watch(spaceRelationsOverviewProvider(selectedParentSpaceId).future);
+        .read(spaceRelationsOverviewProvider(selectedParentSpaceId).future);
 
     childRoomsIds.clear();
     if (widget.childRoomType == ChildRoomType.chat) {
@@ -218,19 +218,20 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //Show space list based on the search term
   Widget searchedSpaceList() {
-    return ref.watch(searchedSpacesProvider).when(
-          data: (spaces) {
-            if (spaces.isEmpty) {
-              return const Center(
-                heightFactor: 10,
-                child: Text('No chats found matching your search term'),
-              );
-            }
-            return spaceListUI(spaces);
-          },
-          loading: () => loadingUI(),
-          error: (e, s) => errorUI('Searching failed', e),
-        );
+    final searchedSpaces = ref.watch(searchedSpacesProvider);
+    return searchedSpaces.when(
+      data: (spaces) {
+        if (spaces.isEmpty) {
+          return const Center(
+            heightFactor: 10,
+            child: Text('No chats found matching your search term'),
+          );
+        }
+        return spaceListUI(spaces);
+      },
+      loading: () => loadingUI(),
+      error: (e, s) => errorUI('Searching failed', e),
+    );
   }
 
 //Space List
@@ -407,17 +408,17 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //Link child room
   void onTapLinkChildRoom(BuildContext context, String roomId) async {
-    final selectedParentSpaceId = ref.watch(selectedSpaceIdProvider);
+    final selectedParentSpaceId = ref.read(selectedSpaceIdProvider);
     if (selectedParentSpaceId == null) return;
 
     //Fetch selected parent space data and add given roomId as child
-    final space = await ref.watch(spaceProvider(selectedParentSpaceId).future);
+    final space = await ref.read(spaceProvider(selectedParentSpaceId).future);
     space.addChildRoom(roomId);
 
     //Make subspace
     if (widget.childRoomType == ChildRoomType.space) {
       //Fetch selected room data and add given parentSpaceId as parent
-      final room = await ref.watch(maybeRoomProvider(roomId).future);
+      final room = await ref.read(maybeRoomProvider(roomId).future);
       if (room != null) {
         room.addParentRoom(selectedParentSpaceId, true);
         // ignore: use_build_context_synchronously
@@ -433,16 +434,16 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //Unlink child room
   void onTapUnlinkChildRoom(String roomId) async {
-    final selectedParentSpaceId = ref.watch(selectedSpaceIdProvider);
+    final selectedParentSpaceId = ref.read(selectedSpaceIdProvider);
     if (selectedParentSpaceId == null) return;
 
     //Fetch selected parent space data and add given roomId as child
-    final space = await ref.watch(spaceProvider(selectedParentSpaceId).future);
+    final space = await ref.read(spaceProvider(selectedParentSpaceId).future);
     space.removeChildRoom(roomId, 'Unlink room');
 
     if (widget.childRoomType == ChildRoomType.space) {
       //Fetch selected room data and add given parentSpaceId as parent
-      final room = await ref.watch(maybeRoomProvider(roomId).future);
+      final room = await ref.read(maybeRoomProvider(roomId).future);
       if (room != null) {
         room.removeParentRoom(selectedParentSpaceId, 'Unlink room');
       }

--- a/app/lib/features/space/widgets/non_acter_space_card.dart
+++ b/app/lib/features/space/widgets/non_acter_space_card.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 class NonActerSpaceCard extends ConsumerWidget {
   final String spaceId;
+
   const NonActerSpaceCard({super.key, required this.spaceId});
 
   @override
@@ -54,7 +55,7 @@ class NonActerSpaceCard extends ConsumerWidget {
     customMsgSnackbar(context, 'Converting to acter space');
 
     try {
-      final space = await ref.watch(spaceProvider(spaceId).future);
+      final space = await ref.read(spaceProvider(spaceId).future);
       debugPrint('before setting space state');
 
       await space.setActerSpaceStates();

--- a/app/lib/features/space/widgets/space_toolbar.dart
+++ b/app/lib/features/space/widgets/space_toolbar.dart
@@ -13,10 +13,7 @@ class SpaceToolbar extends ConsumerWidget {
   static const settingsMenu = Key('space-options-settings');
   final String spaceId;
 
-  const SpaceToolbar({
-    super.key,
-    required this.spaceId,
-  });
+  const SpaceToolbar({super.key, required this.spaceId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -115,7 +112,7 @@ class SpaceToolbar extends ConsumerWidget {
           ),
           ElevatedButton(
             onPressed: () async {
-              final space = await ref.watch(spaceProvider(spaceId).future);
+              final space = await ref.read(spaceProvider(spaceId).future);
               await space.leave();
               // refresh spaces list
               ref.invalidate(spacesProvider);


### PR DESCRIPTION
- miscellaneous refactoring
- replace useless `ref.watch()` with `ref.read()`. We should use `ref.read()` on button click.
- replace useless `ref.read()` with `ref.watch()`. We should use `ref.watch()` on rendering fn.