### PR TITLE
Refactor related spaces

### DIFF
--- a/app/integration_test/tests/sub_spaces.dart
+++ b/app/integration_test/tests/sub_spaces.dart
@@ -1,6 +1,6 @@
 import 'package:acter/common/widgets/sliver_scaffold.dart';
-import 'package:acter/features/space/pages/related_spaces_page.dart';
 import 'package:acter/features/space/sheets/link_room_sheet.dart';
+import 'package:acter/features/space/widgets/relatest_spaces.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -40,8 +40,8 @@ void subSpaceTests() {
     await t.gotoSpace(spaceId);
     await t.navigateTo([
       const Key('spaces'),
-      RelatedSpacesPage.moreOptionKey,
-      RelatedSpacesPage.linkSubspaceKey,
+      RelatedSpaces.moreOptionKey,
+      RelatedSpaces.linkSubspaceKey,
     ]);
 
     final roomListEntry = find.byKey(Key('room-list-link-$subSpace'));
@@ -85,8 +85,8 @@ void subSpaceTests() {
     await t.gotoSpace(spaceId);
     await t.navigateTo([
       const Key('spaces'),
-      RelatedSpacesPage.moreOptionKey,
-      RelatedSpacesPage.linkSubspaceKey,
+      RelatedSpaces.moreOptionKey,
+      RelatedSpaces.linkSubspaceKey,
     ]);
 
     final roomListEntry = find.byKey(Key('room-list-link-$subSpace'));

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -66,7 +66,8 @@ final chatProvider =
     FutureProvider.family<Convo, String>((ref, roomIdOrAlias) async {
   final client = ref.watch(alwaysClientProvider);
   // FIXME: fallback to fetching a public data, if not found
-  return await client.convo(roomIdOrAlias);
+  return await client.convoWithRetry(
+      roomIdOrAlias, 120); // retrying for up to 30seconds before failing
 });
 
 final chatMembersProvider =

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -67,7 +67,7 @@ final chatProvider =
   final client = ref.watch(alwaysClientProvider);
   // FIXME: fallback to fetching a public data, if not found
   return await client.convoWithRetry(
-      roomIdOrAlias, 120); // retrying for up to 30seconds before failing
+      roomIdOrAlias, 120,); // retrying for up to 30seconds before failing
 });
 
 final chatMembersProvider =

--- a/app/lib/features/space/pages/overview_page.dart
+++ b/app/lib/features/space/pages/overview_page.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/space/widgets/about_card.dart';
@@ -12,7 +10,6 @@ import 'package:acter/features/space/widgets/space_header.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 class ActerSpaceChecker extends ConsumerWidget {
   final Widget child;
@@ -45,41 +42,43 @@ class SpaceOverview extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
-    const int minCount = 2;
     // get platform of context.
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: primaryGradient),
-      child: SingleChildScrollView(
-        child: Column(
-          children: [
-            SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
-            StaggeredGrid.count(
-              axisDirection: AxisDirection.down,
-              crossAxisCount: min(widthCount, minCount),
-              children: <Widget>[
-                AboutCard(spaceId: spaceIdOrAlias),
-                ActerSpaceChecker(
-                  spaceId: spaceIdOrAlias,
-                  expectation: (a) => a == null,
-                  child: NonActerSpaceCard(spaceId: spaceIdOrAlias),
-                ),
-                ActerSpaceChecker(
-                  spaceId: spaceIdOrAlias,
-                  expectation: (a) => a?.events().active() ?? false,
-                  child: EventsCard(spaceId: spaceIdOrAlias),
-                ),
-                ActerSpaceChecker(
-                  spaceId: spaceIdOrAlias,
-                  expectation: (a) => a?.pins().active() ?? false,
-                  child: LinksCard(spaceId: spaceIdOrAlias),
-                ),
-                ChatsCard(spaceId: spaceIdOrAlias),
-                RelatedSpacesCard(spaceId: spaceIdOrAlias),
-              ],
+      child: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
+          ),
+          SliverToBoxAdapter(
+            child: AboutCard(spaceId: spaceIdOrAlias),
+          ),
+          SliverToBoxAdapter(
+            child: ActerSpaceChecker(
+              spaceId: spaceIdOrAlias,
+              expectation: (a) => a == null,
+              child: NonActerSpaceCard(spaceId: spaceIdOrAlias),
             ),
-          ],
-        ),
+          ),
+          SliverToBoxAdapter(
+            child: ActerSpaceChecker(
+              spaceId: spaceIdOrAlias,
+              expectation: (a) => a?.events().active() ?? false,
+              child: EventsCard(spaceId: spaceIdOrAlias),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ActerSpaceChecker(
+              spaceId: spaceIdOrAlias,
+              expectation: (a) => a?.pins().active() ?? false,
+              child: LinksCard(spaceId: spaceIdOrAlias),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ChatsCard(spaceId: spaceIdOrAlias),
+          ),
+          RelatedSpacesCard(spaceId: spaceIdOrAlias),
+        ],
       ),
     );
   }

