### PR TITLE
Pull to Filter for Chat Rooms

### DIFF
--- a/.changes/1471-pull-to-filter-chats.md
+++ b/.changes/1471-pull-to-filter-chats.md
@@ -1,2 +1,2 @@
 - You can now bookmark chat rooms (via the chat room details page)
-- An easier way to search & filter chats: just pull down in the chat rooms list and the filter bar appears. Next to a cleaned up SearchField it also features quick-toggles for bookmarked chats and DMs only. The selection made here will be persisted between app restart for convenience;
+- An easier way to search & filter chats: just pull down in the chat rooms list and the filter bar appears. Next to a cleaned up chat search it also features quick-toggles for bookmarked chats and DMs only. The selection made here will be persisted between app restart for convenience;

--- a/.changes/1471-pull-to-filter-chats.md
+++ b/.changes/1471-pull-to-filter-chats.md
@@ -1,0 +1,2 @@
+- You can now bookmark chat rooms (via the chat room details page)
+- An easier way to search & filter chats: just pull down in the chat rooms list and the filter bar appears. Next to a cleaned up SearchField it also features quick-toggles for bookmarked chats and DMs only. The selection made here will be persisted between app restart for convenience;

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -10,6 +10,9 @@ import 'package:logging/logging.dart';
 
 final _log = Logger('a3::common::chat');
 
+final chatSearchValueProvider =
+    StateProvider.autoDispose<String?>((ref) => null);
+
 /// Provider the profile data of a the given space, keeps up to date with underlying client
 final convoProvider =
     AsyncNotifierProvider.family<AsyncConvoNotifier, Convo?, Convo>(

--- a/app/lib/common/providers/notifiers/client_pref_notifier.dart
+++ b/app/lib/common/providers/notifiers/client_pref_notifier.dart
@@ -5,6 +5,7 @@
 /// will store the current value under `$currentDeviceId-$prefKey` in the system
 /// preference allowing the app to save and restore local app settings.
 ///
+library;
 
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';

--- a/app/lib/common/providers/notifiers/client_pref_notifier.dart
+++ b/app/lib/common/providers/notifiers/client_pref_notifier.dart
@@ -1,6 +1,11 @@
 /// Based on https://github.com/gamako/shared_preferences_riverpod/blob/master/lib/shared_preferences_riverpod.dart
 /// but bound to the specific client deviceIDs;
-library;
+///
+/// In essence this provides a SharedPreferences provider which, whenever set,
+/// will store the current value under `$currentDeviceId-$prefKey` in the system
+/// preference allowing the app to save and restore local app settings.
+///
+
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:riverpod/riverpod.dart';
@@ -52,8 +57,10 @@ class PrefNotifier<T> extends StateNotifier<T> {
   /// Instead, use `await update(value).`
   @override
   set state(T value) {
-    assert(false,
-        "Don't use the setter for state. Instead use `await update(value)`.",);
+    assert(
+      false,
+      "Don't use the setter for state. Instead use `await update(value)`.",
+    );
     Future(() async {
       await update(value);
     });

--- a/app/lib/common/providers/notifiers/client_pref_notifier.dart
+++ b/app/lib/common/providers/notifiers/client_pref_notifier.dart
@@ -1,0 +1,218 @@
+/// Based on https://github.com/gamako/shared_preferences_riverpod/blob/master/lib/shared_preferences_riverpod.dart
+/// but bound to the specific client deviceIDs;
+library;
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The type parameter `T` is the type of value that will
+/// be persisted in [SharedPreferences].
+///
+/// To update the value, use the [update()] function.
+/// Direct assignment to state cannot be used.
+///
+/// ```dart
+/// await watch(booPrefProvider.notifier).update(v);
+/// ```
+///
+///
+class PrefNotifier<T> extends StateNotifier<T> {
+  PrefNotifier(this.prefKey, this.defaultValue) : super(defaultValue) {
+    _init();
+  }
+
+  late SharedPreferences prefs;
+  String prefKey;
+  T defaultValue;
+
+  void _init() async {
+    prefs = await sharedPrefs();
+    final newValue = (prefs.get(prefKey) as T? ?? defaultValue);
+    state = newValue;
+  }
+
+  /// Updates the value asynchronously.
+  Future<void> update(T value) async {
+    if (value is String) {
+      await prefs.setString(prefKey, value);
+    } else if (value is bool) {
+      await prefs.setBool(prefKey, value);
+    } else if (value is int) {
+      await prefs.setInt(prefKey, value);
+    } else if (value is double) {
+      await prefs.setDouble(prefKey, value);
+    } else if (value is List<String>) {
+      await prefs.setStringList(prefKey, value);
+    }
+    super.state = value;
+  }
+
+  /// Do not use the setter for state.
+  /// Instead, use `await update(value).`
+  @override
+  set state(T value) {
+    assert(false,
+        "Don't use the setter for state. Instead use `await update(value)`.",);
+    Future(() async {
+      await update(value);
+    });
+  }
+}
+
+/// Returns the [Provider] that has access to the value of preferences.
+///
+/// Persist the value of the type parameter T type in SharedPreferences.
+/// The argument [prefs] specifies an instance of SharedPreferences.
+/// The arguments [prefKey] and [defaultValue] specify the key name and default
+/// value of the preference.
+///
+/// ```dart
+///
+/// Future<void> main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///
+///   final prefs = await SharedPreferences.getInstance();
+///
+///   final booPrefProvider = createPrefProvider<bool>(
+///     prefs: (_) => prefs,
+///     prefKey: "boolValue",
+///     defaultValue: false,
+///   );
+///
+/// ```
+///
+/// When referring to a value, use it as you would a regular provider.
+///
+/// ```dart
+///
+///   Consumer(builder: (context, watch, _) {
+///     final value = watch(booPrefProvider);
+///
+/// ```
+///
+/// To change the value, use the update() method.
+///
+/// ```dart
+///
+///   await watch(booPrefProvider.notifier).update(true);
+///
+/// ```
+///
+StateNotifierProvider<PrefNotifier<T>, T> createPrefProvider<T>({
+  required String prefKey,
+  required T defaultValue,
+}) {
+  return StateNotifierProvider<PrefNotifier<T>, T>((ref) {
+    final clientId =
+        ref.watch(alwaysClientProvider.select((v) => v.deviceId().toString()));
+    return PrefNotifier<T>('$clientId-$prefKey', defaultValue);
+  });
+}
+
+/// Converts the value of type parameter `T` to a String and persists
+/// it in SharedPreferences.
+///
+/// To update the value, use the [update()] function.
+/// Direct assignment to state cannot be used.
+///
+/// ```dart
+/// await watch(mapPrefProvider.notifier).update(v);
+/// ```
+///
+class MapPrefNotifier<T> extends StateNotifier<T> {
+  MapPrefNotifier(this.prefKey, this.mapFrom, this.mapTo)
+      : super(mapFrom(null)) {
+    _init();
+  }
+
+  late SharedPreferences prefs;
+  String prefKey;
+  T Function(String?) mapFrom;
+  String Function(T) mapTo;
+
+  void _init() async {
+    prefs = await sharedPrefs();
+    final newValue = mapFrom(prefs.getString(prefKey));
+    super.state = newValue;
+  }
+
+  /// Updates the value asynchronously.
+  Future<void> update(T value) async {
+    await prefs.setString(prefKey, mapTo(value));
+    super.state = value;
+  }
+
+  /// Do not use the setter for state.
+  /// Instead, use `await update(value).`
+  @override
+  set state(T value) {
+    assert(
+      false,
+      "Don't use the setter for state. Instead use `await update(value)`.",
+    );
+    Future(() async {
+      await update(value);
+    });
+  }
+}
+
+/// Returns a [Provider] that can access the preference with any type you want.
+///
+/// Persist to SharePreferences after converting to String.
+/// The argument [prefs] specifies an instance of SharedPreferences.
+/// The arguments [prefKey] and [defaultValue] specify the key name and default
+/// value of the preference.
+/// Specify how to convert from String to type T in [mapFrom].
+/// Specifies how to convert from type T to String in [mapTo].
+///
+/// ```dart
+///
+/// enum EnumValues {
+///   foo,
+///   bar,
+/// }
+///
+/// Future<void> main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///
+///   final prefs = await SharedPreferences.getInstance();
+///
+///   final enumPrefProvider = createMapPrefProvider<EnumValues>(
+///     prefs: (_) => prefs,
+///     prefKey: "enumValue",
+///     mapFrom: (v) => EnumValues.values
+///         .firstWhere((e) => e.toString() == v, orElse: () => EnumValues.foo),
+///     mapTo: (v) => v.toString(),
+///   );
+///
+/// ```
+///
+/// When referring to a value, use it as you would a regular provider.
+///
+/// ```dart
+///
+///   Consumer(builder: (context, watch, _) {
+///     final value = watch(enumPrefProvider);
+///
+/// ```
+///
+/// To change the value, use the update() method.
+///
+/// ```dart
+///
+///   await watch(enumPrefProvider.notifier).update(EnumValues.bar);
+///
+/// ```
+///
+StateNotifierProvider<MapPrefNotifier<T>, T> createMapPrefProvider<T>({
+  required String prefKey,
+  required T Function(String?) mapFrom,
+  required String Function(T) mapTo,
+}) {
+  return StateNotifierProvider<MapPrefNotifier<T>, T>((ref) {
+    final clientId =
+        ref.watch(alwaysClientProvider.select((v) => v.deviceId().toString()));
+    return MapPrefNotifier<T>('$clientId-$prefKey', mapFrom, mapTo);
+  });
+}

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -7,7 +7,6 @@ import 'package:acter/common/providers/notifiers/room_notifiers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/utils.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';

--- a/app/lib/common/widgets/chat/convo_card.dart
+++ b/app/lib/common/widgets/chat/convo_card.dart
@@ -133,7 +133,7 @@ class _ConvoCardState extends ConsumerState<ConvoCard> {
                 },
               ),
             ],
-          )
+          ),
       ],
     );
   }

