### PR TITLE
more verbose error reporting for fatal error

### DIFF
--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -32,10 +32,13 @@ Future<String?> authGuardRedirect(
       return null;
     }
   } catch (error, trace) {
-    // ignore: deprecated_member_use
+    // ignore: deprecated_member_use, avoid_print
+    print('Fatal error: $error');
+    // ignore: avoid_print
+    print('Stack: $trace');
     return state.namedLocation(
       Routes.fatalFail.name,
-      queryParameters: {'error': error.toString(), 'trace': trace.toString()},
+      queryParameters: {'error': error.toString()},
     );
   }
 
@@ -67,8 +70,13 @@ Future<String?> forwardRedirect(
       client = await acterSdk.getClientWithDeviceId(deviceId!, true);
       // ignore: use_build_context_synchronously
       final ref = ProviderScope.containerOf(context);
-      ref.invalidate(clientProvider); // ensure we have selected the right client
-    } catch(error) {
+      // ensure we have selected the right client
+      ref.invalidate(clientProvider);
+    } catch (error, trace) {
+      // ignore: deprecated_member_use, avoid_print
+      print('Client not found error: $error');
+      // ignore: avoid_print
+      print('Stack: $trace');
       return null;
     }
     final roomId = state.uri.queryParameters['roomId'];
@@ -81,11 +89,16 @@ Future<String?> forwardRedirect(
     } else {
       // final eventId = state.uri.queryParameters['eventId'];
       // with the event ID or further information we could figure out the specific action
-      return state
-          .namedLocation(Routes.space.name, pathParameters: {'spaceId': roomId});
+      return state.namedLocation(
+        Routes.space.name,
+        pathParameters: {'spaceId': roomId},
+      );
     }
   } catch (error, trace) {
-    // ignore: deprecated_member_use
+    // ignore: deprecated_member_use, avoid_print
+    print('Fatal error: $error');
+    // ignore: avoid_print
+    print('Stack: $trace');
     return state.namedLocation(
       Routes.fatalFail.name,
       queryParameters: {'error': error.toString(), 'trace': trace.toString()},

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -38,7 +38,7 @@ Future<String?> authGuardRedirect(
     print('Stack: $trace');
     return state.namedLocation(
       Routes.fatalFail.name,
-      queryParameters: {'error': error.toString()},
+      queryParameters: {'error': error.toString(), 'trace': trace.toString()},
     );
   }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1972,7 +1972,7 @@ packages:
     source: hosted
     version: "2.5.0+2"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -124,6 +124,7 @@ dependencies:
   video_player: ^2.8.1
   share_plus: ^7.2.1
   carousel_indicator: ^1.0.6
+  stack_trace: ^1.11.1
 
 # FIXME keep until a new version has been published
 dependency_overrides:


### PR DESCRIPTION
In two parts:
1. prints for the router to show the local error and stack trace cought
2. improved information display, including the stack trace (and allowing to copy it) from the fatal error page:


https://github.com/acterglobal/a3/assets/40496/ef7c6d82-7e8f-41cc-b262-80750f98f5cd


refs #1422 .