### PR TITLE
Switch to macos-14 for iOS 17.0 SDK build support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
             artifact_path: app/build/linux/x64/release/bundle/
             tar_files: lib/ data/ acter
           - name: iOS
-            os: macos-latest
+            os: macos-14
             target: ios
             with_apple_cert: true
             cargo_make_setup: setup-ios

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,7 @@ jobs:
             artifact_path: app/build/linux/x64/release/bundle/
             tar_files: lib/ data/ acter
           - name: iOS
-            os: macos-latest
+            os: macos-14
             target: ios
             with_apple_cert: true
             cargo_make_setup: setup-ios


### PR DESCRIPTION
this hopefully gets rid of that pesky email reminding me every time I do a iOS release.