--- a/app/lib/common/widgets/chat/convo_card.dart
+++ b/app/lib/common/widgets/chat/convo_card.dart
@@ -92,47 +92,49 @@ class _ConvoCardState extends ConsumerState<ConvoCard> {
             userId: userId,
           ),
         if (mutedStatus.valueOrNull == true)
-          MenuAnchor(
-            builder: (
-              BuildContext context,
-              MenuController controller,
-              Widget? child,
-            ) {
-              return IconButton(
-                padding: EdgeInsets.zero,
-                iconSize: 14,
-                onPressed: () {
-                  if (controller.isOpen) {
-                    controller.close();
-                  } else {
-                    controller.open();
-                  }
-                },
-                icon: const Icon(Atlas.bell_dash_bold),
-              );
-            },
-            menuChildren: [
-              MenuItemButton(
-                child: const Text('Unmute'),
-                onPressed: () async {
-                  final room = await ref.read(maybeRoomProvider(roomId).future);
-                  if (room == null) {
-                    EasyLoading.showError('Room not found');
-                    return;
-                  }
-                  await room.unmute();
-                  EasyLoading.showSuccess(
-                    'Notifications unmuted',
-                  );
-                  await Future.delayed(const Duration(seconds: 1), () {
-                    // FIXME: we want to refresh the view but don't know
-                    //        when the event was confirmed form sync :(
-                    // let's hope that a second delay is reasonable enough
-                    ref.invalidate(maybeRoomProvider(roomId));
-                  });
-                },
-              ),
-            ],
+          Expanded(
+            child: MenuAnchor(
+              builder: (
+                BuildContext context,
+                MenuController controller,
+                Widget? child,
+              ) {
+                return IconButton(
+                  padding: EdgeInsets.zero,
+                  onPressed: () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  },
+                  icon: const Icon(Atlas.bell_dash_bold, size: 14),
+                );
+              },
+              menuChildren: [
+                MenuItemButton(
+                  child: const Text('Unmute'),
+                  onPressed: () async {
+                    final room =
+                        await ref.read(maybeRoomProvider(roomId).future);
+                    if (room == null) {
+                      EasyLoading.showError('Room not found');
+                      return;
+                    }
+                    await room.unmute();
+                    EasyLoading.showSuccess(
+                      'Notifications unmuted',
+                    );
+                    await Future.delayed(const Duration(seconds: 1), () {
+                      // FIXME: we want to refresh the view but don't know
+                      //        when the event was confirmed form sync :(
+                      // let's hope that a second delay is reasonable enough
+                      ref.invalidate(maybeRoomProvider(roomId));
+                    });
+                  },
+                ),
+              ],
+            ),
           ),
       ],
     );

--- a/app/lib/features/chat/models/chat_list_state/chat_list_state.freezed.dart
+++ b/app/lib/features/chat/models/chat_list_state/chat_list_state.freezed.dart
@@ -87,25 +87,25 @@ class _$ChatListStateCopyWithImpl<$Res, $Val extends ChatListState>
 }
 
 /// @nodoc
