### PR TITLE
Do not set the language as a local config unless the user explicitly did so

### DIFF
--- a/app/lib/common/utils/language.dart
+++ b/app/lib/common/utils/language.dart
@@ -11,13 +11,12 @@ Future<void> initLanguage(WidgetRef ref) async {
   final deviceLanguageCode = PlatformDispatcher.instance.locale.languageCode;
   final bool isLanguageContain = LanguageModel.allLanguagesList
       .contains(LanguageModel.fromCode(deviceLanguageCode));
-  if (prefLanguageCode == null && isLanguageContain) {
-    await setLanguage(deviceLanguageCode);
-    ref.read(languageProvider.notifier).update((state) => deviceLanguageCode);
-  } else if (prefLanguageCode != null) {
+  if (prefLanguageCode != null) {
     ref.read(languageProvider.notifier).update(
           (state) => prefLanguageCode,
         );
+  } else if (isLanguageContain) {
+    ref.read(languageProvider.notifier).update((state) => deviceLanguageCode);
   }
 }
 


### PR DESCRIPTION

In the previous code, upon first start up we'd implicitly write the language according to the system settings to a local configuration. If the user now changed their system language, we'd still force the app to start in the previous system language, despite the user never having set that language as their preference. With this change we will not implictly _write_ a local configuration but adhere to the system language until the user explicit set a language themselves.

This was not [sufficiently addressed in the review before being merged](https://github.com/acterglobal/a3/pull/1516#discussion_r1526135834)