### PR TITLE
Switch to set_custom_no_read for performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "tracing-wasm",
- "uniffi",
+ "uniffi 0.26.1",
  "urlencoding",
  "uuid 1.6.1",
  "wasm-bindgen-futures",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk"
 version = "0.7.1"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "anyhow",
  "anymap2",
@@ -3054,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -3072,13 +3072,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uniffi",
+ "uniffi 0.26.0",
 ]
 
 [[package]]
 name = "matrix-sdk-common"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "aes",
  "as_variant",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-sqlite"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "async-trait",
  "deadpool-sqlite",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "base64 0.21.7",
  "blake3",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-test"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "ctor",
  "getrandom",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-test-macros"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "quote 1.0.35",
  "syn 2.0.48",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-ui"
 version = "0.7.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc#cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=f14c00db82539a2e9135b73568c1f68354c47255#f14c00db82539a2e9135b73568c1f68354c47255"
 dependencies = [
  "as_variant",
  "async-once-cell",
@@ -5954,6 +5954,16 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uniffi"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "uniffi_core 0.26.0",
+ "uniffi_macros 0.26.0",
+]
+
+[[package]]
+name = "uniffi"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
@@ -5961,10 +5971,33 @@ dependencies = [
  "anyhow",
  "camino",
  "clap 4.4.18",
- "uniffi_bindgen",
- "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
+ "uniffi_bindgen 0.26.1",
+ "uniffi_build 0.26.1",
+ "uniffi_core 0.26.1",
+ "uniffi_macros 0.26.1",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta 0.26.0",
+ "uniffi_testing 0.26.0",
+ "uniffi_udl 0.26.0",
 ]
 
 [[package]]
@@ -5987,9 +6020,19 @@ dependencies = [
  "serde",
  "textwrap",
  "toml 0.5.11",
- "uniffi_meta",
- "uniffi_testing",
- "uniffi_udl",
+ "uniffi_meta 0.26.1",
+ "uniffi_testing 0.26.1",
+ "uniffi_udl 0.26.1",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen 0.26.0",
 ]
 
 [[package]]
@@ -6000,7 +6043,16 @@ checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen",
+ "uniffi_bindgen 0.26.1",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6011,6 +6063,21 @@ checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote 1.0.35",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "log",
+ "once_cell",
+ "oneshot-uniffi",
+ "paste",
+ "static_assertions",
 ]
 
 [[package]]
@@ -6031,6 +6098,24 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "serde",
+ "syn 2.0.48",
+ "toml 0.5.11",
+ "uniffi_build 0.26.0",
+ "uniffi_meta 0.26.0",
+]
+
+[[package]]
+name = "uniffi_macros"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
@@ -6044,8 +6129,19 @@ dependencies = [
  "serde",
  "syn 2.0.48",
  "toml 0.5.11",
- "uniffi_build",
- "uniffi_meta",
+ "uniffi_build 0.26.1",
+ "uniffi_meta 0.26.1",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive 0.26.0",
 ]
 
 [[package]]
@@ -6057,7 +6153,19 @@ dependencies = [
  "anyhow",
  "bytes",
  "siphasher",
- "uniffi_checksum_derive",
+ "uniffi_checksum_derive 0.26.1",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
 ]
 
 [[package]]
@@ -6075,15 +6183,27 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.26.0",
+ "uniffi_testing 0.26.0",
+ "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1)",
+]
+
+[[package]]
+name = "uniffi_udl"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta",
- "uniffi_testing",
- "weedle2",
+ "uniffi_meta 0.26.1",
+ "uniffi_testing 0.26.1",
+ "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6377,6 +6497,14 @@ name = "weedle2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,34 +9,34 @@ default-members = ["native/acter"]
 
 [workspace.dependencies.matrix-sdk]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 features = ["experimental-sliding-sync"]
 
 [workspace.dependencies.matrix-sdk-base]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 
 [workspace.dependencies.matrix-sdk-sqlite]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 features = ["crypto-store", "state-store"]
 
 [workspace.dependencies.matrix-sdk-store-encryption]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 
 [workspace.dependencies.matrix-sdk-test]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 
 [workspace.dependencies.matrix-sdk-ui]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "cced512ad4a5d3d9b767ac0eb7e5065ac0e773bc"
+rev = "f14c00db82539a2e9135b73568c1f68354c47255"
 default-features = false
 features = ["e2e-encryption"]
 

--- a/app/lib/features/chat/widgets/room_avatar.dart
+++ b/app/lib/features/chat/widgets/room_avatar.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -1995,6 +1995,13 @@ impl RoomMessage {
                 }
                 result
             }
+            TimelineItemContent::CallInvite => RoomEventItem::new(
+                evt_id,
+                txn_id,
+                sender,
+                origin_server_ts,
+                "m.call_invite".to_owned(),
+            ),
         };
         if event.is_local_echo() {
             if let Some(send_state) = event.send_state() {

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -1375,7 +1375,7 @@ impl Room {
                     .context("Path was generated from strings. Must be string")?;
                 client
                     .store()
-                    .set_custom_value(&key, path_text.as_bytes().to_vec())
+                    .set_custom_value_no_read(&key, path_text.as_bytes().to_vec())
                     .await?;
                 Ok(OptionString::new(Some(path_text.to_string())))
             })

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -488,7 +488,7 @@ impl Space {
                 msg_options = MessagesOptions::forward().from(from.as_deref());
                 client
                     .store()
-                    .set_custom_value(
+                    .set_custom_value_no_read(
                         custom_storage_key.as_bytes(),
                         serde_json::to_vec(&HistoryState { seen })?,
                     )

--- a/native/media-cache-wrapper/src/lib.rs
+++ b/native/media-cache-wrapper/src/lib.rs
@@ -201,7 +201,7 @@ where
             .export(passphrase)
             .map_err(|e| StoreCacheWrapperError::StoreError(e.into()))?;
         state_store
-            .set_custom_value(b"ext_media_key", key)
+            .set_custom_value_no_read(b"ext_media_key", key)
             .await
             .map_err(|e| StoreCacheWrapperError::StoreError(e.into()))?;
         cipher
@@ -508,6 +508,18 @@ where
         Ok(self
             .inner
             .set_custom_value(key, value)
+            .await
+            .map_err(|e| StoreCacheWrapperError::StoreError(e.into()))?)
+    }
+
+    async fn set_custom_value_no_read(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<(), Self::Error> {
+        Ok(self
+            .inner
+            .set_custom_value_no_read(key, value)
             .await
             .map_err(|e| StoreCacheWrapperError::StoreError(e.into()))?)
     }


### PR DESCRIPTION
Upgrades to latest matrix-rust-sdk and uses the newly added more performant `set_custom_value_no_read` for the internal store.