-abstract class _$$_ChatListStateInitialCopyWith<$Res> {
-  factory _$$_ChatListStateInitialCopyWith(_$_ChatListStateInitial value,
-          $Res Function(_$_ChatListStateInitial) then) =
-      __$$_ChatListStateInitialCopyWithImpl<$Res>;
+abstract class _$$ChatListStateInitialImplCopyWith<$Res> {
+  factory _$$ChatListStateInitialImplCopyWith(_$ChatListStateInitialImpl value,
+          $Res Function(_$ChatListStateInitialImpl) then) =
+      __$$ChatListStateInitialImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$_ChatListStateInitialCopyWithImpl<$Res>
-    extends _$ChatListStateCopyWithImpl<$Res, _$_ChatListStateInitial>
-    implements _$$_ChatListStateInitialCopyWith<$Res> {
-  __$$_ChatListStateInitialCopyWithImpl(_$_ChatListStateInitial _value,
-      $Res Function(_$_ChatListStateInitial) _then)
+class __$$ChatListStateInitialImplCopyWithImpl<$Res>
+    extends _$ChatListStateCopyWithImpl<$Res, _$ChatListStateInitialImpl>
+    implements _$$ChatListStateInitialImplCopyWith<$Res> {
+  __$$ChatListStateInitialImplCopyWithImpl(_$ChatListStateInitialImpl _value,
+      $Res Function(_$ChatListStateInitialImpl) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$_ChatListStateInitial implements _ChatListStateInitial {
-  const _$_ChatListStateInitial();
+class _$ChatListStateInitialImpl implements _ChatListStateInitial {
+  const _$ChatListStateInitialImpl();
 
   @override
   String toString() {
@@ -113,9 +113,10 @@ class _$_ChatListStateInitial implements _ChatListStateInitial {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_ChatListStateInitial);
+        (other.runtimeType == runtimeType &&
+            other is _$ChatListStateInitialImpl);
   }
 
   @override
@@ -197,29 +198,29 @@ class _$_ChatListStateInitial implements _ChatListStateInitial {
 }
 
 abstract class _ChatListStateInitial implements ChatListState {
-  const factory _ChatListStateInitial() = _$_ChatListStateInitial;
+  const factory _ChatListStateInitial() = _$ChatListStateInitialImpl;
 }
 
 /// @nodoc
-abstract class _$$_ChatListStateLoadingCopyWith<$Res> {
-  factory _$$_ChatListStateLoadingCopyWith(_$_ChatListStateLoading value,
-          $Res Function(_$_ChatListStateLoading) then) =
-      __$$_ChatListStateLoadingCopyWithImpl<$Res>;
+abstract class _$$ChatListStateLoadingImplCopyWith<$Res> {
+  factory _$$ChatListStateLoadingImplCopyWith(_$ChatListStateLoadingImpl value,
+          $Res Function(_$ChatListStateLoadingImpl) then) =
+      __$$ChatListStateLoadingImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$_ChatListStateLoadingCopyWithImpl<$Res>
-    extends _$ChatListStateCopyWithImpl<$Res, _$_ChatListStateLoading>
-    implements _$$_ChatListStateLoadingCopyWith<$Res> {
-  __$$_ChatListStateLoadingCopyWithImpl(_$_ChatListStateLoading _value,
-      $Res Function(_$_ChatListStateLoading) _then)
+class __$$ChatListStateLoadingImplCopyWithImpl<$Res>
+    extends _$ChatListStateCopyWithImpl<$Res, _$ChatListStateLoadingImpl>
+    implements _$$ChatListStateLoadingImplCopyWith<$Res> {
+  __$$ChatListStateLoadingImplCopyWithImpl(_$ChatListStateLoadingImpl _value,
+      $Res Function(_$ChatListStateLoadingImpl) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$_ChatListStateLoading implements _ChatListStateLoading {
-  const _$_ChatListStateLoading();
+class _$ChatListStateLoadingImpl implements _ChatListStateLoading {
+  const _$ChatListStateLoadingImpl();
 
   @override
   String toString() {
@@ -227,9 +228,10 @@ class _$_ChatListStateLoading implements _ChatListStateLoading {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_ChatListStateLoading);
+        (other.runtimeType == runtimeType &&
+            other is _$ChatListStateLoadingImpl);
   }
 
   @override
@@ -311,24 +313,24 @@ class _$_ChatListStateLoading implements _ChatListStateLoading {
 }
 
 abstract class _ChatListStateLoading implements ChatListState {
-  const factory _ChatListStateLoading() = _$_ChatListStateLoading;
+  const factory _ChatListStateLoading() = _$ChatListStateLoadingImpl;
 }
 
 /// @nodoc
-abstract class _$$_ChatListStateDataCopyWith<$Res> {
-  factory _$$_ChatListStateDataCopyWith(_$_ChatListStateData value,
-          $Res Function(_$_ChatListStateData) then) =
-      __$$_ChatListStateDataCopyWithImpl<$Res>;
+abstract class _$$ChatListStateDataImplCopyWith<$Res> {
+  factory _$$ChatListStateDataImplCopyWith(_$ChatListStateDataImpl value,
+          $Res Function(_$ChatListStateDataImpl) then) =
+      __$$ChatListStateDataImplCopyWithImpl<$Res>;
   @useResult
   $Res call({List<Convo> chats});
 }
 
 /// @nodoc
-class __$$_ChatListStateDataCopyWithImpl<$Res>
-    extends _$ChatListStateCopyWithImpl<$Res, _$_ChatListStateData>
-    implements _$$_ChatListStateDataCopyWith<$Res> {
-  __$$_ChatListStateDataCopyWithImpl(
-      _$_ChatListStateData _value, $Res Function(_$_ChatListStateData) _then)
+class __$$ChatListStateDataImplCopyWithImpl<$Res>
+    extends _$ChatListStateCopyWithImpl<$Res, _$ChatListStateDataImpl>
+    implements _$$ChatListStateDataImplCopyWith<$Res> {
+  __$$ChatListStateDataImplCopyWithImpl(_$ChatListStateDataImpl _value,
+      $Res Function(_$ChatListStateDataImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -336,7 +338,7 @@ class __$$_ChatListStateDataCopyWithImpl<$Res>
   $Res call({
     Object? chats = null,
   }) {
-    return _then(_$_ChatListStateData(
+    return _then(_$ChatListStateDataImpl(
       chats: null == chats
           ? _value._chats
           : chats // ignore: cast_nullable_to_non_nullable
@@ -347,8 +349,8 @@ class __$$_ChatListStateDataCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ChatListStateData implements _ChatListStateData {
-  const _$_ChatListStateData({required final List<Convo> chats})
+class _$ChatListStateDataImpl implements _ChatListStateData {
+  const _$ChatListStateDataImpl({required final List<Convo> chats})
       : _chats = chats;
 
   final List<Convo> _chats;
@@ -365,10 +367,10 @@ class _$_ChatListStateData implements _ChatListStateData {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ChatListStateData &&
+            other is _$ChatListStateDataImpl &&
             const DeepCollectionEquality().equals(other._chats, _chats));
   }
 
@@ -379,8 +381,8 @@ class _$_ChatListStateData implements _ChatListStateData {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ChatListStateDataCopyWith<_$_ChatListStateData> get copyWith =>
-      __$$_ChatListStateDataCopyWithImpl<_$_ChatListStateData>(
+  _$$ChatListStateDataImplCopyWith<_$ChatListStateDataImpl> get copyWith =>
+      __$$ChatListStateDataImplCopyWithImpl<_$ChatListStateDataImpl>(
           this, _$identity);
 
   @override
@@ -460,29 +462,29 @@ class _$_ChatListStateData implements _ChatListStateData {
 
 abstract class _ChatListStateData implements ChatListState {
   const factory _ChatListStateData({required final List<Convo> chats}) =
-      _$_ChatListStateData;
+      _$ChatListStateDataImpl;
 
   List<Convo> get chats;
   @JsonKey(ignore: true)
-  _$$_ChatListStateDataCopyWith<_$_ChatListStateData> get copyWith =>
+  _$$ChatListStateDataImplCopyWith<_$ChatListStateDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_ChatListStateErrorCopyWith<$Res> {
-  factory _$$_ChatListStateErrorCopyWith(_$_ChatListStateError value,
-          $Res Function(_$_ChatListStateError) then) =
-      __$$_ChatListStateErrorCopyWithImpl<$Res>;
+abstract class _$$ChatListStateErrorImplCopyWith<$Res> {
+  factory _$$ChatListStateErrorImplCopyWith(_$ChatListStateErrorImpl value,
+          $Res Function(_$ChatListStateErrorImpl) then) =
+      __$$ChatListStateErrorImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String? error});
 }
 
 /// @nodoc
-class __$$_ChatListStateErrorCopyWithImpl<$Res>
-    extends _$ChatListStateCopyWithImpl<$Res, _$_ChatListStateError>
-    implements _$$_ChatListStateErrorCopyWith<$Res> {
-  __$$_ChatListStateErrorCopyWithImpl(
-      _$_ChatListStateError _value, $Res Function(_$_ChatListStateError) _then)
+class __$$ChatListStateErrorImplCopyWithImpl<$Res>
+    extends _$ChatListStateCopyWithImpl<$Res, _$ChatListStateErrorImpl>
+    implements _$$ChatListStateErrorImplCopyWith<$Res> {
+  __$$ChatListStateErrorImplCopyWithImpl(_$ChatListStateErrorImpl _value,
+      $Res Function(_$ChatListStateErrorImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -490,7 +492,7 @@ class __$$_ChatListStateErrorCopyWithImpl<$Res>
   $Res call({
     Object? error = freezed,
   }) {
-    return _then(_$_ChatListStateError(
+    return _then(_$ChatListStateErrorImpl(
       freezed == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -501,8 +503,8 @@ class __$$_ChatListStateErrorCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ChatListStateError implements _ChatListStateError {
-  const _$_ChatListStateError([this.error]);
+class _$ChatListStateErrorImpl implements _ChatListStateError {
+  const _$ChatListStateErrorImpl([this.error]);
 
   @override
   final String? error;
@@ -513,10 +515,10 @@ class _$_ChatListStateError implements _ChatListStateError {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ChatListStateError &&
+            other is _$ChatListStateErrorImpl &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -526,8 +528,8 @@ class _$_ChatListStateError implements _ChatListStateError {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ChatListStateErrorCopyWith<_$_ChatListStateError> get copyWith =>
-      __$$_ChatListStateErrorCopyWithImpl<_$_ChatListStateError>(
+  _$$ChatListStateErrorImplCopyWith<_$ChatListStateErrorImpl> get copyWith =>
+      __$$ChatListStateErrorImplCopyWithImpl<_$ChatListStateErrorImpl>(
           this, _$identity);
 
   @override
@@ -607,10 +609,10 @@ class _$_ChatListStateError implements _ChatListStateError {
 
 abstract class _ChatListStateError implements ChatListState {
   const factory _ChatListStateError([final String? error]) =
-      _$_ChatListStateError;
+      _$ChatListStateErrorImpl;
 
   String? get error;
   @JsonKey(ignore: true)
-  _$$_ChatListStateErrorCopyWith<_$_ChatListStateError> get copyWith =>
+  _$$ChatListStateErrorImplCopyWith<_$ChatListStateErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.dart
+++ b/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.dart
@@ -1,0 +1,54 @@
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'room_list_filter_state.freezed.dart';
+
+Future<bool> roomListFilterStateAppliesToRoom(
+  RoomListFilterState state,
+  Ref ref,
+  Convo convo,
+) async {
+  switch (state.selection) {
+    case FilterSelection.dmsOnly:
+      if (!convo.isDm()) {
+        return false;
+      }
+      break;
+    case FilterSelection.favorites:
+      if (!convo.isFavorite()) {
+        return false;
+      }
+      break;
+    default: // all other case just continue
+      break;
+  }
+  if (state.searchTerm?.isNotEmpty == true) {
+    final searchTerm = state.searchTerm!.toLowerCase();
+    if (convo.getRoomIdStr().toLowerCase().contains(searchTerm)) {
+      return true;
+    }
+    final profile = await ref.watch(chatProfileDataProvider(convo).future);
+    if (profile.displayName != null &&
+        profile.displayName!.toLowerCase().contains(searchTerm)) {
+      return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+enum FilterSelection {
+  all,
+  dmsOnly,
+  favorites,
+}
+
+@freezed
+class RoomListFilterState with _$RoomListFilterState {
+  const factory RoomListFilterState({
+    String? searchTerm,
+    @Default(FilterSelection.all) FilterSelection selection,
+  }) = _RoomListFilterState;
+}

--- a/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.freezed.dart
+++ b/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.freezed.dart
@@ -1,0 +1,155 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'room_list_filter_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$RoomListFilterState {
+  String? get searchTerm => throw _privateConstructorUsedError;
+  FilterSelection get selection => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RoomListFilterStateCopyWith<RoomListFilterState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RoomListFilterStateCopyWith<$Res> {
+  factory $RoomListFilterStateCopyWith(
+          RoomListFilterState value, $Res Function(RoomListFilterState) then) =
+      _$RoomListFilterStateCopyWithImpl<$Res, RoomListFilterState>;
+  @useResult
+  $Res call({String? searchTerm, FilterSelection selection});
+}
+
+/// @nodoc
+class _$RoomListFilterStateCopyWithImpl<$Res, $Val extends RoomListFilterState>
+    implements $RoomListFilterStateCopyWith<$Res> {
+  _$RoomListFilterStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchTerm = freezed,
+    Object? selection = null,
+  }) {
+    return _then(_value.copyWith(
+      searchTerm: freezed == searchTerm
+          ? _value.searchTerm
+          : searchTerm // ignore: cast_nullable_to_non_nullable
+              as String?,
+      selection: null == selection
+          ? _value.selection
+          : selection // ignore: cast_nullable_to_non_nullable
+              as FilterSelection,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RoomListFilterStateImplCopyWith<$Res>
+    implements $RoomListFilterStateCopyWith<$Res> {
+  factory _$$RoomListFilterStateImplCopyWith(_$RoomListFilterStateImpl value,
+          $Res Function(_$RoomListFilterStateImpl) then) =
+      __$$RoomListFilterStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? searchTerm, FilterSelection selection});
+}
+
+/// @nodoc
+class __$$RoomListFilterStateImplCopyWithImpl<$Res>
+    extends _$RoomListFilterStateCopyWithImpl<$Res, _$RoomListFilterStateImpl>
+    implements _$$RoomListFilterStateImplCopyWith<$Res> {
+  __$$RoomListFilterStateImplCopyWithImpl(_$RoomListFilterStateImpl _value,
+      $Res Function(_$RoomListFilterStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchTerm = freezed,
+    Object? selection = null,
+  }) {
+    return _then(_$RoomListFilterStateImpl(
+      searchTerm: freezed == searchTerm
+          ? _value.searchTerm
+          : searchTerm // ignore: cast_nullable_to_non_nullable
+              as String?,
+      selection: null == selection
+          ? _value.selection
+          : selection // ignore: cast_nullable_to_non_nullable
+              as FilterSelection,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RoomListFilterStateImpl implements _RoomListFilterState {
+  const _$RoomListFilterStateImpl(
+      {this.searchTerm, this.selection = FilterSelection.all});
+
+  @override
+  final String? searchTerm;
+  @override
+  @JsonKey()
+  final FilterSelection selection;
+
+  @override
+  String toString() {
+    return 'RoomListFilterState(searchTerm: $searchTerm, selection: $selection)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RoomListFilterStateImpl &&
+            (identical(other.searchTerm, searchTerm) ||
+                other.searchTerm == searchTerm) &&
+            (identical(other.selection, selection) ||
+                other.selection == selection));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, searchTerm, selection);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RoomListFilterStateImplCopyWith<_$RoomListFilterStateImpl> get copyWith =>
+      __$$RoomListFilterStateImplCopyWithImpl<_$RoomListFilterStateImpl>(
+          this, _$identity);
+}
+
+abstract class _RoomListFilterState implements RoomListFilterState {
+  const factory _RoomListFilterState(
+      {final String? searchTerm,
+      final FilterSelection selection}) = _$RoomListFilterStateImpl;
+
+  @override
+  String? get searchTerm;
+  @override
+  FilterSelection get selection;
+  @override
+  @JsonKey(ignore: true)
+  _$$RoomListFilterStateImplCopyWith<_$RoomListFilterStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -132,27 +132,16 @@ class RoomProfilePage extends ConsumerWidget {
         children: [
           convoLoader.maybeWhen(
             data: (conv) {
-              if (conv.isFavorite()) {
-                return IconButton.filled(
-                  icon: const Icon(
-                    Icons.bookmark_remove_rounded,
-                    size: 20,
-                  ),
-                  onPressed: () async {
-                    await conv.setFavorite(false);
-                  },
-                );
-              } else {
-                return IconButton.filled(
-                  icon: const Icon(
-                    Icons.bookmark_add_outlined,
-                    size: 20,
-                  ),
-                  onPressed: () async {
-                    await conv.setFavorite(true);
-                  },
-                );
-              }
+              final isFav = conv.isFavorite();
+              return IconButton(
+                icon: Icon(
+                  isFav ? Icons.bookmark : Icons.bookmark_border,
+                  size: 20,
+                ),
+                onPressed: () async {
+                  await conv.setFavorite(!isFav);
+                },
+              );
             },
             orElse: () => Skeletonizer(
               child: IconButton.filled(

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -167,17 +167,17 @@ class RoomProfilePage extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 5),
             child: IconButton.filled(
-              onPressed: () {
-                //FIXME : ?via=$serverName data should be handle from rust helper function
-                final serverName = roomId.split(':').last;
+              onPressed: () async {
+                final permaLink =
+                    await (await ref.read(chatProvider(roomId).future))
+                        .permalink();
                 Clipboard.setData(
                   ClipboardData(
-                    text: 'https://matrix.to/#/$roomId?via=$serverName',
+                    text: permaLink,
                   ),
                 );
-                customMsgSnackbar(
-                  context,
-                  'Room ID: $roomId copied to clipboard',
+                EasyLoading.showToast(
+                  'Link to Room copied to clipboard',
                 );
               },
               tooltip: 'Copy RoomLink',

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -126,7 +126,7 @@ class RoomProfilePage extends ConsumerWidget {
   Widget actions(BuildContext context, WidgetRef ref) {
     final convoLoader = ref.watch(chatProvider(roomId));
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 10),
+      padding: const EdgeInsets.symmetric(vertical: 10),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -138,7 +138,9 @@ class RoomProfilePage extends ConsumerWidget {
                     Icons.bookmark_remove_rounded,
                     size: 20,
                   ),
-                  onPressed: () {},
+                  onPressed: () async {
+                    await conv.setFavorite(false);
+                  },
                 );
               } else {
                 return IconButton.filled(
@@ -146,7 +148,9 @@ class RoomProfilePage extends ConsumerWidget {
                     Icons.bookmark_add_outlined,
                     size: 20,
                   ),
-                  onPressed: () {},
+                  onPressed: () async {
+                    await conv.setFavorite(true);
+                  },
                 );
               }
             },

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -38,6 +38,7 @@ class RoomProfilePage extends ConsumerWidget {
         child: Column(
           children: [
             header(context, ref),
+            actions(context, ref),
             description(context, ref),
             optionsBody(context, ref),
           ],
@@ -122,6 +123,71 @@ class RoomProfilePage extends ConsumerWidget {
     );
   }
 
+  Widget actions(BuildContext context, WidgetRef ref) {
+    final convoLoader = ref.watch(chatProvider(roomId));
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          convoLoader.maybeWhen(
+            data: (conv) {
+              if (conv.isFavorite()) {
+                return IconButton.filled(
+                  icon: const Icon(
+                    Icons.bookmark_remove_rounded,
+                    size: 20,
+                  ),
+                  onPressed: () {},
+                );
+              } else {
+                return IconButton.filled(
+                  icon: const Icon(
+                    Icons.bookmark_add_outlined,
+                    size: 20,
+                  ),
+                  onPressed: () {},
+                );
+              }
+            },
+            orElse: () => Skeletonizer(
+              child: IconButton.filled(
+                icon: const Icon(
+                  Icons.bookmark_add_outlined,
+                  size: 20,
+                ),
+                onPressed: () {},
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 5),
+            child: IconButton.filled(
+              onPressed: () {
+                //FIXME : ?via=$serverName data should be handle from rust helper function
+                final serverName = roomId.split(':').last;
+                Clipboard.setData(
+                  ClipboardData(
+                    text: 'https://matrix.to/#/$roomId?via=$serverName',
+                  ),
+                );
+                customMsgSnackbar(
+                  context,
+                  'Room ID: $roomId copied to clipboard',
+                );
+              },
+              tooltip: 'Copy RoomLink',
+              icon: const Icon(
+                Icons.copy_outlined,
+                size: 20,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget optionsBody(BuildContext context, WidgetRef ref) {
     final convo = ref.watch(chatProvider(roomId));
     final members = ref.watch(chatMembersProvider(roomId));
@@ -157,31 +223,6 @@ class RoomProfilePage extends ConsumerWidget {
       sections: [
         SettingsSection(
           tiles: [
-            SettingsTile(
-              onPressed: (ctx) {
-                //FIXME : ?via=$serverName data should be handle from rust helper function
-                final serverName = roomId.split(':').last;
-                Clipboard.setData(
-                  ClipboardData(
-                    text: 'https://matrix.to/#/$roomId?via=$serverName',
-                  ),
-                );
-                customMsgSnackbar(
-                  context,
-                  'Room ID: $roomId copied to clipboard',
-                );
-              },
-              title: Text(
-                'Copy room link',
-                style: tileTextTheme,
-              ),
-              leading: const Icon(Atlas.chain_link_thin, size: 18),
-              trailing: Icon(
-                Atlas.pages_thin,
-                size: 18,
-                color: Theme.of(context).colorScheme.success,
-              ),
-            ),
             NotificationsSettingsTile(roomId: roomId),
             myMembership.when(
               data: (membership) => SettingsTile.navigation(

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -3,9 +3,11 @@ import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/models/chat_input_state/chat_input_state.dart';
 import 'package:acter/features/chat/models/chat_room_state/chat_room_state.dart';
 import 'package:acter/features/chat/models/media_chat_state/media_chat_state.dart';
+import 'package:acter/features/chat/models/room_list_filter_state/room_list_filter_state.dart';
 import 'package:acter/features/chat/providers/notifiers/chat_input_notifier.dart';
 import 'package:acter/features/chat/providers/notifiers/chat_room_notifier.dart';
 import 'package:acter/features/chat/providers/notifiers/media_chat_notifier.dart';
+import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,25 +28,18 @@ final mediaChatStateProvider = StateNotifierProvider.family<MediaChatNotifier,
   (ref, messageInfo) => MediaChatNotifier(ref: ref, messageInfo: messageInfo),
 );
 
-final chatSearchValueProvider =
-    StateProvider.autoDispose<String?>((ref) => null);
-
-final searchedChatsProvider =
+final filteredChatsProvider =
     FutureProvider.autoDispose<List<Convo>>((ref) async {
   final allRooms = ref.watch(chatsProvider);
-  final searchValue = ref.watch(chatSearchValueProvider);
-  if (searchValue == null || searchValue.isEmpty) {
-    return allRooms;
+  if (!ref.watch(hasRoomFilters)) {
+    throw 'No filters selected';
   }
-
-  final searchTerm = searchValue.toLowerCase();
 
   final foundRooms = List<Convo>.empty(growable: true);
 
+  final search = ref.watch(roomListFilterProvider);
   for (final convo in allRooms) {
-    final profile = await ref.watch(chatProfileDataProvider(convo).future);
-    final name = profile.displayName ?? convo.getRoomIdStr();
-    if (name.toLowerCase().contains(searchTerm)) {
+    if (await roomListFilterStateAppliesToRoom(search, ref, convo)) {
       foundRooms.add(convo);
     }
   }

--- a/app/lib/features/chat/providers/room_list_filter_provider.dart
+++ b/app/lib/features/chat/providers/room_list_filter_provider.dart
@@ -1,9 +1,18 @@
+import 'package:acter/common/providers/notifiers/client_pref_notifier.dart';
 import 'package:acter/features/chat/models/room_list_filter_state/room_list_filter_state.dart';
 import 'package:riverpod/riverpod.dart';
 
+final persistentRoomListFilterSelector = createMapPrefProvider<FilterSelection>(
+  prefKey: 'chatRoomFilterSelection',
+  mapFrom: (v) => FilterSelection.values
+      .firstWhere((e) => e.toString() == v, orElse: () => FilterSelection.all),
+  mapTo: (v) => v.toString(),
+);
+
 final roomListFilterProvider =
     StateNotifierProvider<RoomListFilterNotifier, RoomListFilterState>(
-  (ref) => RoomListFilterNotifier(),
+  (ref) =>
+      RoomListFilterNotifier(ref.read(persistentRoomListFilterSelector), ref),
 );
 
 final hasRoomFilters = StateProvider((ref) {
@@ -15,10 +24,22 @@ final hasRoomFilters = StateProvider((ref) {
 });
 
 class RoomListFilterNotifier extends StateNotifier<RoomListFilterState> {
-  RoomListFilterNotifier() : super(const RoomListFilterState());
+  RoomListFilterNotifier(FilterSelection selection, this.ref)
+      : super(RoomListFilterState(selection: selection)) {
+    ref.listen(persistentRoomListFilterSelector, (previous, next) {
+      // the persistance loader might come back a little late ...
+      if (state.selection != next) {
+        // live update, apply
+        state = state.copyWith(selection: next);
+      }
+    });
+  }
 
-  void setSelection(FilterSelection newFilter) {
+  final Ref ref;
+
+  Future<void> setSelection(FilterSelection newFilter) async {
     state = state.copyWith(selection: newFilter);
+    await ref.read(persistentRoomListFilterSelector.notifier).update(newFilter);
   }
 
   void updateSearchTerm(String? newTerm) {

--- a/app/lib/features/chat/providers/room_list_filter_provider.dart
+++ b/app/lib/features/chat/providers/room_list_filter_provider.dart
@@ -1,0 +1,32 @@
+import 'package:acter/features/chat/models/room_list_filter_state/room_list_filter_state.dart';
+import 'package:riverpod/riverpod.dart';
+
+final roomListFilterProvider =
+    StateNotifierProvider<RoomListFilterNotifier, RoomListFilterState>(
+  (ref) => RoomListFilterNotifier(),
+);
+
+final hasRoomFilters = StateProvider((ref) {
+  final state = ref.watch(roomListFilterProvider);
+  if (state.searchTerm != null && state.searchTerm!.isNotEmpty) {
+    return true;
+  }
+  return state.selection != FilterSelection.all;
+});
+
+class RoomListFilterNotifier extends StateNotifier<RoomListFilterState> {
+  RoomListFilterNotifier() : super(const RoomListFilterState());
+
+  void setSelection(FilterSelection newFilter) {
+    state = state.copyWith(selection: newFilter);
+  }
+
+  void updateSearchTerm(String? newTerm) {
+    state = state.copyWith(searchTerm: newTerm);
+  }
+
+  void clear() {
+    // reset to nothing
+    state = const RoomListFilterState();
+  }
+}

--- a/app/lib/features/chat/widgets/convo_list.dart
+++ b/app/lib/features/chat/widgets/convo_list.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/chat/convo_card.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
+import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,14 +22,14 @@ class _ConvosListConsumerState extends ConsumerState<ConvosList> {
   @override
   Widget build(BuildContext context) {
     final chats = ref.watch(chatsProvider);
-    final searchValue = ref.watch(chatSearchValueProvider);
-    if (searchValue?.isNotEmpty == true) {
-      return ref.watch(searchedChatsProvider).when(
+    final hasSearchFilter = ref.watch(hasRoomFilters);
+    if (hasSearchFilter) {
+      return ref.watch(filteredChatsProvider).when(
             data: (chats) {
               if (chats.isEmpty) {
                 return const Center(
                   heightFactor: 10,
-                  child: Text('No chats found matching your search term'),
+                  child: Text('No chats found matching your filters & search'),
                 );
               }
               return renderList(context, chats);

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -97,16 +97,17 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
         const SizedBox(height: 5),
         SearchBar(
           focusNode: searchFocus,
+          controller: searchTextController,
           leading: const Icon(Atlas.magnifying_glass),
           hintText: 'Search chats',
           trailing: hasSearchTerm
               ? [
                   InkWell(
                     onTap: () {
+                      searchTextController.clear();
                       ref
                           .read(roomListFilterProvider.notifier)
                           .updateSearchTerm(null);
-                      searchTextController.clear();
                     },
                     child: const Icon(Icons.clear),
                   ),
@@ -146,6 +147,7 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
             if (hasFilters)
               OutlinedButton(
                 onPressed: () {
+                  searchTextController.clear();
                   ref.read(roomListFilterProvider.notifier).clear();
                   setState(() {
                     _isSearchVisible = false;
@@ -239,13 +241,13 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
               opacity: !_isSearchVisible ? 0 : 1,
               curve: Curves.easeInOut,
               duration: const Duration(milliseconds: 400),
-              child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                child: _isSearchVisible
-                    ? filterBox(context)
-                    : const SizedBox.shrink(),
-              ),
+              child: _isSearchVisible
+                  ? Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 10),
+                      child: filterBox(context),
+                    )
+                  : const SizedBox.shrink(),
             ),
           ),
           SliverToBoxAdapter(

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -66,8 +66,9 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
 
     if (ref.watch(hasRoomFilters)) {
       String subFiltered = 'chats';
-      switch (ref
-          .watch(roomListFilterProvider.select((value) => value.selection))) {
+      final selection =
+          ref.watch(roomListFilterProvider.select((value) => value.selection));
+      switch (selection) {
         case FilterSelection.dmsOnly:
           subFiltered = 'DMs';
           break;
@@ -76,7 +77,6 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
         default:
           break;
       }
-      ;
 
       final searchTerm =
           ref.watch(roomListFilterProvider.select((value) => value.searchTerm));
@@ -255,7 +255,7 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
               child: _isSearchVisible
                   ? Padding(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 10),
+                          horizontal: 16, vertical: 10,),
                       child: filterBox(context),
                     )
                   : const SizedBox.shrink(),

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -132,8 +132,8 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
               label: Text("only DM's"),
             ),
           ],
-          onSelectionChanged: (Set<FilterSelection> newSelection) {
-            ref
+          onSelectionChanged: (Set<FilterSelection> newSelection) async {
+            await ref
                 .read(roomListFilterProvider.notifier)
                 .setSelection(newSelection.first);
           },

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -62,22 +62,33 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
   }
 
   Widget roomListTitle(BuildContext context) {
-    if (_isSearchVisible) {
-      return Text(
-        'Filter chats',
-        style: Theme.of(context).textTheme.headlineSmall,
-      );
-    }
+    String title = AppLocalizations.of(context)!.chat;
 
-    if (!ref.watch(hasRoomFilters)) {
-      return Text(
-        AppLocalizations.of(context)!.chat,
-        style: Theme.of(context).textTheme.headlineSmall,
-      );
+    if (ref.watch(hasRoomFilters)) {
+      String subFiltered = 'chats';
+      switch (ref
+          .watch(roomListFilterProvider.select((value) => value.selection))) {
+        case FilterSelection.dmsOnly:
+          subFiltered = 'DMs';
+          break;
+        case FilterSelection.favorites:
+          subFiltered = 'Bookmarked chats';
+        default:
+          break;
+      }
+      ;
+
+      final searchTerm =
+          ref.watch(roomListFilterProvider.select((value) => value.searchTerm));
+      if (searchTerm != null && searchTerm.isNotEmpty) {
+        title = "Show $subFiltered with '$searchTerm'";
+      } else {
+        title = subFiltered;
+      }
     }
 
     return Text(
-      'Filtered chats',
+      title,
       style: Theme.of(context).textTheme.headlineSmall,
     );
   }

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -1,6 +1,8 @@
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/chat/models/room_list_filter_state/room_list_filter_state.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
+import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter/features/chat/widgets/convo_list.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -11,25 +13,172 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
 final bucketGlobal = PageStorageBucket();
-// interface providers
-final _searchToggleProvider = StateProvider.autoDispose<bool>((ref) => false);
 
-class RoomsListWidget extends ConsumerWidget {
+class RoomsListWidget extends ConsumerStatefulWidget {
   static const roomListMenuKey = Key('room-list');
 
-  const RoomsListWidget({
-    super.key = roomListMenuKey,
-  });
+  const RoomsListWidget({super.key = roomListMenuKey});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _RoomsListWidgetState();
+}
+
+class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
+  final ScrollController controller = ScrollController();
+  final TextEditingController searchTextController = TextEditingController();
+  final FocusNode searchFocus = FocusNode();
+
+  bool _isSearchVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    controller.addListener(_onScroll);
+    searchTextController.text =
+        ref.read(roomListFilterProvider).searchTerm ?? '';
+  }
+
+  @override
+  void didUpdateWidget(RoomsListWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    searchTextController.text =
+        ref.read(roomListFilterProvider).searchTerm ?? '';
+  }
+
+  void _onScroll() {
+    final topPosition = controller.position.pixels <= 0;
+    final outOfRange = controller.position.outOfRange;
+    final offset = controller.offset;
+    if (topPosition && outOfRange && offset <= -80) {
+      setState(() {
+        _isSearchVisible = true;
+      });
+    } else if (!topPosition && !outOfRange) {
+      setState(() {
+        _isSearchVisible = false;
+      });
+    }
+  }
+
+  Widget roomListTitle(BuildContext context) {
+    if (_isSearchVisible) {
+      return Text(
+        'Filter chats',
+        style: Theme.of(context).textTheme.headlineSmall,
+      );
+    }
+
+    if (!ref.watch(hasRoomFilters)) {
+      return Text(
+        AppLocalizations.of(context)!.chat,
+        style: Theme.of(context).textTheme.headlineSmall,
+      );
+    }
+
+    return Text(
+      'Filtered chats',
+      style: Theme.of(context).textTheme.headlineSmall,
+    );
+  }
+
+  Widget filterBox(BuildContext context) {
+    final selected =
+        ref.watch(roomListFilterProvider.select((value) => value.selection));
+    final hasSearchTerm = ref
+            .watch(roomListFilterProvider.select((value) => value.searchTerm))
+            ?.isNotEmpty ==
+        true;
+    final hasFilters = ref.watch(hasRoomFilters);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 5),
+        SearchBar(
+          focusNode: searchFocus,
+          leading: const Icon(Atlas.magnifying_glass),
+          hintText: 'Search chats',
+          trailing: hasSearchTerm
+              ? [
+                  InkWell(
+                    onTap: () {
+                      ref
+                          .read(roomListFilterProvider.notifier)
+                          .updateSearchTerm(null);
+                      searchTextController.clear();
+                    },
+                    child: const Icon(Icons.clear),
+                  ),
+                ]
+              : null,
+          onChanged: (value) {
+            ref.read(roomListFilterProvider.notifier).updateSearchTerm(value);
+          },
+        ),
+        const SizedBox(height: 20),
+        SegmentedButton<FilterSelection>(
+          segments: const [
+            ButtonSegment(
+              value: FilterSelection.all,
+              label: Text('all'),
+            ),
+            ButtonSegment(
+              value: FilterSelection.favorites,
+              icon: Icon(Icons.bookmark_outline),
+            ),
+            ButtonSegment(
+              value: FilterSelection.dmsOnly,
+              label: Text("only DM's"),
+            ),
+          ],
+          onSelectionChanged: (Set<FilterSelection> newSelection) {
+            ref
+                .read(roomListFilterProvider.notifier)
+                .setSelection(newSelection.first);
+          },
+          selected: {selected},
+        ),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (hasFilters)
+              OutlinedButton(
+                onPressed: () {
+                  ref.read(roomListFilterProvider.notifier).clear();
+                  setState(() {
+                    _isSearchVisible = false;
+                  });
+                },
+                child: const Text('clear'),
+              ),
+            if (!hasFilters)
+              OutlinedButton(
+                onPressed: () {
+                  setState(() {
+                    _isSearchVisible = false;
+                  });
+                },
+                child: const Text('close'),
+              ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        const Divider(),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final client = ref.watch(alwaysClientProvider);
-    final showSearch = ref.watch(_searchToggleProvider);
-    final searchNotifier = ref.watch(_searchToggleProvider.notifier);
+    final hasFilters = ref.watch(hasRoomFilters);
     final inSideBar = ref.watch(inSideBarProvider);
     return PageStorage(
       bucket: bucketGlobal,
       child: CustomScrollView(
+        controller: controller,
         key: const PageStorageKey<String>('convo-list'),
         physics: const BouncingScrollPhysics(),
         slivers: [
@@ -39,61 +188,39 @@ class RoomsListWidget extends ConsumerWidget {
                 automaticallyImplyLeading: false,
                 floating: true,
                 elevation: 0,
-                leading: showSearch
-                    ? Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 8,
-                        ),
-                        child: TextFormField(
-                          autofocus: true,
-                          onChanged: (value) => ref
-                              .read(chatSearchValueProvider.notifier)
-                              .update((state) => value),
-                          cursorColor:
-                              Theme.of(context).colorScheme.tertiary2,
-                          decoration: InputDecoration(
-                            hintStyle: const TextStyle(color: Colors.white),
-                            suffixIcon: GestureDetector(
-                              onTap: () {
-                                searchNotifier.update((state) => false);
-                                ref
-                                    .read(
-                                      chatSearchValueProvider.notifier,
-                                    )
-                                    .state = null;
-                              },
-                              child: const Icon(
-                                Icons.close,
-                                color: Colors.white,
-                              ),
-                            ),
-                            contentPadding: const EdgeInsets.only(
-                              left: 12,
-                              bottom: 2,
-                              top: 2,
-                            ),
-                          ),
-                        ),
-                      )
-                    : Padding(
-                        padding: const EdgeInsets.all(15),
-                        child: Text(
-                          AppLocalizations.of(context)!.chat,
-                          style: Theme.of(context).textTheme.headlineSmall,
-                        ),
-                      ),
+                leading: Padding(
+                  padding: const EdgeInsets.all(15),
+                  child: roomListTitle(context),
+                ),
                 leadingWidth: double.infinity,
-                actions: showSearch
+                actions: _isSearchVisible
                     ? []
                     : [
-                        IconButton(
-                          onPressed: () {
-                            searchNotifier.update((state) => !state);
-                          },
-                          padding: const EdgeInsets.only(right: 10, left: 5),
-                          icon: const Icon(Atlas.magnifying_glass),
-                        ),
+                        if (!hasFilters)
+                          IconButton(
+                            onPressed: () {
+                              setState(() {
+                                _isSearchVisible = true;
+                                searchFocus.requestFocus();
+                              });
+                            },
+                            padding: const EdgeInsets.only(right: 10, left: 5),
+                            icon: const Icon(Atlas.magnifying_glass),
+                          ),
+                        if (hasFilters)
+                          IconButton(
+                            onPressed: () {
+                              setState(() {
+                                _isSearchVisible = true;
+                              });
+                            },
+                            padding: const EdgeInsets.only(right: 10, left: 5),
+                            icon: Badge(
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.badgeImportant,
+                              child: const Icon(Atlas.filter_thin),
+                            ),
+                          ),
                         IconButton(
                           onPressed: () async => context.pushNamed(
                             Routes.createChat.name,
@@ -106,6 +233,20 @@ class RoomsListWidget extends ConsumerWidget {
                       ],
               );
             },
+          ),
+          SliverToBoxAdapter(
+            child: AnimatedOpacity(
+              opacity: !_isSearchVisible ? 0 : 1,
+              curve: Curves.easeInOut,
+              duration: const Duration(milliseconds: 400),
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                child: _isSearchVisible
+                    ? filterBox(context)
+                    : const SizedBox.shrink(),
+              ),
+            ),
           ),
           SliverToBoxAdapter(
             child: client.isGuest()

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -1,10 +1,10 @@
+import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/search.dart';
 import 'package:acter/common/widgets/side_sheet.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/home/widgets/space_chip.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -5107,6 +5107,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __convoSetFavoriteFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _convoSetFavoriteFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   bool? __convoInviteUserFuturePoll(
     int boxed,
     int postCobject,
@@ -17509,6 +17553,18 @@ class Api {
       int Function(
         int,
       )>();
+  late final _convoSetFavoritePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Uint8,
+          )>>("__Convo_set_favorite");
+
+  late final _convoSetFavorite = _convoSetFavoritePtr.asFunction<
+      int Function(
+        int,
+        int,
+      )>();
   late final _convoIsLowPriorityPtr = _lookup<
       ffi.NativeFunction<
           ffi.Uint8 Function(
@@ -24705,6 +24761,21 @@ class Api {
   late final _convoMediaBinaryFuturePoll =
       _convoMediaBinaryFuturePollPtr.asFunction<
           _ConvoMediaBinaryFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _convoSetFavoriteFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ConvoSetFavoriteFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Convo_set_favorite_future_poll");
+
+  late final _convoSetFavoriteFuturePoll =
+      _convoSetFavoriteFuturePollPtr.asFunction<
+          _ConvoSetFavoriteFuturePollReturn Function(
             int,
             int,
             int,
@@ -36731,6 +36802,27 @@ class Convo {
     final tmp3 = tmp1;
     final tmp2 = tmp3 > 0;
     return tmp2;
+  }
+
+  /// set this a favorite chat
+  Future<bool> setFavorite(
+    bool isFavorite,
+  ) {
+    final tmp1 = isFavorite;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    final tmp3 = _api._convoSetFavorite(
+      tmp0,
+      tmp2,
+    );
+    final tmp5 = tmp3;
+    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
+    final tmp5_1 = _Box(_api, tmp5_0, "__Convo_set_favorite_future_drop");
+    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
+    final tmp4 = _nativeFuture(tmp5_1, _api.__convoSetFavoriteFuturePoll);
+    return tmp4;
   }
 
   /// is this a low priority chat
@@ -52408,6 +52500,21 @@ class _ConvoMediaBinaryFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _ConvoSetFavoriteFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -17499,6 +17499,26 @@ class Api {
       int Function(
         int,
       )>();
+  late final _convoIsFavoritePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.Int64,
+          )>>("__Convo_is_favorite");
+
+  late final _convoIsFavorite = _convoIsFavoritePtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _convoIsLowPriorityPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.Int64,
+          )>>("__Convo_is_low_priority");
+
+  late final _convoIsLowPriority = _convoIsLowPriorityPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _convoDmUsersPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -36694,6 +36714,30 @@ class Convo {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._convoIsDm(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// is this a favorite chat
+  bool isFavorite() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._convoIsFavorite(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// is this a low priority chat
+  bool isLowPriority() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._convoIsLowPriority(
       tmp0,
     );
     final tmp3 = tmp1;

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -5195,6 +5195,68 @@ class Api {
     return tmp7;
   }
 
+  String? __convoPermalinkFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _convoPermalinkFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    final tmp14 = tmp6.arg6;
+    final tmp15 = tmp6.arg7;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    if (tmp14 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp13_ptr = ffi.Pointer.fromAddress(tmp13);
+    List<int> tmp13_buf = [];
+    final tmp13_precast = tmp13_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp14; i++) {
+      int char = tmp13_precast.elementAt(i).value;
+      tmp13_buf.add(char);
+    }
+    final tmp7 = utf8.decode(tmp13_buf, allowMalformed: true);
+    if (tmp15 > 0) {
+      final ffi.Pointer<ffi.Void> tmp13_0;
+      tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+      this.__deallocate(tmp13_0, tmp15 * 1, 1);
+    }
+    return tmp7;
+  }
+
   bool? __convoJoinFuturePoll(
     int boxed,
     int postCobject,
@@ -17601,6 +17663,16 @@ class Api {
         int,
         int,
       )>();
+  late final _convoPermalinkPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Convo_permalink");
+
+  late final _convoPermalink = _convoPermalinkPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _convoJoinPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -24791,6 +24863,21 @@ class Api {
   late final _convoInviteUserFuturePoll =
       _convoInviteUserFuturePollPtr.asFunction<
           _ConvoInviteUserFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _convoPermalinkFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ConvoPermalinkFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Convo_permalink_future_poll");
+
+  late final _convoPermalinkFuturePoll =
+      _convoPermalinkFuturePollPtr.asFunction<
+          _ConvoPermalinkFuturePollReturn Function(
             int,
             int,
             int,
@@ -36883,6 +36970,21 @@ class Convo {
     tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
     final tmp6 = _nativeFuture(tmp7_1, _api.__convoInviteUserFuturePoll);
     return tmp6;
+  }
+
+  /// generate the room permalink
+  Future<String> permalink() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._convoPermalink(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Convo_permalink_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__convoPermalinkFuturePoll);
+    return tmp2;
   }
 
   /// join this room
@@ -52531,6 +52633,25 @@ class _ConvoInviteUserFuturePollReturn extends ffi.Struct {
   external int arg4;
   @ffi.Uint8()
   external int arg5;
+}
+
+class _ConvoPermalinkFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Int64()
+  external int arg5;
+  @ffi.Uint64()
+  external int arg6;
+  @ffi.Uint64()
+  external int arg7;
 }
 
 class _ConvoJoinFuturePollReturn extends ffi.Struct {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1175,6 +1175,12 @@ object Convo {
     /// is this a direct message
     fn is_dm() -> bool;
 
+    /// is this a favorite chat
+    fn is_favorite() -> bool;
+
+    /// is this a low priority chat
+    fn is_low_priority() -> bool;
+
     /// the list of users ids if this is a direct message
     fn dm_users() -> Vec<string>;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1190,6 +1190,8 @@ object Convo {
     /// invite the new user to this room
     fn invite_user(user_id: string) -> Future<Result<bool>>;
 
+    /// generate the room permalink
+    fn permalink() -> Future<Result<string>>;
     /// join this room
     fn join() -> Future<Result<bool>>;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1178,6 +1178,9 @@ object Convo {
     /// is this a favorite chat
     fn is_favorite() -> bool;
 
+    /// set this a favorite chat
+    fn set_favorite(is_favorite: bool) -> Future<Result<bool>>;
+
     /// is this a low priority chat
     fn is_low_priority() -> bool;
 

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -246,6 +246,13 @@ impl Convo {
         self.inner.room.is_low_priority()
     }
 
+    pub async fn permalink(&self) -> Result<String> {
+        let room = self.inner.room.clone();
+        Ok(RUNTIME
+            .spawn(async move { room.matrix_permalink(false).await.map(|u| u.to_string()) })
+            .await??)
+    }
+
     pub fn dm_users(&self) -> Vec<String> {
         self.inner
             .room

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -231,6 +231,17 @@ impl Convo {
         self.inner.room.is_favourite()
     }
 
+    pub async fn set_favorite(&self, is_favorite: bool) -> Result<bool> {
+        let room = self.inner.room.clone();
+        Ok(RUNTIME
+            .spawn(async move {
+                room.set_is_favourite(is_favorite, None)
+                    .await
+                    .map(|()| true)
+            })
+            .await??)
+    }
+
     pub fn is_low_priority(&self) -> bool {
         self.inner.room.is_low_priority()
     }

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -224,7 +224,15 @@ impl Convo {
     }
 
     pub fn is_dm(&self) -> bool {
-        !self.inner.room.direct_targets().is_empty()
+        self.inner.room.direct_targets_length() > 0
+    }
+
+    pub fn is_favorite(&self) -> bool {
+        self.inner.room.is_favourite()
+    }
+
+    pub fn is_low_priority(&self) -> bool {
+        self.inner.room.is_low_priority()
     }
 
     pub fn dm_users(&self) -> Vec<String> {


### PR DESCRIPTION
- [x] Pull-To-Filter UI for Chat list
- [x] Expose `isFavorite` and `isDm` and allow to filter by them
- [x] keep filter between restarts
- [x] allow user to favorite chat rooms
- [x] use rust for permalink generation for chat rooms
- [x] add Changelog  

See it in action: The Chat is bookmarked and then we go through the filters:

https://github.com/acterglobal/a3/assets/40496/f7b0f7c7-686c-4884-9e64-6a3d51e8c9f4


And once you scroll, it closes, but shows the "filtered chats" and a filter-with-badge icon in the top bar:


https://github.com/acterglobal/a3/assets/40496/078f0245-c2fb-4823-a2df-0ba4a6b0fbbd