--- a/app/lib/features/space/pages/related_spaces_page.dart
+++ b/app/lib/features/space/pages/related_spaces_page.dart
@@ -24,25 +24,29 @@ class RelatedSpacesPage extends ConsumerWidget {
     // get platform of context.
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: primaryGradient),
-      child: Column(
-        children: [
-          SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
-          Expanded(
-            child: spaces.when(
-              data: (spaces) {
-                final canLinkSpace =
-                    spaces.membership?.canString('CanLinkSpaces') ?? false;
-                return RelatedSpaces(
-                  spaceIdOrAlias: spaceIdOrAlias,
-                  spaces: spaces,
-                  crossAxisCount: crossAxisCount,
-                  fallback: renderFallback(context, canLinkSpace),
-                );
-              },
-              error: (error, stack) => Center(
+      child: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
+          ),
+          spaces.when(
+            data: (spaces) {
+              final canLinkSpace =
+                  spaces.membership?.canString('CanLinkSpaces') ?? false;
+              return RelatedSpaces(
+                spaceIdOrAlias: spaceIdOrAlias,
+                spaces: spaces,
+                crossAxisCount: crossAxisCount,
+                fallback: renderFallback(context, canLinkSpace),
+              );
+            },
+            error: (error, stack) => SliverToBoxAdapter(
+              child: Center(
                 child: Text('Loading failed: $error'),
               ),
-              loading: () => const Center(
+            ),
+            loading: () => const SliverToBoxAdapter(
+              child: Center(
                 child: Text('Loading'),
               ),
             ),

--- a/app/lib/features/space/pages/related_spaces_page.dart
+++ b/app/lib/features/space/pages/related_spaces_page.dart
@@ -38,255 +38,7 @@ class RelatedSpacesPage extends ConsumerWidget {
             child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
           ),
           ...spaces.when(
-            data: (spaces) {
-              final widthCount =
-                  (MediaQuery.of(context).size.width ~/ 300).toInt();
-              const int minCount = 3;
-              // we have more than just the spaces screen, put them into a grid.
-              final List<Widget> items = [];
-              bool checkPermission(String permission) {
-                return spaces.membership?.canString(permission) ?? false;
-              }
-
-              final canLinkSpace = checkPermission('CanLinkSpaces');
-              void addSubspaceHeading(String title, bool withTools) {
-                List<Widget> children = [
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      child: Text(title),
-                    ),
-                  ),
-                ];
-                if (canLinkSpace && withTools) {
-                  children.add(
-                    PopupMenuButton(
-                      icon: Icon(
-                        Atlas.plus_circle,
-                        key: moreOptionKey,
-                        color: Theme.of(context).colorScheme.neutral5,
-                      ),
-                      iconSize: 28,
-                      color: Theme.of(context).colorScheme.surface,
-                      itemBuilder: (BuildContext context) => <PopupMenuEntry>[
-                        PopupMenuItem(
-                          key: createSubspaceKey,
-                          onTap: () => context.pushNamed(
-                            Routes.createSpace.name,
-                            queryParameters: {'parentSpaceId': spaceIdOrAlias},
-                          ),
-                          child: const Row(
-                            children: <Widget>[
-                              Text('Create Subspace'),
-                              Spacer(),
-                              Icon(Atlas.connection),
-                            ],
-                          ),
-                        ),
-                        PopupMenuItem(
-                          key: linkSubspaceKey,
-                          onTap: () => context.pushNamed(
-                            Routes.linkSubspace.name,
-                            pathParameters: {'spaceId': spaceIdOrAlias},
-                          ),
-                          child: const Row(
-                            children: <Widget>[
-                              Text('Link existing Space'),
-                              Spacer(),
-                              Icon(Atlas.connection),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }
-                items.add(
-                  SliverToBoxAdapter(
-                    child: Row(
-                      children: children,
-                    ),
-                  ),
-                );
-              }
-
-              if (spaces.parents.isNotEmpty || spaces.mainParent != null) {
-                List<Widget> children = [
-                  const Expanded(
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 12),
-                      child: Text('Parents'),
-                    ),
-                  ),
-                ];
-                items.add(
-                  SliverToBoxAdapter(
-                    child: Row(
-                      children: children,
-                    ),
-                  ),
-                );
-              }
-
-              if (spaces.mainParent != null) {
-                final space = spaces.mainParent!;
-                items.add(
-                  SliverToBoxAdapter(
-                    child: SpaceCard(
-                      key: Key(space.getRoomIdStr()),
-                      space: space,
-                    ),
-                  ),
-                );
-              }
-              if (spaces.parents.isNotEmpty) {
-                if (spaces.parents.isNotEmpty) {
-                  items.add(
-                    SliverGrid.builder(
-                      itemCount: spaces.parents.length,
-                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: max(1, min(widthCount, minCount)),
-                        childAspectRatio: 4.0,
-                        mainAxisExtent: 100,
-                      ),
-                      itemBuilder: (context, index) {
-                        final space = spaces.parents[index];
-                        return SpaceCard(
-                          key: Key('parent-list-item-${space.getRoomIdStr()}'),
-                          space: space,
-                          showParent: false,
-                        );
-                      },
-                    ),
-                  );
-                }
-              }
-              if (spaces.knownSubspaces.isNotEmpty) {
-                if (spaces.hasMoreSubspaces) {
-                  addSubspaceHeading('My Subspaces', false);
-                } else {
-                  addSubspaceHeading('Subspaces', true);
-                }
-                items.add(
-                  SliverGrid.builder(
-                    itemCount: spaces.knownSubspaces.length,
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: max(1, min(widthCount, minCount)),
-                      childAspectRatio: 9.0,
-                      mainAxisExtent: 100,
-                    ),
-                    itemBuilder: (context, index) {
-                      final space = spaces.knownSubspaces[index];
-                      return SpaceCard(
-                        key: Key('subspace-list-item-${space.getRoomIdStr()}'),
-                        space: space,
-                        showParent: false,
-                      );
-                    },
-                  ),
-                );
-              }
-              if (spaces.hasMoreSubspaces) {
-                if (spaces.knownSubspaces.isEmpty) {
-                  addSubspaceHeading('Subspaces', true);
-                } else {
-                  addSubspaceHeading('More Subspaces', true);
-                }
-                items.add(
-                  RiverPagedBuilder<Next?, SpaceHierarchyRoomInfo>.autoDispose(
-                    firstPageKey: const Next(isStart: true),
-                    provider: remoteSpaceHierarchyProvider(spaces),
-                    itemBuilder: (context, item, index) => SpaceHierarchyCard(
-                      key: Key('subspace-list-item-${item.roomIdStr()}'),
-                      space: item,
-                    ),
-                    pagedBuilder: (controller, builder) => PagedSliverList(
-                      pagingController: controller,
-                      builderDelegate: builder,
-                    ),
-                  ),
-                );
-              }
-
-              if (spaces.knownSubspaces.isEmpty &&
-                  !spaces.hasMoreSubspaces &&
-                  canLinkSpace) {
-                // fallback if there are no subspaces show, allow admins to access the buttons
-                addSubspaceHeading('Subspaces', true);
-              }
-
-              if (spaces.otherRelations.isNotEmpty || canLinkSpace) {
-                List<Widget> children = [
-                  const Expanded(child: Text('Recommended Spaces')),
-                  IconButton(
-                    icon: Icon(
-                      Atlas.plus_circle,
-                      color: Theme.of(context).colorScheme.neutral5,
-                    ),
-                    onPressed: () => context.pushNamed(
-                      Routes.linkRecommended.name,
-                      pathParameters: {'spaceId': spaceIdOrAlias},
-                    ),
-                  ),
-                ];
-                items.add(
-                  SliverToBoxAdapter(
-                    child: Row(
-                      children: children,
-                    ),
-                  ),
-                );
-              }
-              if (spaces.otherRelations.isNotEmpty) {
-                items.add(
-                  SliverGrid.builder(
-                    itemCount: spaces.otherRelations.length,
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: max(1, min(widthCount, minCount)),
-                      childAspectRatio: 4.0,
-                      mainAxisExtent: 100,
-                    ),
-                    itemBuilder: (context, index) {
-                      final space = spaces.otherRelations[index];
-                      return SpaceCard(
-                        key: Key('subspace-list-item-${space.getRoomIdStr()}'),
-                        space: space,
-                      );
-                    },
-                  ),
-                );
-              }
-
-              // Widget to use when there are no spaces linked
-              if (items.isEmpty) {
-                items.add(
-                  SliverToBoxAdapter(
-                    child: Center(
-                      heightFactor: 1,
-                      child: EmptyState(
-                        title: 'No connected spaces',
-                        subtitle:
-                            'In connected spaces, you can focus on specific actions or campaigns of your working groups and start organizing.',
-                        image: 'assets/images/empty_space.svg',
-                        primaryButton: canLinkSpace
-                            ? ElevatedButton(
-                                onPressed: () => context.pushNamed(
-                                  Routes.createSpace.name,
-                                  queryParameters: {
-                                    'parentSpaceId': spaceIdOrAlias,
-                                  },
-                                ),
-                                child: const Text('Create New Spaces'),
-                              )
-                            : null,
-                      ),
-                    ),
-                  ),
-                );
-              }
-
-              return items;
-            },
+            data: (spaces) => renderSpaces(spaces, context, ref),
             error: (error, stack) => [
               SliverToBoxAdapter(
                 child: Center(
@@ -305,5 +57,356 @@ class RelatedSpacesPage extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  Widget renderTools(BuildContext context) {
+    return PopupMenuButton(
+      icon: Icon(
+        Atlas.plus_circle,
+        key: moreOptionKey,
+        color: Theme.of(context).colorScheme.neutral5,
+      ),
+      iconSize: 28,
+      color: Theme.of(context).colorScheme.surface,
+      itemBuilder: (BuildContext context) => <PopupMenuEntry>[
+        PopupMenuItem(
+          key: createSubspaceKey,
+          onTap: () => context.pushNamed(
+            Routes.createSpace.name,
+            queryParameters: {'parentSpaceId': spaceIdOrAlias},
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('Create Subspace'),
+              Spacer(),
+              Icon(Atlas.connection),
+            ],
+          ),
+        ),
+        PopupMenuItem(
+          key: linkSubspaceKey,
+          onTap: () => context.pushNamed(
+            Routes.linkSubspace.name,
+            pathParameters: {'spaceId': spaceIdOrAlias},
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('Link existing Space'),
+              Spacer(),
+              Icon(Atlas.connection),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget renderSubspaceHeading(
+    BuildContext context,
+    String title, {
+    bool canLinkSpace = false,
+    bool withTools = false,
+  }) {
+    return SliverToBoxAdapter(
+      child: Row(children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(title),
+          ),
+        ),
+        if (canLinkSpace && withTools) renderTools(context),
+      ],),
+    );
+  }
+
+  Widget? renderParentsHeader(
+    SpaceRelationsOverview spaces,
+  ) {
+    if (spaces.parents.isNotEmpty || spaces.mainParent != null) {
+      return const SliverToBoxAdapter(
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text('Parents'),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    return null;
+  }
+
+  Widget? renderMainParent(
+    SpaceRelationsOverview spaces,
+  ) {
+    if (spaces.mainParent == null) {
+      return null;
+    }
+    final space = spaces.mainParent!;
+    return SliverToBoxAdapter(
+      child: SpaceCard(
+        key: Key(space.getRoomIdStr()),
+        space: space,
+      ),
+    );
+  }
+
+  Widget? renderFurtherParent(
+    SpaceRelationsOverview spaces,
+    int crossAxisCount,
+  ) {
+    if (spaces.parents.isEmpty) {
+      return null;
+    }
+    return SliverGrid.builder(
+      itemCount: spaces.parents.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        childAspectRatio: 4.0,
+        mainAxisExtent: 100,
+      ),
+      itemBuilder: (context, index) {
+        final space = spaces.parents[index];
+        return SpaceCard(
+          key: Key('parent-list-item-${space.getRoomIdStr()}'),
+          space: space,
+          showParent: false,
+        );
+      },
+    );
+  }
+
+  List<Widget>? renderKnownSubspaces(
+    BuildContext context,
+    SpaceRelationsOverview spaces,
+    bool canLinkSpace,
+    int crossAxisCount,
+  ) {
+    if (spaces.knownSubspaces.isEmpty) {
+      return null;
+    }
+
+    return [
+      spaces.hasMoreSubspaces
+          ? renderSubspaceHeading(
+              context,
+              'My Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: false,
+            )
+          : renderSubspaceHeading(
+              context,
+              'Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            ),
+      SliverGrid.builder(
+        itemCount: spaces.knownSubspaces.length,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: crossAxisCount,
+          childAspectRatio: 9.0,
+          mainAxisExtent: 100,
+        ),
+        itemBuilder: (context, index) {
+          final space = spaces.knownSubspaces[index];
+          return SpaceCard(
+            key: Key('subspace-list-item-${space.getRoomIdStr()}'),
+            space: space,
+            showParent: false,
+          );
+        },
+      ),
+    ];
+  }
+
+  List<Widget>? renderMoreSubspaces(
+    BuildContext context,
+    SpaceRelationsOverview spaces,
+    bool canLinkSpace,
+    int crossAxisCount,
+  ) {
+    if (!spaces.hasMoreSubspaces) {
+      return null;
+    }
+
+    return [
+      spaces.knownSubspaces.isEmpty
+          ? renderSubspaceHeading(
+              context,
+              'Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            )
+          : renderSubspaceHeading(
+              context,
+              'More Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            ),
+      RiverPagedBuilder<Next?, SpaceHierarchyRoomInfo>.autoDispose(
+        firstPageKey: const Next(isStart: true),
+        provider: remoteSpaceHierarchyProvider(spaces),
+        itemBuilder: (context, item, index) => SpaceHierarchyCard(
+          key: Key('subspace-list-item-${item.roomIdStr()}'),
+          space: item,
+        ),
+        pagedBuilder: (controller, builder) => PagedSliverList(
+          pagingController: controller,
+          builderDelegate: builder,
+        ),
+      ),
+    ];
+  }
+
+  Widget? renderFallbackSubspaceHeader(
+    BuildContext context,
+    SpaceRelationsOverview spaces,
+    bool canLinkSpace,
+  ) {
+    if (spaces.knownSubspaces.isEmpty &&
+        !spaces.hasMoreSubspaces &&
+        canLinkSpace) {
+      // fallback if there are no subspaces show, allow admins to access the buttons
+
+      return renderSubspaceHeading(
+        context,
+        'Subspaces',
+        canLinkSpace: canLinkSpace,
+        withTools: true,
+      );
+    }
+    return null;
+  }
+
+  List<Widget>? renderOtherRelations(
+    BuildContext context,
+    SpaceRelationsOverview spaces,
+    bool canLinkSpace,
+    int crossAxisCount,
+  ) {
+    if (spaces.otherRelations.isEmpty || !canLinkSpace) {
+      return null;
+    }
+
+    return [
+      if (spaces.otherRelations.isNotEmpty || canLinkSpace)
+        SliverToBoxAdapter(
+          child: Row(
+            children: [
+              const Expanded(child: Text('Recommended Spaces')),
+              IconButton(
+                icon: Icon(
+                  Atlas.plus_circle,
+                  color: Theme.of(context).colorScheme.neutral5,
+                ),
+                onPressed: () => context.pushNamed(
+                  Routes.linkRecommended.name,
+                  pathParameters: {'spaceId': spaceIdOrAlias},
+                ),
+              ),
+            ],
+          ),
+        ),
+      if (spaces.otherRelations.isNotEmpty)
+        SliverGrid.builder(
+          itemCount: spaces.otherRelations.length,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            childAspectRatio: 4.0,
+            mainAxisExtent: 100,
+          ),
+          itemBuilder: (context, index) {
+            final space = spaces.otherRelations[index];
+            return SpaceCard(
+              key: Key('subspace-list-item-${space.getRoomIdStr()}'),
+              space: space,
+            );
+          },
+        ),
+    ];
+  }
+
+  List<Widget> renderSpaces(
+    SpaceRelationsOverview spaces,
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
+    const int minCount = 3;
+    final crossAxisCount = max(1, min(widthCount, minCount));
+
+    final canLinkSpace = spaces.membership?.canString('CanLinkSpaces') ?? false;
+
+    final parentsHeader = renderParentsHeader(spaces);
+    final mainParent = renderMainParent(spaces);
+    final furtherParents = renderFurtherParent(spaces, crossAxisCount);
+    final knownSubspaces = renderKnownSubspaces(
+      context,
+      spaces,
+      canLinkSpace,
+      crossAxisCount,
+    );
+
+    final moreSubspaces = renderMoreSubspaces(
+      context,
+      spaces,
+      canLinkSpace,
+      crossAxisCount,
+    );
+    final fallbackSubspacesHeader = renderFallbackSubspaceHeader(
+      context,
+      spaces,
+      canLinkSpace,
+    );
+    final otherRelations = renderOtherRelations(
+      context,
+      spaces,
+      canLinkSpace,
+      crossAxisCount,
+    );
+
+    final items = [
+      if (parentsHeader != null) parentsHeader,
+      if (mainParent != null) mainParent,
+      if (furtherParents != null) furtherParents,
+      if (knownSubspaces != null) ...knownSubspaces,
+      if (moreSubspaces != null) ...moreSubspaces,
+      if (fallbackSubspacesHeader != null) fallbackSubspacesHeader,
+      if (otherRelations != null) ...otherRelations,
+    ];
+
+    if (items.isNotEmpty) {
+      return items;
+    }
+
+    // fallback when nothing was found
+    return [
+      SliverToBoxAdapter(
+        child: Center(
+          heightFactor: 1,
+          child: EmptyState(
+            title: 'No connected spaces',
+            subtitle:
+                'In connected spaces, you can focus on specific actions or campaigns of your working groups and start organizing.',
+            image: 'assets/images/empty_space.svg',
+            primaryButton: canLinkSpace
+                ? ElevatedButton(
+                    onPressed: () => context.pushNamed(
+                      Routes.createSpace.name,
+                      queryParameters: {
+                        'parentSpaceId': spaceIdOrAlias,
+                      },
+                    ),
+                    child: const Text('Create New Spaces'),
+                  )
+                : null,
+          ),
+        ),
+      ),
+    ];
   }
 }

--- a/app/lib/features/space/pages/related_spaces_page.dart
+++ b/app/lib/features/space/pages/related_spaces_page.dart
@@ -1,27 +1,16 @@
 import 'dart:math';
 
 import 'package:acter/common/providers/space_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
-import 'package:acter/common/widgets/spaces/space_card.dart';
-import 'package:acter/common/widgets/spaces/space_hierarchy_card.dart';
-import 'package:acter/features/space/providers/space_providers.dart';
-import 'package:acter/features/space/providers/notifiers/space_hierarchy_notifier.dart';
+import 'package:acter/features/space/widgets/relatest_spaces.dart';
 import 'package:acter/features/space/widgets/space_header.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:riverpod_infinite_scroll/riverpod_infinite_scroll.dart';
 
 class RelatedSpacesPage extends ConsumerWidget {
-  static const moreOptionKey = Key('related-spaces-more-actions');
-  static const createSubspaceKey = Key('related-spaces-more-create-subspace');
-  static const linkSubspaceKey = Key('related-spaces-more-link-subspace');
   final String spaceIdOrAlias;
 
   const RelatedSpacesPage({super.key, required this.spaceIdOrAlias});
@@ -29,384 +18,62 @@ class RelatedSpacesPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final spaces = ref.watch(spaceRelationsOverviewProvider(spaceIdOrAlias));
+    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
+    const int minCount = 3;
+    final crossAxisCount = max(1, min(widthCount, minCount));
     // get platform of context.
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: primaryGradient),
-      child: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
-          ),
-          ...spaces.when(
-            data: (spaces) => renderSpaces(spaces, context, ref),
-            error: (error, stack) => [
-              SliverToBoxAdapter(
-                child: Center(
-                  child: Text('Loading failed: $error'),
-                ),
+      child: Column(
+        children: [
+          SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
+          Expanded(
+            child: spaces.when(
+              data: (spaces) {
+                final canLinkSpace =
+                    spaces.membership?.canString('CanLinkSpaces') ?? false;
+                return RelatedSpaces(
+                  spaceIdOrAlias: spaceIdOrAlias,
+                  spaces: spaces,
+                  crossAxisCount: crossAxisCount,
+                  fallback: renderFallback(context, canLinkSpace),
+                );
+              },
+              error: (error, stack) => Center(
+                child: Text('Loading failed: $error'),
               ),
-            ],
-            loading: () => [
-              const SliverToBoxAdapter(
-                child: Center(
-                  child: Text('Loading'),
-                ),
+              loading: () => const Center(
+                child: Text('Loading'),
               ),
-            ],
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget renderTools(BuildContext context) {
-    return PopupMenuButton(
-      icon: Icon(
-        Atlas.plus_circle,
-        key: moreOptionKey,
-        color: Theme.of(context).colorScheme.neutral5,
-      ),
-      iconSize: 28,
-      color: Theme.of(context).colorScheme.surface,
-      itemBuilder: (BuildContext context) => <PopupMenuEntry>[
-        PopupMenuItem(
-          key: createSubspaceKey,
-          onTap: () => context.pushNamed(
-            Routes.createSpace.name,
-            queryParameters: {'parentSpaceId': spaceIdOrAlias},
-          ),
-          child: const Row(
-            children: <Widget>[
-              Text('Create Subspace'),
-              Spacer(),
-              Icon(Atlas.connection),
-            ],
-          ),
-        ),
-        PopupMenuItem(
-          key: linkSubspaceKey,
-          onTap: () => context.pushNamed(
-            Routes.linkSubspace.name,
-            pathParameters: {'spaceId': spaceIdOrAlias},
-          ),
-          child: const Row(
-            children: <Widget>[
-              Text('Link existing Space'),
-              Spacer(),
-              Icon(Atlas.connection),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget renderSubspaceHeading(
-    BuildContext context,
-    String title, {
-    bool canLinkSpace = false,
-    bool withTools = false,
-  }) {
+  Widget renderFallback(BuildContext context, bool canLinkSpace) {
     return SliverToBoxAdapter(
-      child: Row(children: [
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Text(title),
-          ),
-        ),
-        if (canLinkSpace && withTools) renderTools(context),
-      ],),
-    );
-  }
-
-  Widget? renderParentsHeader(
-    SpaceRelationsOverview spaces,
-  ) {
-    if (spaces.parents.isNotEmpty || spaces.mainParent != null) {
-      return const SliverToBoxAdapter(
-        child: Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Text('Parents'),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-    return null;
-  }
-
-  Widget? renderMainParent(
-    SpaceRelationsOverview spaces,
-  ) {
-    if (spaces.mainParent == null) {
-      return null;
-    }
-    final space = spaces.mainParent!;
-    return SliverToBoxAdapter(
-      child: SpaceCard(
-        key: Key(space.getRoomIdStr()),
-        space: space,
-      ),
-    );
-  }
-
-  Widget? renderFurtherParent(
-    SpaceRelationsOverview spaces,
-    int crossAxisCount,
-  ) {
-    if (spaces.parents.isEmpty) {
-      return null;
-    }
-    return SliverGrid.builder(
-      itemCount: spaces.parents.length,
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
-        childAspectRatio: 4.0,
-        mainAxisExtent: 100,
-      ),
-      itemBuilder: (context, index) {
-        final space = spaces.parents[index];
-        return SpaceCard(
-          key: Key('parent-list-item-${space.getRoomIdStr()}'),
-          space: space,
-          showParent: false,
-        );
-      },
-    );
-  }
-
-  List<Widget>? renderKnownSubspaces(
-    BuildContext context,
-    SpaceRelationsOverview spaces,
-    bool canLinkSpace,
-    int crossAxisCount,
-  ) {
-    if (spaces.knownSubspaces.isEmpty) {
-      return null;
-    }
-
-    return [
-      spaces.hasMoreSubspaces
-          ? renderSubspaceHeading(
-              context,
-              'My Subspaces',
-              canLinkSpace: canLinkSpace,
-              withTools: false,
-            )
-          : renderSubspaceHeading(
-              context,
-              'Subspaces',
-              canLinkSpace: canLinkSpace,
-              withTools: true,
-            ),
-      SliverGrid.builder(
-        itemCount: spaces.knownSubspaces.length,
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: crossAxisCount,
-          childAspectRatio: 9.0,
-          mainAxisExtent: 100,
-        ),
-        itemBuilder: (context, index) {
-          final space = spaces.knownSubspaces[index];
-          return SpaceCard(
-            key: Key('subspace-list-item-${space.getRoomIdStr()}'),
-            space: space,
-            showParent: false,
-          );
-        },
-      ),
-    ];
-  }
-
-  List<Widget>? renderMoreSubspaces(
-    BuildContext context,
-    SpaceRelationsOverview spaces,
-    bool canLinkSpace,
-    int crossAxisCount,
-  ) {
-    if (!spaces.hasMoreSubspaces) {
-      return null;
-    }
-
-    return [
-      spaces.knownSubspaces.isEmpty
-          ? renderSubspaceHeading(
-              context,
-              'Subspaces',
-              canLinkSpace: canLinkSpace,
-              withTools: true,
-            )
-          : renderSubspaceHeading(
-              context,
-              'More Subspaces',
-              canLinkSpace: canLinkSpace,
-              withTools: true,
-            ),
-      RiverPagedBuilder<Next?, SpaceHierarchyRoomInfo>.autoDispose(
-        firstPageKey: const Next(isStart: true),
-        provider: remoteSpaceHierarchyProvider(spaces),
-        itemBuilder: (context, item, index) => SpaceHierarchyCard(
-          key: Key('subspace-list-item-${item.roomIdStr()}'),
-          space: item,
-        ),
-        pagedBuilder: (controller, builder) => PagedSliverList(
-          pagingController: controller,
-          builderDelegate: builder,
+      child: Center(
+        heightFactor: 1,
+        child: EmptyState(
+          title: 'No connected spaces',
+          subtitle:
+              'In connected spaces, you can focus on specific actions or campaigns of your working groups and start organizing.',
+          image: 'assets/images/empty_space.svg',
+          primaryButton: canLinkSpace
+              ? ElevatedButton(
+                  onPressed: () => context.pushNamed(
+                    Routes.createSpace.name,
+                    queryParameters: {
+                      'parentSpaceId': spaceIdOrAlias,
+                    },
+                  ),
+                  child: const Text('Create New Spaces'),
+                )
+              : null,
         ),
       ),
-    ];
-  }
-
-  Widget? renderFallbackSubspaceHeader(
-    BuildContext context,
-    SpaceRelationsOverview spaces,
-    bool canLinkSpace,
-  ) {
-    if (spaces.knownSubspaces.isEmpty &&
-        !spaces.hasMoreSubspaces &&
-        canLinkSpace) {
-      // fallback if there are no subspaces show, allow admins to access the buttons
-
-      return renderSubspaceHeading(
-        context,
-        'Subspaces',
-        canLinkSpace: canLinkSpace,
-        withTools: true,
-      );
-    }
-    return null;
-  }
-
-  List<Widget>? renderOtherRelations(
-    BuildContext context,
-    SpaceRelationsOverview spaces,
-    bool canLinkSpace,
-    int crossAxisCount,
-  ) {
-    if (spaces.otherRelations.isEmpty || !canLinkSpace) {
-      return null;
-    }
-
-    return [
-      if (spaces.otherRelations.isNotEmpty || canLinkSpace)
-        SliverToBoxAdapter(
-          child: Row(
-            children: [
-              const Expanded(child: Text('Recommended Spaces')),
-              IconButton(
-                icon: Icon(
-                  Atlas.plus_circle,
-                  color: Theme.of(context).colorScheme.neutral5,
-                ),
-                onPressed: () => context.pushNamed(
-                  Routes.linkRecommended.name,
-                  pathParameters: {'spaceId': spaceIdOrAlias},
-                ),
-              ),
-            ],
-          ),
-        ),
-      if (spaces.otherRelations.isNotEmpty)
-        SliverGrid.builder(
-          itemCount: spaces.otherRelations.length,
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 4.0,
-            mainAxisExtent: 100,
-          ),
-          itemBuilder: (context, index) {
-            final space = spaces.otherRelations[index];
-            return SpaceCard(
-              key: Key('subspace-list-item-${space.getRoomIdStr()}'),
-              space: space,
-            );
-          },
-        ),
-    ];
-  }
-
-  List<Widget> renderSpaces(
-    SpaceRelationsOverview spaces,
-    BuildContext context,
-    WidgetRef ref,
-  ) {
-    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
-    const int minCount = 3;
-    final crossAxisCount = max(1, min(widthCount, minCount));
-
-    final canLinkSpace = spaces.membership?.canString('CanLinkSpaces') ?? false;
-
-    final parentsHeader = renderParentsHeader(spaces);
-    final mainParent = renderMainParent(spaces);
-    final furtherParents = renderFurtherParent(spaces, crossAxisCount);
-    final knownSubspaces = renderKnownSubspaces(
-      context,
-      spaces,
-      canLinkSpace,
-      crossAxisCount,
     );
-
-    final moreSubspaces = renderMoreSubspaces(
-      context,
-      spaces,
-      canLinkSpace,
-      crossAxisCount,
-    );
-    final fallbackSubspacesHeader = renderFallbackSubspaceHeader(
-      context,
-      spaces,
-      canLinkSpace,
-    );
-    final otherRelations = renderOtherRelations(
-      context,
-      spaces,
-      canLinkSpace,
-      crossAxisCount,
-    );
-
-    final items = [
-      if (parentsHeader != null) parentsHeader,
-      if (mainParent != null) mainParent,
-      if (furtherParents != null) furtherParents,
-      if (knownSubspaces != null) ...knownSubspaces,
-      if (moreSubspaces != null) ...moreSubspaces,
-      if (fallbackSubspacesHeader != null) fallbackSubspacesHeader,
-      if (otherRelations != null) ...otherRelations,
-    ];
-
-    if (items.isNotEmpty) {
-      return items;
-    }
-
-    // fallback when nothing was found
-    return [
-      SliverToBoxAdapter(
-        child: Center(
-          heightFactor: 1,
-          child: EmptyState(
-            title: 'No connected spaces',
-            subtitle:
-                'In connected spaces, you can focus on specific actions or campaigns of your working groups and start organizing.',
-            image: 'assets/images/empty_space.svg',
-            primaryButton: canLinkSpace
-                ? ElevatedButton(
-                    onPressed: () => context.pushNamed(
-                      Routes.createSpace.name,
-                      queryParameters: {
-                        'parentSpaceId': spaceIdOrAlias,
-                      },
-                    ),
-                    child: const Text('Create New Spaces'),
-                  )
-                : null,
-          ),
-        ),
-      ),
-    ];
   }
 }

--- a/app/lib/features/space/widgets/related_spaces_card.dart
+++ b/app/lib/features/space/widgets/related_spaces_card.dart
@@ -1,9 +1,7 @@
-import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/widgets/spaces/space_card.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/features/space/widgets/relatest_spaces.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class RelatedSpacesCard extends ConsumerWidget {
   final String spaceId;
@@ -12,50 +10,22 @@ class RelatedSpacesCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final spaces = ref.watch(relatedSpacesProvider(spaceId));
+    final spaces = ref.watch(spaceRelationsOverviewProvider(spaceId));
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          InkWell(
-            onTap: () {
-              context.pushNamed(
-                Routes.spaceRelatedSpaces.name,
-                pathParameters: {'spaceId': spaceId},
-              );
-            },
-            child: Text(
-              'Related Spaces',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-          ),
-          const SizedBox(height: 10),
-          ...spaces.when(
-            data: (spaces) {
-              if (spaces.isEmpty) {
-                return [
-                  Text(
-                    'There are no spaces related to this space',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ];
-              }
-              return spaces.map(
-                (space) => SpaceCard.small(
-                  space: space,
-                  titleTextStyle: Theme.of(context).textTheme.bodySmall,
-                  subtitleTextStyle: Theme.of(context).textTheme.bodySmall,
-                  showParent: false,
-                ),
-              );
-            },
-            error: (error, stack) => [Text('Loading spaces failed: $error')],
-            loading: () => [const Text('Loading')],
-          ),
-        ],
+    return spaces.when(
+      data: (spaces) => RelatedSpaces(
+        spaceIdOrAlias: spaceId,
+        spaces: spaces,
+        showParents: false,
+        fallback: Text(
+          'There are no spaces related to this space',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
       ),
+      error: (error, stack) => SliverToBoxAdapter(
+        child: Text('Loading spaces failed: $error'),
+      ),
+      loading: () => const SliverToBoxAdapter(child: Text('Loading')),
     );
   }
 }

--- a/app/lib/features/space/widgets/relatest_spaces.dart
+++ b/app/lib/features/space/widgets/relatest_spaces.dart
@@ -1,0 +1,333 @@
+import 'dart:math';
+
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/widgets/spaces/space_card.dart';
+import 'package:acter/common/widgets/spaces/space_hierarchy_card.dart';
+import 'package:acter/features/space/providers/notifiers/space_hierarchy_notifier.dart';
+import 'package:acter/features/space/providers/space_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:riverpod_infinite_scroll/riverpod_infinite_scroll.dart';
+
+class RelatedSpaces extends StatelessWidget {
+  static const moreOptionKey = Key('related-spaces-more-actions');
+  static const createSubspaceKey = Key('related-spaces-more-create-subspace');
+  static const linkSubspaceKey = Key('related-spaces-more-link-subspace');
+
+  final String spaceIdOrAlias;
+  final SpaceRelationsOverview spaces;
+  final int crossAxisCount;
+  final Widget fallback;
+
+  const RelatedSpaces({
+    super.key,
+    required this.spaceIdOrAlias,
+    required this.spaces,
+    required this.fallback,
+    this.crossAxisCount = 1,
+  });
+
+  Widget renderTools(BuildContext context) {
+    return PopupMenuButton(
+      icon: Icon(
+        Atlas.plus_circle,
+        key: moreOptionKey,
+        color: Theme.of(context).colorScheme.neutral5,
+      ),
+      iconSize: 28,
+      color: Theme.of(context).colorScheme.surface,
+      itemBuilder: (BuildContext context) => <PopupMenuEntry>[
+        PopupMenuItem(
+          key: createSubspaceKey,
+          onTap: () => context.pushNamed(
+            Routes.createSpace.name,
+            queryParameters: {'parentSpaceId': spaceIdOrAlias},
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('Create Subspace'),
+              Spacer(),
+              Icon(Atlas.connection),
+            ],
+          ),
+        ),
+        PopupMenuItem(
+          key: linkSubspaceKey,
+          onTap: () => context.pushNamed(
+            Routes.linkSubspace.name,
+            pathParameters: {'spaceId': spaceIdOrAlias},
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('Link existing Space'),
+              Spacer(),
+              Icon(Atlas.connection),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget renderSubspaceHeading(
+    BuildContext context,
+    String title, {
+    bool canLinkSpace = false,
+    bool withTools = false,
+  }) {
+    return SliverToBoxAdapter(
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Text(title),
+            ),
+          ),
+          if (canLinkSpace && withTools) renderTools(context),
+        ],
+      ),
+    );
+  }
+
+  Widget? renderParentsHeader() {
+    if (spaces.parents.isNotEmpty || spaces.mainParent != null) {
+      return const SliverToBoxAdapter(
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Text('Parents'),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    return null;
+  }
+
+  Widget? renderMainParent() {
+    if (spaces.mainParent == null) {
+      return null;
+    }
+    final space = spaces.mainParent!;
+    return SliverToBoxAdapter(
+      child: SpaceCard(
+        key: Key(space.getRoomIdStr()),
+        space: space,
+      ),
+    );
+  }
+
+  Widget? renderFurtherParent() {
+    if (spaces.parents.isEmpty) {
+      return null;
+    }
+    return SliverGrid.builder(
+      itemCount: spaces.parents.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        childAspectRatio: 4.0,
+        mainAxisExtent: 100,
+      ),
+      itemBuilder: (context, index) {
+        final space = spaces.parents[index];
+        return SpaceCard(
+          key: Key('parent-list-item-${space.getRoomIdStr()}'),
+          space: space,
+          showParent: false,
+        );
+      },
+    );
+  }
+
+  List<Widget>? renderKnownSubspaces(
+    BuildContext context,
+    bool canLinkSpace,
+  ) {
+    if (spaces.knownSubspaces.isEmpty) {
+      return null;
+    }
+
+    return [
+      spaces.hasMoreSubspaces
+          ? renderSubspaceHeading(
+              context,
+              'My Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: false,
+            )
+          : renderSubspaceHeading(
+              context,
+              'Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            ),
+      SliverGrid.builder(
+        itemCount: spaces.knownSubspaces.length,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: crossAxisCount,
+          childAspectRatio: 9.0,
+          mainAxisExtent: 100,
+        ),
+        itemBuilder: (context, index) {
+          final space = spaces.knownSubspaces[index];
+          return SpaceCard(
+            key: Key('subspace-list-item-${space.getRoomIdStr()}'),
+            space: space,
+            showParent: false,
+          );
+        },
+      ),
+    ];
+  }
+
+  List<Widget>? renderMoreSubspaces(
+    BuildContext context,
+    bool canLinkSpace,
+  ) {
+    if (!spaces.hasMoreSubspaces) {
+      return null;
+    }
+
+    return [
+      spaces.knownSubspaces.isEmpty
+          ? renderSubspaceHeading(
+              context,
+              'Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            )
+          : renderSubspaceHeading(
+              context,
+              'More Subspaces',
+              canLinkSpace: canLinkSpace,
+              withTools: true,
+            ),
+      RiverPagedBuilder<Next?, SpaceHierarchyRoomInfo>.autoDispose(
+        firstPageKey: const Next(isStart: true),
+        provider: remoteSpaceHierarchyProvider(spaces),
+        itemBuilder: (context, item, index) => SpaceHierarchyCard(
+          key: Key('subspace-list-item-${item.roomIdStr()}'),
+          space: item,
+        ),
+        pagedBuilder: (controller, builder) => PagedSliverList(
+          pagingController: controller,
+          builderDelegate: builder,
+        ),
+      ),
+    ];
+  }
+
+  Widget? renderFallbackSubspaceHeader(
+    BuildContext context,
+    bool canLinkSpace,
+  ) {
+    if (spaces.knownSubspaces.isEmpty &&
+        !spaces.hasMoreSubspaces &&
+        canLinkSpace) {
+      // fallback if there are no subspaces show, allow admins to access the buttons
+
+      return renderSubspaceHeading(
+        context,
+        'Subspaces',
+        canLinkSpace: canLinkSpace,
+        withTools: true,
+      );
+    }
+    return null;
+  }
+
+  List<Widget>? renderOtherRelations(
+    BuildContext context,
+    bool canLinkSpace,
+  ) {
+    if (spaces.otherRelations.isEmpty || !canLinkSpace) {
+      return null;
+    }
+
+    return [
+      if (spaces.otherRelations.isNotEmpty || canLinkSpace)
+        SliverToBoxAdapter(
+          child: Row(
+            children: [
+              const Expanded(child: Text('Recommended Spaces')),
+              IconButton(
+                icon: Icon(
+                  Atlas.plus_circle,
+                  color: Theme.of(context).colorScheme.neutral5,
+                ),
+                onPressed: () => context.pushNamed(
+                  Routes.linkRecommended.name,
+                  pathParameters: {'spaceId': spaceIdOrAlias},
+                ),
+              ),
+            ],
+          ),
+        ),
+      if (spaces.otherRelations.isNotEmpty)
+        SliverGrid.builder(
+          itemCount: spaces.otherRelations.length,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            childAspectRatio: 4.0,
+            mainAxisExtent: 100,
+          ),
+          itemBuilder: (context, index) {
+            final space = spaces.otherRelations[index];
+            return SpaceCard(
+              key: Key('subspace-list-item-${space.getRoomIdStr()}'),
+              space: space,
+            );
+          },
+        ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canLinkSpace = spaces.membership?.canString('CanLinkSpaces') ?? false;
+
+    final parentsHeader = renderParentsHeader();
+    final mainParent = renderMainParent();
+    final furtherParents = renderFurtherParent();
+    final knownSubspaces = renderKnownSubspaces(
+      context,
+      canLinkSpace,
+    );
+
+    final moreSubspaces = renderMoreSubspaces(
+      context,
+      canLinkSpace,
+    );
+    final fallbackSubspacesHeader =
+        renderFallbackSubspaceHeader(context, canLinkSpace);
+    final otherRelations = renderOtherRelations(
+      context,
+      canLinkSpace,
+    );
+
+    final items = [
+      if (parentsHeader != null) parentsHeader,
+      if (mainParent != null) mainParent,
+      if (furtherParents != null) furtherParents,
+      if (knownSubspaces != null) ...knownSubspaces,
+      if (moreSubspaces != null) ...moreSubspaces,
+      if (fallbackSubspacesHeader != null) fallbackSubspacesHeader,
+      if (otherRelations != null) ...otherRelations,
+    ];
+
+    if (items.isNotEmpty) {
+      return CustomScrollView(slivers: items);
+    } else {
+      return fallback;
+    }
+  }
+}

--- a/app/lib/features/space/widgets/relatest_spaces.dart
+++ b/app/lib/features/space/widgets/relatest_spaces.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
@@ -23,12 +21,14 @@ class RelatedSpaces extends StatelessWidget {
   final SpaceRelationsOverview spaces;
   final int crossAxisCount;
   final Widget fallback;
+  final bool showParents;
 
   const RelatedSpaces({
     super.key,
     required this.spaceIdOrAlias,
     required this.spaces,
     required this.fallback,
+    this.showParents = true,
     this.crossAxisCount = 1,
   });
 
@@ -96,25 +96,25 @@ class RelatedSpaces extends StatelessWidget {
   }
 
   Widget? renderParentsHeader() {
-    if (spaces.parents.isNotEmpty || spaces.mainParent != null) {
-      return const SliverToBoxAdapter(
-        child: Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Text('Parents'),
-              ),
-            ),
-          ],
-        ),
-      );
+    if (!showParents || (spaces.parents.isEmpty && spaces.mainParent != null)) {
+      return null;
     }
-    return null;
+    return const SliverToBoxAdapter(
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12),
+              child: Text('Parents'),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget? renderMainParent() {
-    if (spaces.mainParent == null) {
+    if (!showParents || spaces.mainParent == null) {
       return null;
     }
     final space = spaces.mainParent!;
@@ -127,7 +127,7 @@ class RelatedSpaces extends StatelessWidget {
   }
 
   Widget? renderFurtherParent() {
-    if (spaces.parents.isEmpty) {
+    if (!showParents || spaces.parents.isEmpty) {
       return null;
     }
     return SliverGrid.builder(
@@ -325,7 +325,7 @@ class RelatedSpaces extends StatelessWidget {
     ];
 
     if (items.isNotEmpty) {
-      return CustomScrollView(slivers: items);
+      return SliverMainAxisGroup(slivers: items);
     } else {
       return fallback;
     }


### PR DESCRIPTION
Probably best viewed one commit at a time. On top of #1505 .

https://github.com/acterglobal/a3/assets/40496/acccc41c-914c-49fc-8a48-9e7ec3f2aa58

This does two things:
1. refactor the complicated related-spaces page in two steps: first switch all these sections into their own FNs for easier reading (first commit) then move that into a separate widget (second commit).
2. Reuse the same widget for the related-spaces section of the space overview without showing the parents, fixing #1096 .

In order to allow for the latter, I had to remove the grid view from the overview because those are not compatible with one another and I couldn't find a good way of making that work, considering that the widget itself uses the rather complex sliver-mechanism to allow for autoloading on scroll. As a side effect the screen looks a bit worse on desktop after this PR was applied :( (see screenshot below), but I guess that is an okay price to pay for now...

![grafik](https://github.com/acterglobal/a3/assets/40496/424d4750-e9b3-4391-801d-0fe61d01e899)

