### PR TITLE
Ensure events come in soonest-first order from the rust api

### DIFF
--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -11,6 +11,7 @@ use anyhow::{bail, Context, Result};
 use chrono::DateTime;
 use futures::stream::StreamExt;
 use matrix_sdk::{room::Room, RoomState};
+use ruma::serde::PartialEqAsRefStr;
 use ruma_common::{OwnedEventId, OwnedRoomId, OwnedUserId};
 use ruma_events::room::message::TextMessageEventContent;
 use std::{
@@ -129,6 +130,26 @@ pub struct CalendarEvent {
     client: Client,
     room: Room,
     inner: models::CalendarEvent,
+}
+
+impl PartialEq for CalendarEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.event_id() == other.inner.event_id()
+    }
+}
+
+impl Eq for CalendarEvent {}
+
+impl PartialOrd for CalendarEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.inner.utc_start.partial_cmp(&other.inner.utc_start)
+    }
+}
+
+impl Ord for CalendarEvent {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner.utc_start.cmp(&other.inner.utc_start)
+    }
 }
 
 impl Deref for CalendarEvent {

--- a/native/acter/src/api/rsvp.rs
+++ b/native/acter/src/api/rsvp.rs
@@ -71,6 +71,7 @@ impl Client {
                         );
                     }
                 }
+                cal_events.sort();
                 Ok(cal_events)
             })
             .await?


### PR DESCRIPTION
refs #1128 .

See how a newly created item isn't added to the end anymore but sorted in to the list depending on start time:

https://github.com/acterglobal/a3/assets/40496/cedba1d3-bca9-4378-b137-d5034639bd65

