### PR TITLE
minor attachment fixes

### DIFF
--- a/app/lib/common/widgets/attachments/post_attachment_selection.dart
+++ b/app/lib/common/widgets/attachments/post_attachment_selection.dart
@@ -42,7 +42,7 @@ class _PostAttachmentSelectionState
         Padding(
           padding: const EdgeInsets.all(12),
           child: Text(
-            'Attachments Selected ($attachments.length})',
+            'Attachments Selected (${attachments.length})',
             style: titleTextStyle,
           ),
         ),
@@ -140,6 +140,7 @@ class _PostAttachmentSelectionState
         final res = await draft.send();
         _log.info('attachment sent: $res');
       }
+      EasyLoading.dismiss();
     } catch (e) {
       EasyLoading.showError('Error sending attachments $e');
       _log.severe('Error sending attachments', e);


### PR DESCRIPTION
### Include fixes for:

1. Selected Attachment showing full path instead of count.
2. Dismiss loading after attachment is sent.

UI bug:
<img width="403" alt="Screenshot 2024-03-15 at 6 58 22 PM" src="https://github.com/acterglobal/a3/assets/68579938/4ab81226-adce-41e9-8d70-3842db07dba0">
