### PR TITLE
Follow up of #1537: Android SDK needs to be 34+ now

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion "25.2.9519653"
 
     sourceSets {
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         applicationId "global.acter.a3"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
Trying to build Android might fail since #1537 since that emoji dependency wants a higher SDK number. This updates the SDK number so all should be fine again.