### PR TITLE
Members Info box with quick actions

### DIFF
--- a/.changes/1508-member-profiles.md
+++ b/.changes/1508-member-profiles.md
@@ -1,0 +1,1 @@
+- [enhancement] Upon clicking a users avatar in the space members list, the chat members list or within a chat directly a new drawer pulls up with more details and actions (like jump to the DM) in it for your convenience.

--- a/app/lib/common/dialogs/block_user_dialog.dart
+++ b/app/lib/common/dialogs/block_user_dialog.dart
@@ -26,7 +26,7 @@ Future<void> showBlockUserDialog(BuildContext context, Member member) async {
         ),
         actions: <Widget>[
           TextButton(
-            onPressed: () => context.pop(),
+            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
             child: const Text('No'),
           ),
           TextButton(

--- a/app/lib/common/dialogs/block_user_dialog.dart
+++ b/app/lib/common/dialogs/block_user_dialog.dart
@@ -1,0 +1,102 @@
+import 'package:acter/common/widgets/default_dialog.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+Future<void> showBlockUserDialog(BuildContext context, Member member) async {
+  final userId = member.userId().toString();
+  await showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text('Block $userId'),
+        content: RichText(
+          textAlign: TextAlign.left,
+          text: TextSpan(
+            text: 'You are about to block $userId. ',
+            style: const TextStyle(color: Colors.white, fontSize: 24),
+            children: const <TextSpan>[
+              TextSpan(
+                text:
+                    "Once blocked you won't see their messages anymore and it will block their attempt to contact you directly. ",
+              ),
+              TextSpan(text: 'Continue?'),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => context.pop(),
+            child: const Text('No'),
+          ),
+          TextButton(
+            onPressed: () async {
+              showAdaptiveDialog(
+                barrierDismissible: false,
+                context: context,
+                builder: (context) => DefaultDialog(
+                  title: Text(
+                    'Blocking User',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  isLoader: true,
+                ),
+              );
+              try {
+                await member.ignore();
+                if (!context.mounted) {
+                  return;
+                }
+                context.pop();
+
+                showAdaptiveDialog(
+                  context: context,
+                  builder: (context) => DefaultDialog(
+                    title: Text(
+                      'User blocked. It might takes a bit before the UI reflects this update.',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    actions: <Widget>[
+                      ElevatedButton(
+                        onPressed: () {
+                          // close both dialogs
+                          context.pop();
+                          context.pop();
+                        },
+                        child: const Text('Okay'),
+                      ),
+                    ],
+                  ),
+                );
+              } catch (err) {
+                if (!context.mounted) {
+                  return;
+                }
+                showAdaptiveDialog(
+                  context: context,
+                  builder: (context) => DefaultDialog(
+                    title: Text(
+                      'Block user failed: \n $err"',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    actions: <Widget>[
+                      ElevatedButton(
+                        onPressed: () {
+                          // close both dialogs
+                          context.pop();
+                          context.pop();
+                        },
+                        child: const Text('Okay'),
+                      ),
+                    ],
+                  ),
+                );
+              }
+            },
+            child: const Text('Yes'),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/app/lib/common/dialogs/member_info_drawer.dart
+++ b/app/lib/common/dialogs/member_info_drawer.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/dialogs/block_user_dialog.dart';
 import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/utils/routes.dart';
@@ -46,6 +47,11 @@ class _MemberInfoDrawer extends StatelessWidget {
               iconData: Atlas.block_thin,
               title: 'Block User',
               withMenu: false,
+              onTap: () async {
+                await showBlockUserDialog(context, member);
+                // ignore: use_build_context_synchronously
+                context.pop();
+              },
             ),
             const SizedBox(height: 30),
           ],

--- a/app/lib/common/dialogs/member_info_drawer.dart
+++ b/app/lib/common/dialogs/member_info_drawer.dart
@@ -1,0 +1,251 @@
+import 'package:acter/common/models/profile_data.dart';
+import 'package:acter/common/snackbars/custom_msg.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_avatar/acter_avatar.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class _MemberInfoDrawer extends StatelessWidget {
+  final ProfileData memberProfile;
+  final String memberId;
+  final String roomId;
+  const _MemberInfoDrawer({
+    super.key,
+    required this.memberProfile,
+    required this.memberId,
+    required this.roomId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 20),
+            _buildAvatarUI(context),
+            const SizedBox(height: 20),
+            if (memberProfile.displayName != null) _buildDisplayName(context),
+            const SizedBox(height: 20),
+            _buildUserName(context),
+            const SizedBox(height: 20),
+            _buildMessageUser(),
+            const SizedBox(height: 30),
+            _actionMenuItem(
+              context: context,
+              iconData: Atlas.block_thin,
+              title: 'Block User',
+              withMenu: false,
+            ),
+            const SizedBox(height: 30),
+          ],
+          // _profileItem(
+          //   key: MyProfilePage.displayNameKey,
+          //   context: context,
+          //   title: 'Display Name',
+          //   subTitle: displayName,
+          //   trailingIcon: Atlas.pencil_edit,
+          //   onPressed: () => updateDisplayName(data, context, ref),
+          // ),
+          // const SizedBox(height: 20),
+          // _profileItem(
+          //   context: context,
+          //   title: 'Username',
+          //   subTitle: userId,
+          //   trailingIcon: Atlas.pages,
+          //   onPressed: () {
+          //     Clipboard.setData(
+          //       ClipboardData(text: userId),
+          //     );
+          //     customMsgSnackbar(
+          //       context,
+          //       'Username copied to clipboard',
+          //     );
+          //   },
+          // ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatarUI(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        await gotoFullProfile(context);
+      },
+      child: Center(
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(100),
+            border: Border.all(
+              width: 2,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          child: ActerAvatar(
+            mode: DisplayMode.DM,
+            avatarInfo: AvatarInfo(
+              uniqueId: memberId,
+              avatar: memberProfile.getAvatarImage(),
+              displayName: memberProfile.displayName,
+            ),
+            size: 50,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageUser() {
+    return Consumer(
+      builder: (context, ref, widget) {
+        final client = ref.watch(alwaysClientProvider);
+        final dmId = client.dmWithUser(memberId).text();
+        if (dmId != null) {
+          debugPrint('DM id; $dmId');
+          return Center(
+            child: OutlinedButton.icon(
+              icon: const Icon(Atlas.chats_thin),
+              onPressed: () async {
+                context.pop();
+                context.pushNamed(
+                  Routes.chatroom.name,
+                  pathParameters: {
+                    'roomId': dmId,
+                  },
+                );
+              },
+              label: const Text('Message'),
+            ),
+          );
+        } else {
+          return Center(
+            child: OutlinedButton.icon(
+              icon: const Icon(Atlas.chats_thin),
+              onPressed: () {
+                context.pop();
+                context.pushNamed(
+                  Routes.createChat.name,
+                  queryParameters: {
+                    'userId': memberId,
+                  },
+                );
+              },
+              label: const Text('Start DM'),
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  Widget _buildDisplayName(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        await gotoFullProfile(context);
+      },
+      child: Center(
+        child: Text(memberProfile.displayName!), // FIXME: make this prettier
+      ),
+    );
+  }
+
+  Widget _buildUserName(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        context.pop(); // close the drawer
+        Clipboard.setData(
+          ClipboardData(
+            text: memberId,
+          ),
+        );
+        customMsgSnackbar(
+          context,
+          'Username copied to clipboard',
+        );
+      },
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(memberId), // FIXME: make this prettier
+          const SizedBox(width: 5),
+          const Icon(Icons.copy_outlined),
+        ],
+      ),
+    );
+  }
+
+  Future<void> gotoFullProfile(BuildContext context) async {}
+}
+
+Widget _actionMenuItem({
+  Key? key,
+  required BuildContext context,
+  required IconData iconData,
+  Color? iconColor,
+  required String title,
+  TextStyle? titleStyles,
+  String? subTitle,
+  VoidCallback? onTap,
+  bool enable = true,
+  bool withMenu = true,
+}) {
+  return Card(
+    child: ListTile(
+      key: key,
+      onTap: onTap,
+      leading: Icon(
+        iconData,
+        color: enable ? iconColor : Theme.of(context).disabledColor,
+      ),
+      title: Text(
+        title,
+        style: titleStyles?.copyWith(
+          color: enable ? null : Theme.of(context).disabledColor,
+        ),
+      ),
+      subtitle: subTitle == null
+          ? null
+          : Text(
+              subTitle,
+              style: titleStyles?.copyWith(
+                color: enable ? null : Theme.of(context).disabledColor,
+              ),
+            ),
+      trailing: withMenu
+          ? const Icon(
+              Icons.keyboard_arrow_right_outlined,
+            )
+          : null,
+    ),
+  );
+}
+
+const Key memberInfoDrawer = Key('members-widgets-member-info-drawer');
+Future<void> showMemberInfoDrawer({
+  required BuildContext context,
+  required ProfileData memberProfile,
+  required String roomId,
+  required String memberId,
+  Key? key = memberInfoDrawer,
+}) async {
+  await showModalBottomSheet(
+    showDragHandle: true,
+    enableDrag: true,
+    context: context,
+    isScrollControlled: true,
+    isDismissible: true,
+    builder: (context) => _MemberInfoDrawer(
+      key: key,
+      roomId: roomId,
+      memberId: memberId,
+      memberProfile: memberProfile,
+    ),
+  );
+}

--- a/app/lib/common/dialogs/member_info_drawer.dart
+++ b/app/lib/common/dialogs/member_info_drawer.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/dialogs/block_user_dialog.dart';
 import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
+import 'package:acter/common/toolkit/menu_item_widget.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/chat/providers/create_chat_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -42,8 +43,7 @@ class _MemberInfoDrawer extends StatelessWidget {
             const SizedBox(height: 20),
             _buildMessageUser(),
             const SizedBox(height: 30),
-            _actionMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.block_thin,
               title: 'Block User',
               withMenu: false,
@@ -55,58 +55,29 @@ class _MemberInfoDrawer extends StatelessWidget {
             ),
             const SizedBox(height: 30),
           ],
-          // _profileItem(
-          //   key: MyProfilePage.displayNameKey,
-          //   context: context,
-          //   title: 'Display Name',
-          //   subTitle: displayName,
-          //   trailingIcon: Atlas.pencil_edit,
-          //   onPressed: () => updateDisplayName(data, context, ref),
-          // ),
-          // const SizedBox(height: 20),
-          // _profileItem(
-          //   context: context,
-          //   title: 'Username',
-          //   subTitle: userId,
-          //   trailingIcon: Atlas.pages,
-          //   onPressed: () {
-          //     Clipboard.setData(
-          //       ClipboardData(text: userId),
-          //     );
-          //     customMsgSnackbar(
-          //       context,
-          //       'Username copied to clipboard',
-          //     );
-          //   },
-          // ),
         ),
       ),
     );
   }
 
   Widget _buildAvatarUI(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        await gotoFullProfile(context);
-      },
-      child: Center(
-        child: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(100),
-            border: Border.all(
-              width: 2,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
+    return Center(
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(100),
+          border: Border.all(
+            width: 2,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
-          child: ActerAvatar(
-            mode: DisplayMode.DM,
-            avatarInfo: AvatarInfo(
-              uniqueId: memberId,
-              avatar: memberProfile.getAvatarImage(),
-              displayName: memberProfile.displayName,
-            ),
-            size: 50,
+        ),
+        child: ActerAvatar(
+          mode: DisplayMode.DM,
+          avatarInfo: AvatarInfo(
+            uniqueId: memberId,
+            avatar: memberProfile.getAvatarImage(),
+            displayName: memberProfile.displayName,
           ),
+          size: 50,
         ),
       ),
     );
@@ -118,7 +89,6 @@ class _MemberInfoDrawer extends StatelessWidget {
         final client = ref.watch(alwaysClientProvider);
         final dmId = client.dmWithUser(memberId).text();
         if (dmId != null) {
-          debugPrint('DM id; $dmId');
           return Center(
             child: OutlinedButton.icon(
               icon: const Icon(Atlas.chats_thin),
@@ -157,13 +127,8 @@ class _MemberInfoDrawer extends StatelessWidget {
   }
 
   Widget _buildDisplayName(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        await gotoFullProfile(context);
-      },
-      child: Center(
-        child: Text(memberProfile.displayName!), // FIXME: make this prettier
-      ),
+    return Center(
+      child: Text(memberProfile.displayName!), // FIXME: make this prettier
     );
   }
 
@@ -191,51 +156,6 @@ class _MemberInfoDrawer extends StatelessWidget {
       ),
     );
   }
-
-  Future<void> gotoFullProfile(BuildContext context) async {}
-}
-
-Widget _actionMenuItem({
-  Key? key,
-  required BuildContext context,
-  required IconData iconData,
-  Color? iconColor,
-  required String title,
-  TextStyle? titleStyles,
-  String? subTitle,
-  VoidCallback? onTap,
-  bool enable = true,
-  bool withMenu = true,
-}) {
-  return Card(
-    child: ListTile(
-      key: key,
-      onTap: onTap,
-      leading: Icon(
-        iconData,
-        color: enable ? iconColor : Theme.of(context).disabledColor,
-      ),
-      title: Text(
-        title,
-        style: titleStyles?.copyWith(
-          color: enable ? null : Theme.of(context).disabledColor,
-        ),
-      ),
-      subtitle: subTitle == null
-          ? null
-          : Text(
-              subTitle,
-              style: titleStyles?.copyWith(
-                color: enable ? null : Theme.of(context).disabledColor,
-              ),
-            ),
-      trailing: withMenu
-          ? const Icon(
-              Icons.keyboard_arrow_right_outlined,
-            )
-          : null,
-    ),
-  );
 }
 
 const Key memberInfoDrawer = Key('members-widgets-member-info-drawer');

--- a/app/lib/common/dialogs/member_info_drawer.dart
+++ b/app/lib/common/dialogs/member_info_drawer.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/dialogs/block_user_dialog.dart';
 import 'package:acter/common/models/profile_data.dart';
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/toolkit/menu_item_widget.dart';
 import 'package:acter/common/utils/routes.dart';
@@ -13,7 +14,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class _MemberInfoDrawer extends StatelessWidget {
+class _MemberInfoDrawer extends ConsumerWidget {
   final ProfileData memberProfile;
   final String memberId;
   final Member member;
@@ -27,7 +28,7 @@ class _MemberInfoDrawer extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20.0),
@@ -41,23 +42,38 @@ class _MemberInfoDrawer extends StatelessWidget {
             const SizedBox(height: 20),
             _buildUserName(context),
             const SizedBox(height: 20),
-            _buildMessageUser(),
-            const SizedBox(height: 30),
-            MenuItemWidget(
-              iconData: Atlas.block_thin,
-              title: 'Block User',
-              withMenu: false,
-              onTap: () async {
-                await showBlockUserDialog(context, member);
-                // ignore: use_build_context_synchronously
-                context.pop();
-              },
-            ),
-            const SizedBox(height: 30),
+            ..._buildMenu(context, ref),
           ],
         ),
       ),
     );
+  }
+
+  List<Widget> _buildMenu(BuildContext context, WidgetRef ref) {
+    final myUserId = ref.watch(accountProvider).userId().toString();
+    final itsMe = memberId == myUserId;
+    if (itsMe) {
+      return [
+        const Center(child: Text('This is you')),
+        const SizedBox(height: 30),
+      ];
+    }
+
+    // regular user
+    return [
+      _buildMessageUser(),
+      const SizedBox(height: 30),
+      MenuItemWidget(
+        iconData: Atlas.block_thin,
+        title: 'Block User',
+        withMenu: false,
+        onTap: () async {
+          await showBlockUserDialog(context, member);
+          // ignore: use_build_context_synchronously
+          context.pop();
+        },
+      ),
+    ];
   }
 
   Widget _buildAvatarUI(BuildContext context) {

--- a/app/lib/common/dialogs/member_info_drawer.dart
+++ b/app/lib/common/dialogs/member_info_drawer.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/models/profile_data.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/chat/providers/create_chat_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -12,12 +14,14 @@ import 'package:go_router/go_router.dart';
 class _MemberInfoDrawer extends StatelessWidget {
   final ProfileData memberProfile;
   final String memberId;
+  final Member member;
   final String roomId;
   const _MemberInfoDrawer({
     super.key,
     required this.memberProfile,
     required this.memberId,
     required this.roomId,
+    required this.member,
   });
 
   @override
@@ -129,12 +133,13 @@ class _MemberInfoDrawer extends StatelessWidget {
             child: OutlinedButton.icon(
               icon: const Icon(Atlas.chats_thin),
               onPressed: () {
+                final profile = member.getProfile();
+                ref.read(createChatSelectedUsersProvider.notifier).state = [
+                  profile,
+                ];
                 context.pop();
                 context.pushNamed(
                   Routes.createChat.name,
-                  queryParameters: {
-                    'userId': memberId,
-                  },
                 );
               },
               label: const Text('Start DM'),
@@ -232,6 +237,7 @@ Future<void> showMemberInfoDrawer({
   required BuildContext context,
   required ProfileData memberProfile,
   required String roomId,
+  required Member member,
   required String memberId,
   Key? key = memberInfoDrawer,
 }) async {
@@ -244,6 +250,7 @@ Future<void> showMemberInfoDrawer({
     builder: (context) => _MemberInfoDrawer(
       key: key,
       roomId: roomId,
+      member: member,
       memberId: memberId,
       memberProfile: memberProfile,
     ),

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -67,7 +67,9 @@ final chatProvider =
   final client = ref.watch(alwaysClientProvider);
   // FIXME: fallback to fetching a public data, if not found
   return await client.convoWithRetry(
-      roomIdOrAlias, 120,); // retrying for up to 30seconds before failing
+    roomIdOrAlias,
+    120,
+  ); // retrying for up to 30seconds before failing
 });
 
 final chatMembersProvider =

--- a/app/lib/common/toolkit/menu_item_widget.dart
+++ b/app/lib/common/toolkit/menu_item_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class MenuItemWidget extends StatelessWidget {
+  final IconData iconData;
+  final Color? iconColor;
+  final String title;
+  final TextStyle? titleStyles;
+  final String? subTitle;
+  final VoidCallback? onTap;
+  final bool enabled;
+  final bool withMenu;
+
+  const MenuItemWidget({
+    super.key,
+    required this.iconData,
+    this.iconColor,
+    required this.title,
+    this.titleStyles,
+    this.subTitle,
+    this.onTap,
+    this.enabled = true,
+    this.withMenu = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        key: key,
+        onTap: onTap,
+        leading: Icon(
+          iconData,
+          color: enabled ? iconColor : Theme.of(context).disabledColor,
+        ),
+        title: Text(
+          title,
+          style: titleStyles?.copyWith(
+            color: enabled ? null : Theme.of(context).disabledColor,
+          ),
+        ),
+        subtitle: subTitle != null
+            ? Text(
+                subTitle!,
+                style: titleStyles?.copyWith(
+                  color: enabled ? null : Theme.of(context).disabledColor,
+                ),
+              )
+            : null,
+        trailing: withMenu
+            ? const Icon(
+                Icons.keyboard_arrow_right_outlined,
+              )
+            : null,
+      ),
+    );
+  }
+}

--- a/app/lib/common/widgets/member_list_entry.dart
+++ b/app/lib/common/widgets/member_list_entry.dart
@@ -561,6 +561,7 @@ class MemberListEntry extends ConsumerWidget {
         await showMemberInfoDrawer(
           context: context,
           memberProfile: memberProfile,
+          member: member,
           roomId: roomId,
           memberId: userId,
         );

--- a/app/lib/common/widgets/member_list_entry.dart
+++ b/app/lib/common/widgets/member_list_entry.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:acter/common/dialogs/member_info_drawer.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
 import 'package:acter/common/themes/app_theme.dart';
@@ -552,6 +553,18 @@ class MemberListEntry extends ConsumerWidget {
       trailing.add(submenu(context, ref));
     }
     return ListTile(
+      onTap: () async {
+        final memberProfile =
+            await ref.watch(memberProfileProvider(member).future);
+        final roomId = space?.getRoomIdStr() ?? convo!.getRoomIdStr();
+        // ignore: use_build_context_synchronously
+        await showMemberInfoDrawer(
+          context: context,
+          memberProfile: memberProfile,
+          roomId: roomId,
+          memberId: userId,
+        );
+      },
       leading: profile.when(
         data: (data) => ActerAvatar(
           mode: DisplayMode.DM,

--- a/app/lib/common/widgets/member_list_entry.dart
+++ b/app/lib/common/widgets/member_list_entry.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:acter/common/dialogs/block_user_dialog.dart';
 import 'package:acter/common/dialogs/member_info_drawer.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/snackbars/custom_msg.dart';
@@ -190,101 +191,7 @@ class MemberListEntry extends ConsumerWidget {
   });
 
   Future<void> blockUser(BuildContext context) async {
-    final userId = member.userId().toString();
-    await showDialog(
-      context: context,
-      builder: (BuildContext ctx) {
-        return AlertDialog(
-          title: Text('Block $userId'),
-          content: RichText(
-            textAlign: TextAlign.left,
-            text: TextSpan(
-              text: 'You are about to block $userId. ',
-              style: const TextStyle(color: Colors.white, fontSize: 24),
-              children: const <TextSpan>[
-                TextSpan(
-                  text:
-                      "Once blocked you won't see their messages anymore and it will block their attempt to contact you directly. ",
-                ),
-                TextSpan(text: 'Continue?'),
-              ],
-            ),
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => context.pop(),
-              child: const Text('No'),
-            ),
-            TextButton(
-              onPressed: () async {
-                showAdaptiveDialog(
-                  barrierDismissible: false,
-                  context: context,
-                  builder: (context) => DefaultDialog(
-                    title: Text(
-                      'Blocking User',
-                      style: Theme.of(context).textTheme.titleSmall,
-                    ),
-                    isLoader: true,
-                  ),
-                );
-                try {
-                  await member.ignore();
-                  if (!context.mounted) {
-                    return;
-                  }
-                  context.pop();
-
-                  showAdaptiveDialog(
-                    context: context,
-                    builder: (context) => DefaultDialog(
-                      title: Text(
-                        'User blocked. It might takes a bit before the UI reflects this update.',
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
-                      actions: <Widget>[
-                        ElevatedButton(
-                          onPressed: () {
-                            // close both dialogs
-                            context.pop();
-                            context.pop();
-                          },
-                          child: const Text('Okay'),
-                        ),
-                      ],
-                    ),
-                  );
-                } catch (err) {
-                  if (!context.mounted) {
-                    return;
-                  }
-                  showAdaptiveDialog(
-                    context: context,
-                    builder: (context) => DefaultDialog(
-                      title: Text(
-                        'Block user failed: \n $err"',
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
-                      actions: <Widget>[
-                        ElevatedButton(
-                          onPressed: () {
-                            // close both dialogs
-                            context.pop();
-                            context.pop();
-                          },
-                          child: const Text('Okay'),
-                        ),
-                      ],
-                    ),
-                  );
-                }
-              },
-              child: const Text('Yes'),
-            ),
-          ],
-        );
-      },
-    );
+    await showBlockUserDialog(context, member);
   }
 
   Future<void> unblockUser(BuildContext context) async {

--- a/app/lib/features/chat/providers/create_chat_providers.dart
+++ b/app/lib/features/chat/providers/create_chat_providers.dart
@@ -1,0 +1,6 @@
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// saves selected users from search result
+final createChatSelectedUsersProvider =
+    StateProvider<List<ffi.UserProfile>>((ref) => []);

--- a/app/lib/features/chat/widgets/avatar_builder.dart
+++ b/app/lib/features/chat/widgets/avatar_builder.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/dialogs/member_info_drawer.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
@@ -26,6 +27,21 @@ class AvatarBuilder extends ConsumerWidget {
         return Padding(
           padding: const EdgeInsets.only(right: 10),
           child: ActerAvatar(
+            onAvatarTap: () async {
+              final member = await ref.read(
+                memberProvider(
+                  (userId: userId, roomId: roomId),
+                ).future,
+              );
+              // ignore: use_build_context_synchronously
+              showMemberInfoDrawer(
+                context: context,
+                memberProfile: profile,
+                roomId: roomId,
+                member: member!,
+                memberId: userId,
+              );
+            },
             mode: DisplayMode.DM,
             avatarInfo: AvatarInfo(
               uniqueId: userId,

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -33,11 +33,13 @@ class CreateChatPage extends ConsumerStatefulWidget {
   static const chatTitleKey = Key('create-chat-title');
   static const submiteKey = Key('create-chat-submit');
   final String? initialSelectedSpaceId;
+  final String? initialSelectedUserId;
   final int? initialPage;
 
   const CreateChatPage({
     super.key,
     this.initialSelectedSpaceId,
+    this.initialSelectedUserId,
     this.initialPage,
   });
 
@@ -59,6 +61,7 @@ class _CreateChatWidgetState extends ConsumerState<CreateChatPage> {
     pages = [
       _CreateChatWidget(
         controller: controller,
+        initialSelectedUserId: widget.initialSelectedUserId,
         onCreateConvo: _handleCreateConvo,
       ),
       _CreateRoomFormWidget(

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/dialogs/deactivation_confirmation.dart';
 import 'package:acter/common/dialogs/logout_confirmation.dart';
 import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/toolkit/menu_item_widget.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/settings/super_invites/providers/super_invites_providers.dart';
 import 'package:acter/router/providers/router_providers.dart';
@@ -44,8 +45,7 @@ class SettingsMenu extends ConsumerWidget {
           context: context,
           sectionTitle: 'Account',
           children: [
-            _settingMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.key_monitor_thin,
               iconColor: colorSelected(Routes.settingSessions),
               title: 'Sessions',
@@ -55,8 +55,7 @@ class SettingsMenu extends ConsumerWidget {
                   ? context.goNamed(Routes.settingSessions.name)
                   : context.pushNamed(Routes.settingSessions.name),
             ),
-            _settingMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.bell_mobile_thin,
               iconColor: colorSelected(Routes.settingNotifications),
               title: 'Notifications',
@@ -66,8 +65,7 @@ class SettingsMenu extends ConsumerWidget {
                   ? context.goNamed(Routes.settingNotifications.name)
                   : context.pushNamed(Routes.settingNotifications.name),
             ),
-            _settingMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.envelope_paper_email_thin,
               iconColor: colorSelected(Routes.emailAddresses),
               title: 'Email Addresses',
@@ -77,8 +75,7 @@ class SettingsMenu extends ConsumerWidget {
                   ? context.goNamed(Routes.emailAddresses.name)
                   : context.pushNamed(Routes.emailAddresses.name),
             ),
-            _settingMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.users_thin,
               iconColor: colorSelected(Routes.blockedUsers),
               title: 'Blocked Users',
@@ -94,11 +91,10 @@ class SettingsMenu extends ConsumerWidget {
           context: context,
           sectionTitle: 'Community',
           children: [
-            _settingMenuItem(
+            MenuItemWidget(
               key: SettingsMenu.superInvitations,
-              context: context,
               iconData: Atlas.plus_envelope_thin,
-              enable: isSuperInviteEnable,
+              enabled: isSuperInviteEnable,
               iconColor: colorSelected(Routes.settingsSuperInvites),
               title: 'Super Invitations',
               subTitle: 'Manage your invitation codes',
@@ -115,9 +111,8 @@ class SettingsMenu extends ConsumerWidget {
           context: context,
           sectionTitle: 'Acter App',
           children: [
-            _settingMenuItem(
+            MenuItemWidget(
               key: SettingsMenu.labs,
-              context: context,
               iconData: Atlas.lab_appliance_thin,
               iconColor: colorSelected(Routes.settingsLabs),
               title: 'Labs',
@@ -127,8 +122,7 @@ class SettingsMenu extends ConsumerWidget {
                   ? context.goNamed(Routes.settingsLabs.name)
                   : context.pushNamed(Routes.settingsLabs.name),
             ),
-            _settingMenuItem(
-              context: context,
+            MenuItemWidget(
               iconData: Atlas.info_circle_thin,
               iconColor: colorSelected(Routes.info),
               title: 'Info',
@@ -144,9 +138,8 @@ class SettingsMenu extends ConsumerWidget {
           sectionTitle: 'Danger Zone',
           isDanderZone: true,
           children: [
-            _settingMenuItem(
+            MenuItemWidget(
               key: SettingsMenu.logoutAccount,
-              context: context,
               iconData: Atlas.exit_thin,
               iconColor: Theme.of(context).colorScheme.error,
               title: 'Logout',
@@ -156,9 +149,8 @@ class SettingsMenu extends ConsumerWidget {
               ),
               onTap: () => logoutConfirmationDialog(context, ref),
             ),
-            _settingMenuItem(
+            MenuItemWidget(
               key: SettingsMenu.deactivateAccount,
-              context: context,
               iconData: Atlas.trash_can_thin,
               iconColor: Theme.of(context).colorScheme.error,
               title: 'Deactivate Account',
@@ -203,46 +195,6 @@ class SettingsMenu extends ConsumerWidget {
             children: children,
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _settingMenuItem({
-    Key? key,
-    required BuildContext context,
-    required IconData iconData,
-    Color? iconColor,
-    required String title,
-    TextStyle? titleStyles,
-    String? subTitle,
-    VoidCallback? onTap,
-    bool enable = true,
-  }) {
-    return Card(
-      child: ListTile(
-        key: key,
-        onTap: onTap,
-        leading: Icon(
-          iconData,
-          color: enable ? iconColor : Theme.of(context).disabledColor,
-        ),
-        title: Text(
-          title,
-          style: titleStyles?.copyWith(
-            color: enable ? null : Theme.of(context).disabledColor,
-          ),
-        ),
-        subtitle: subTitle == null
-            ? null
-            : Text(
-                subTitle,
-                style: titleStyles?.copyWith(
-                  color: enable ? null : Theme.of(context).disabledColor,
-                ),
-              ),
-        trailing: const Icon(
-          Icons.keyboard_arrow_right_outlined,
-        ),
       ),
     );
   }

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -349,6 +349,7 @@ List<RouteBase> makeGeneralRoutes() {
                 barrierDismissible: false,
                 builder: (context) => CreateChatPage(
                   initialSelectedSpaceId: state.uri.queryParameters['spaceId'],
+                  initialSelectedUserId: state.uri.queryParameters['userId'],
                   initialPage: state.extra as int?,
                 ),
               )
@@ -368,6 +369,7 @@ List<RouteBase> makeGeneralRoutes() {
                 },
                 child: CreateChatPage(
                   initialSelectedSpaceId: state.uri.queryParameters['spaceId'],
+                  initialSelectedUserId: state.uri.queryParameters['userId'],
                   initialPage: state.extra as int?,
                 ),
               );

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -349,7 +349,6 @@ List<RouteBase> makeGeneralRoutes() {
                 barrierDismissible: false,
                 builder: (context) => CreateChatPage(
                   initialSelectedSpaceId: state.uri.queryParameters['spaceId'],
-                  initialSelectedUserId: state.uri.queryParameters['userId'],
                   initialPage: state.extra as int?,
                 ),
               )
@@ -369,7 +368,6 @@ List<RouteBase> makeGeneralRoutes() {
                 },
                 child: CreateChatPage(
                   initialSelectedSpaceId: state.uri.queryParameters['spaceId'],
-                  initialSelectedUserId: state.uri.queryParameters['userId'],
                   initialPage: state.extra as int?,
                 ),
               );


### PR DESCRIPTION
A new bottom drawer for members, space and chat room, for quick actions and info.

- [x] Members Info Box upon click in space
- [x] Members Info Box upon click in chat
- [x] Members Info Box upon click in chat room details
- [x] Copy UserID from info box
- [x] Quick access existing DM from info box
- [x] Start new DM from info Box
- [x] Block from InfoBox
- [x] Box for Self
- [x] clean up
- [x] changelog
- [x] fixes #1507 

See it in action:

https://github.com/acterglobal/a3/assets/40496/485b8f7f-07bd-4cb4-ae40-76539a18d956

https://github.com/acterglobal/a3/assets/40496/721e61c7-01b9-43cd-8222-923777143432

https://github.com/acterglobal/a3/assets/40496/f12d6771-114b-44c6-b584-874f0ffda482


On self:
![grafik](https://github.com/acterglobal/a3/assets/40496/b024c631-575c-467a-a83f-12794d83a804)

