### PR TITLE
Remove media cache path from permanent RestoreToken

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -858,16 +858,21 @@ class Api {
   /// Create a new client from the restore token
   Future<Client> loginWithToken(
     String basePath,
+    String mediaCacheBasePath,
     String restoreToken,
   ) {
     final tmp0 = basePath;
-    final tmp4 = restoreToken;
+    final tmp4 = mediaCacheBasePath;
+    final tmp8 = restoreToken;
     var tmp1 = 0;
     var tmp2 = 0;
     var tmp3 = 0;
     var tmp5 = 0;
     var tmp6 = 0;
     var tmp7 = 0;
+    var tmp9 = 0;
+    var tmp10 = 0;
+    var tmp11 = 0;
     final tmp0_0 = utf8.encode(tmp0);
     tmp2 = tmp0_0.length;
 
@@ -884,20 +889,31 @@ class Api {
     tmp5_1.setAll(0, tmp4_0);
     tmp5 = tmp5_0.address;
     tmp7 = tmp6;
-    final tmp8 = _loginWithToken(
+    final tmp8_0 = utf8.encode(tmp8);
+    tmp10 = tmp8_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp9_0 = this.__allocate(tmp10 * 1, 1);
+    final Uint8List tmp9_1 = tmp9_0.asTypedList(tmp10);
+    tmp9_1.setAll(0, tmp8_0);
+    tmp9 = tmp9_0.address;
+    tmp11 = tmp10;
+    final tmp12 = _loginWithToken(
       tmp1,
       tmp2,
       tmp3,
       tmp5,
       tmp6,
       tmp7,
+      tmp9,
+      tmp10,
+      tmp11,
     );
-    final tmp10 = tmp8;
-    final ffi.Pointer<ffi.Void> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-    final tmp10_1 = _Box(this, tmp10_0, "__login_with_token_future_drop");
-    tmp10_1._finalizer = this._registerFinalizer(tmp10_1);
-    final tmp9 = _nativeFuture(tmp10_1, this.__loginWithTokenFuturePoll);
-    return tmp9;
+    final tmp14 = tmp12;
+    final ffi.Pointer<ffi.Void> tmp14_0 = ffi.Pointer.fromAddress(tmp14);
+    final tmp14_1 = _Box(this, tmp14_0, "__login_with_token_future_drop");
+    tmp14_1._finalizer = this._registerFinalizer(tmp14_1);
+    final tmp13 = _nativeFuture(tmp14_1, this.__loginWithTokenFuturePoll);
+    return tmp13;
   }
 
   /// Create an anonymous client connecting to the homeserver
@@ -13982,10 +13998,16 @@ class Api {
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
           )>>("__login_with_token");
 
   late final _loginWithToken = _loginWithTokenPtr.asFunction<
       int Function(
+        int,
+        int,
+        int,
         int,
         int,
         int,

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -24,7 +24,7 @@ fn write_log(text: string, level: string) -> Result<()>;
 fn login_new_client(base_path: string, media_cache_base_path: string, username: string, password: string, default_homeserver_name: string, default_homeserver_url: string, device_name: Option<string>) -> Future<Result<Client>>;
 
 /// Create a new client from the restore token
-fn login_with_token(base_path: string, restore_token: string) -> Future<Result<Client>>;
+fn login_with_token(base_path: string, media_cache_base_path: string, restore_token: string) -> Future<Result<Client>>;
 
 /// Create an anonymous client connecting to the homeserver
 fn guest_client(base_path: string, media_cache_base_path: string, default_homeserver_name: string, default_homeserver_url: string, device_name: Option<string>) -> Future<Result<Client>>;

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -63,7 +63,7 @@ pub async fn destroy_local_data(
 pub async fn make_client_config(
     base_path: String,
     username: &str,
-    media_cache_base_path: Option<String>,
+    media_cache_base_path: String,
     db_passphrase: Option<String>,
     default_homeserver_name: &str,
     default_homeserver_url: &str,
@@ -102,7 +102,7 @@ pub async fn guest_client(
     let config = platform::new_client_config(
         base_path.clone(),
         default_homeserver_name,
-        Some(media_cache_base_path.clone()),
+        media_cache_base_path,
         Some(db_passphrase.clone()),
         true,
     )
@@ -134,7 +134,6 @@ pub async fn guest_client(
             let state = ClientStateBuilder::default()
                 .is_guest(true)
                 .db_passphrase(Some(db_passphrase))
-                .media_cache_base_path(Some(media_cache_base_path))
                 .build()?;
             let c = Client::new(client, state).await?;
             info!("Successfully created guest login: {:?}", response.user_id);
@@ -152,7 +151,7 @@ pub async fn login_with_token_under_config(
         homeurl,
         is_guest,
         db_passphrase,
-        media_cache_base_path,
+        ..
     } = restore_token;
     let user_id = session.user_id.to_string();
     RUNTIME
@@ -172,7 +171,6 @@ pub async fn login_with_token_under_config(
             let state = ClientStateBuilder::default()
                 .is_guest(is_guest)
                 .db_passphrase(db_passphrase)
-                .media_cache_base_path(media_cache_base_path)
                 .build()?;
             let c = Client::new(client.clone(), state).await?;
             info!(
@@ -184,12 +182,16 @@ pub async fn login_with_token_under_config(
         .await?
 }
 
-pub async fn login_with_token(base_path: String, restore_token: String) -> Result<Client> {
+pub async fn login_with_token(
+    base_path: String,
+    media_cache_base_path: String,
+    restore_token: String,
+) -> Result<Client> {
     let token: RestoreToken = serde_json::from_str(&restore_token)?;
     let (config, user_id) = make_client_config(
         base_path,
         token.session.user_id.as_str(),
-        token.media_cache_base_path.clone(),
+        media_cache_base_path,
         token.db_passphrase.clone(),
         "",
         "",
@@ -203,7 +205,6 @@ async fn login_client(
     client: SdkClient,
     user_id: OwnedUserId,
     password: String,
-    media_cache_base_path: Option<String>,
     db_passphrase: Option<String>,
     device_name: Option<String>,
 ) -> Result<Client> {
@@ -217,7 +218,6 @@ async fn login_client(
     let state = ClientStateBuilder::default()
         .is_guest(false)
         .db_passphrase(db_passphrase)
-        .media_cache_base_path(media_cache_base_path)
         .build()?;
     info!(
         "Successfully logged in user {user_id}, device {:?}",
@@ -230,7 +230,6 @@ pub async fn login_new_client_under_config(
     config: ClientBuilder,
     user_id: OwnedUserId,
     password: String,
-    media_cache_base_path: Option<String>,
     db_passphrase: Option<String>,
     device_name: Option<String>,
 ) -> Result<Client> {
@@ -240,7 +239,6 @@ pub async fn login_new_client_under_config(
                 config.build().await?,
                 user_id,
                 password,
-                media_cache_base_path,
                 db_passphrase,
                 device_name,
             )
@@ -262,22 +260,14 @@ pub async fn login_new_client(
     let (config, user_id) = make_client_config(
         base_path,
         &username,
-        Some(media_cache_base_path.clone()),
+        media_cache_base_path,
         Some(db_passphrase.clone()),
         &default_homeserver_name,
         &default_homeserver_url,
         true,
     )
     .await?;
-    login_new_client_under_config(
-        config,
-        user_id,
-        password,
-        Some(media_cache_base_path),
-        Some(db_passphrase),
-        device_name,
-    )
-    .await
+    login_new_client_under_config(config, user_id, password, Some(db_passphrase), device_name).await
 }
 #[allow(clippy::too_many_arguments)]
 pub async fn register(
@@ -294,29 +284,20 @@ pub async fn register(
     let (config, user_id) = make_client_config(
         base_path,
         &username,
-        Some(media_cache_base_path.clone()),
+        media_cache_base_path,
         Some(db_passphrase.clone()),
         &default_homeserver_name,
         &default_homeserver_url,
         true,
     )
     .await?;
-    register_under_config(
-        config,
-        user_id,
-        password,
-        Some(media_cache_base_path),
-        Some(db_passphrase),
-        user_agent,
-    )
-    .await
+    register_under_config(config, user_id, password, Some(db_passphrase), user_agent).await
 }
 
 pub async fn register_under_config(
     config: ClientBuilder,
     user_id: OwnedUserId,
     password: String,
-    media_cache_base_path: Option<String>,
     db_passphrase: Option<String>,
     user_agent: String,
 ) -> Result<Client> {
@@ -351,20 +332,11 @@ pub async fn register_under_config(
                 let state = ClientStateBuilder::default()
                     .is_guest(false)
                     .db_passphrase(db_passphrase)
-                    .media_cache_base_path(media_cache_base_path)
                     .build()?;
                 Client::new(client, state).await
             } else {
                 // we didn't receive the login details yet, do a full login attempt
-                login_client(
-                    client,
-                    user_id,
-                    password,
-                    media_cache_base_path,
-                    db_passphrase,
-                    Some(user_agent),
-                )
-                .await
+                login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
             }
         })
         .await?
@@ -385,7 +357,7 @@ pub async fn register_with_token(
     let (config, user_id) = make_client_config(
         base_path,
         &username,
-        Some(media_cache_base_path.clone()),
+        media_cache_base_path.clone(),
         Some(db_passphrase.clone()),
         &default_homeserver_name,
         &default_homeserver_url,
@@ -397,7 +369,6 @@ pub async fn register_with_token(
         user_id,
         password,
         Some(db_passphrase),
-        Some(media_cache_base_path),
         user_agent,
         registration_token,
     )
@@ -409,7 +380,6 @@ pub async fn register_with_token_under_config(
     user_id: OwnedUserId,
     password: String,
     db_passphrase: Option<String>,
-    media_cache_base_path: Option<String>,
     user_agent: String,
     registration_token: String,
 ) -> Result<Client> {
@@ -450,20 +420,11 @@ pub async fn register_with_token_under_config(
                 let state = ClientStateBuilder::default()
                     .is_guest(false)
                     .db_passphrase(db_passphrase)
-                    .media_cache_base_path(media_cache_base_path)
                     .build()?;
                 Client::new(client, state).await
             } else {
                 // we didn't receive the login details yet, do a full login attempt
-                login_client(
-                    client,
-                    user_id,
-                    password,
-                    media_cache_base_path,
-                    db_passphrase,
-                    Some(user_agent),
-                )
-                .await
+                login_client(client, user_id, password, db_passphrase, Some(user_agent)).await
             }
         })
         .await?

--- a/native/acter/src/platform/android.rs
+++ b/native/acter/src/platform/android.rs
@@ -16,7 +16,7 @@ pub async fn destroy_local_data(
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,
-    media_cache_base_path: Option<String>,
+    media_cache_base_path: String,
     db_passphrase: Option<String>,
     reset_if_existing: bool,
 ) -> Result<ClientBuilder> {

--- a/native/acter/src/platform/desktop.rs
+++ b/native/acter/src/platform/desktop.rs
@@ -14,7 +14,7 @@ pub async fn destroy_local_data(
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,
-    media_cache_base_path: Option<String>,
+    media_cache_base_path: String,
     db_passphrase: Option<String>,
     reset_if_existing: bool,
 ) -> Result<ClientBuilder> {

--- a/native/acter/src/platform/ios.rs
+++ b/native/acter/src/platform/ios.rs
@@ -15,7 +15,7 @@ pub async fn destroy_local_data(
 pub async fn new_client_config(
     base_path: String,
     home_dir: String,
-    media_cache_base_path: Option<String>,
+    media_cache_base_path: String,
     db_passphrase: Option<String>,
     reset_if_existing: bool,
 ) -> Result<ClientBuilder> {

--- a/native/acter/src/testing.rs
+++ b/native/acter/src/testing.rs
@@ -109,7 +109,6 @@ pub async fn ensure_user(
             user_id,
             password.clone(),
             None,
-            None,
             user_agent.clone(),
             token,
         )
@@ -120,7 +119,6 @@ pub async fn ensure_user(
             config.clone(),
             user_id,
             password.clone(),
-            None,
             None,
             user_agent.clone(),
         )

--- a/native/cli/src/config.rs
+++ b/native/cli/src/config.rs
@@ -88,7 +88,7 @@ impl LoginConfig {
                 token_path_string.display()
             );
             let token = std::fs::read_to_string(access_token_path)?;
-            return login_with_token(base_path, token).await;
+            return login_with_token(base_path, cache_base_path, token).await;
         }
 
         let password = match self.login_password {

--- a/native/core/src/support.rs
+++ b/native/core/src/support.rs
@@ -13,8 +13,29 @@ pub struct RestoreToken {
     pub session: CustomAuthSession,
     /// a passphrase for the underlying database
     pub db_passphrase: Option<String>,
+
+    // legacy that isn't used anymore
+    #[serde(default, skip_serializing)]
+    #[allow(dead_code)]
     /// a separate local cache path
-    pub media_cache_base_path: Option<String>,
+    media_cache_base_path: Option<String>,
+}
+
+impl RestoreToken {
+    pub fn serialized(
+        session: CustomAuthSession,
+        homeurl: Url,
+        is_guest: bool,
+        db_passphrase: Option<String>,
+    ) -> serde_json::Result<String> {
+        serde_json::to_string(&RestoreToken {
+            session,
+            homeurl,
+            is_guest,
+            db_passphrase,
+            media_cache_base_path: None,
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/native/test/src/tests/auth.rs
+++ b/native/test/src/tests/auth.rs
@@ -93,12 +93,13 @@ async fn kyra_can_restore() -> Result<()> {
     let homeserver_url = option_env!("DEFAULT_HOMESERVER_URL")
         .unwrap_or("http://localhost:8118")
         .to_string();
-    let tmp_dir = TempDir::new()?;
-    let base_path = tmp_dir.path().to_string_lossy().to_string();
+    let base_data = TempDir::new()?;
+    let base_path = base_data.path().to_string_lossy().to_string();
+    let media_data = TempDir::new()?;
     let (config, user_id) = make_client_config(
         base_path,
         "@kyra",
-        None,
+        media_data.path().to_string_lossy().to_string(),
         None,
         &homeserver_name,
         &homeserver_url,
@@ -111,7 +112,6 @@ async fn kyra_can_restore() -> Result<()> {
             config.clone(),
             user_id,
             default_user_password("kyra"),
-            None,
             None,
             Some("KYRA_DEV".to_string()),
         )
@@ -142,11 +142,12 @@ async fn kyra_can_restore_with_db_passphrase() -> Result<()> {
         .to_string();
     let tmp_dir = TempDir::new()?;
     let base_path = tmp_dir.path().to_string_lossy().to_string();
+    let media_data_dir = TempDir::new()?;
     let db_passphrase = Uuid::new_v4().to_string();
     let (config, user_id) = make_client_config(
         base_path,
         "@kyra",
-        None,
+        media_data_dir.path().to_string_lossy().to_string(),
         Some(db_passphrase.clone()),
         &homeserver_name,
         &homeserver_url,
@@ -159,7 +160,6 @@ async fn kyra_can_restore_with_db_passphrase() -> Result<()> {
             config.clone(),
             user_id,
             default_user_password("kyra"),
-            None,
             Some(db_passphrase),
             Some("KYRA_DEV".to_string()),
         )


### PR DESCRIPTION
This fixes #1422: "Fatal error: operation not permitted (os error 1)]()"

## Evidence:

Some further debugging on an effected instances showed that despite it working fine before, when trying to "recreate" the media cache dir from the restore token, we've gotten a the "Operation not permitted" Error thrown at us. A further attempt to just `ls` the folder that was stored in the restore token, told us that wasn't available ... and it contained what we identified as a "Container"-ID. 


## Explanation:

We have had seen a similar problem before with the `base_path`, where in some "sandboxed" environments (most notably iOS) the `getApplicationPath` would give us a different path upon every run of the App. The background is that while the files and folders are untouched, the app runs in a "container" and has read-write-access to that container only. Upon startup a fresh container is created and all previousl local data is hooked into that container, returning those changing path (as each container run gives it a new UUID and mount point on the file system).

For that reason we had to move out the `base_path` from the restore token and instead reconstruct the _actual path_ to data ourselves once we knew the new container UUID we were running on. Up until recently the `cache`-folder wasn't effected by this and we had stored it in the restore token and read from it without problems. But it appears that this has changed now and app-cache is also moved into the containerized environment-system now.

That explains why when trying to recreate the folder, we didn't have the permission by the system and why it only happened upon restarts. 

## The fix:
This PR fixes that issue by removing the `media_cache_dir`-field from the `RestoreToken` and instead goes the same way as with the `base_path` of reconstructing the same every time upon startup.

The only reason it was stored in the first place was to allow for older logins, that still used the existing db-base-cached to remain using that cache. This was a nice feature for the users, but is ultimately not necessary as a) we don't want this to be the case for long anyway and b) it would only fetch the data to be cached once and while it would store it twice now (once in the cache, once in the db) only a super small minority of users is ever going to be effected - a fresh relogin resolves that issue entirely.

## The proof

On a system that consistently showed this problem, this fix allowed @kumarpalsinh25 to use the app as always without running into the error again.
