### PR TITLE
Refactor chat routing to avoid riverpod states

### DIFF
--- a/app/lib/features/chat/config.dart
+++ b/app/lib/features/chat/config.dart
@@ -1,0 +1,1 @@
+const sidebarMinWidth = 750;

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -31,16 +31,18 @@ import 'package:skeletonizer/skeletonizer.dart';
 class RoomPage extends ConsumerWidget {
   static const roomPageKey = Key('chat-room-page');
   final String roomId;
+  final bool inSidebar;
 
   const RoomPage({
     required this.roomId,
+    required this.inSidebar,
     super.key = roomPageKey,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ref.watch(chatProvider(roomId)).when(
-          data: (convo) => ChatRoom(convo: convo),
+          data: (convo) => ChatRoom(convo: convo, inSidebar: inSidebar),
           error: (e, s) => Center(
             child: Text(L10n.of(context).loadingRoomFailed(e)),
           ),
@@ -51,9 +53,11 @@ class RoomPage extends ConsumerWidget {
 
 class ChatRoom extends ConsumerStatefulWidget {
   final Convo convo;
+  final bool inSidebar;
 
   const ChatRoom({
     required this.convo,
+    required this.inSidebar,
     super.key,
   });
 
@@ -93,12 +97,21 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
 
   @override
   Widget build(BuildContext context) {
+    return OrientationBuilder(
+      builder: (context, orientation) => Scaffold(
+        resizeToAvoidBottomInset: orientation == Orientation.portrait,
+        body: CustomScrollView(
+          physics: const NeverScrollableScrollPhysics(),
+          slivers: [appBar(context), chatBody(context)],
+        ),
+      ),
+    );
+  }
+
+  SliverFillRemaining chatBody(BuildContext context) {
+    final chatState = ref.watch(chatStateProvider(widget.convo));
     final userId = ref.watch(myUserIdStrProvider);
     final roomId = widget.convo.getRoomIdStr();
-    final inSideBar = ref.watch(inSideBarProvider);
-    final convoProfile = ref.watch(chatProfileDataProvider(widget.convo));
-    final activeMembers = ref.watch(membersIdsProvider(roomId));
-    final chatState = ref.watch(chatStateProvider(widget.convo));
     final messages = chatState.messages
         .where(
           // filter only items we can show
@@ -108,227 +121,200 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
         .reversed
         .toList();
 
-    return OrientationBuilder(
-      builder: (context, orientation) => Scaffold(
-        resizeToAvoidBottomInset: orientation == Orientation.portrait,
-        body: CustomScrollView(
-          physics: const NeverScrollableScrollPhysics(),
-          slivers: [
-            SliverAppBar(
-              elevation: 0,
-              automaticallyImplyLeading: false,
-              centerTitle: true,
-              toolbarHeight: 70,
-              leading: !inSideBar
-                  ? IconButton(
-                      onPressed: () => context.canPop()
-                          ? context.pop()
-                          : context.goNamed(Routes.chat.name),
-                      icon: const Icon(Icons.chevron_left_outlined, size: 28),
-                    )
-                  : null,
-              flexibleSpace: FrostEffect(
-                child: Container(),
-              ),
-              title: GestureDetector(
-                onTap: () {
-                  inSideBar
-                      ? ref
-                          .read(hasExpandedPanel.notifier)
-                          .update((state) => true)
-                      : context.pushNamed(
-                          Routes.chatProfile.name,
-                          pathParameters: {'roomId': roomId},
-                        );
-                },
-                child: Column(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    convoProfile.when(
-                      data: (profile) => Text(
-                        profile.displayName ?? roomId,
-                        overflow: TextOverflow.clip,
-                        style: Theme.of(context).textTheme.bodyLarge,
-                      ),
-                      skipLoadingOnReload: true,
-                      error: (error, stackTrace) => Text(
-                        L10n.of(context).errorLoadingProfile(error),
-                      ),
-                      loading: () => Skeletonizer(
-                        child: Text(L10n.of(context).loading),
-                      ),
-                    ),
-                    const SizedBox(height: 5),
-                    activeMembers.when(
-                      data: (members) {
-                        int count = members.length;
-                        return Text(
-                          L10n.of(context).membersCount(count),
-                          style: Theme.of(context).textTheme.bodySmall,
-                        );
-                      },
-                      skipLoadingOnReload: false,
-                      error: (error, stackTrace) => Text(
-                        L10n.of(context).errorLoadingMembersCount(error),
-                      ),
-                      loading: () => Skeletonizer(
-                        child: Text(
-                          L10n.of(context).membersCount(100),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              actions: [
-                GestureDetector(
-                  onTap: () {
-                    inSideBar
-                        ? ref
-                            .read(hasExpandedPanel.notifier)
-                            .update((state) => true)
-                        : context.pushNamed(
-                            Routes.chatProfile.name,
-                            pathParameters: {'roomId': roomId},
-                          );
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 10),
-                    child: RoomAvatar(
-                      roomId: roomId,
-                      showParent: true,
-                    ),
-                  ),
-                ),
-              ],
+    return SliverFillRemaining(
+      child: Container(
+        decoration: const BoxDecoration(
+          gradient: primaryGradient,
+        ),
+        child: Chat(
+          keyboardDismissBehavior: Platform.isIOS
+              ? ScrollViewKeyboardDismissBehavior.onDrag
+              : ScrollViewKeyboardDismissBehavior.manual,
+          customBottomWidget:
+              CustomChatInput(key: Key(roomId), convo: widget.convo),
+          textMessageBuilder: (
+            types.TextMessage m, {
+            required int messageWidth,
+            required bool showName,
+          }) =>
+              TextMessageBuilder(
+            convo: widget.convo,
+            message: m,
+            messageWidth: messageWidth,
+          ),
+          l10n: ChatL10nEn(
+            emptyChatPlaceholder: '',
+            attachmentButtonAccessibilityLabel: '',
+            fileButtonAccessibilityLabel: '',
+            inputPlaceholder: L10n.of(context).message,
+            sendButtonAccessibilityLabel: '',
+          ),
+          timeFormat: DateFormat.jm(),
+          messages: messages,
+          onSendPressed: (types.PartialText partialText) {},
+          user: types.User(id: userId),
+          // disable image preview
+          disableImageGallery: true,
+          // custom avatar builder
+          avatarBuilder: (types.User user) =>
+              AvatarBuilder(userId: user.id, roomId: roomId),
+          isLastPage: !chatState.hasMore,
+          bubbleBuilder: (
+            Widget child, {
+            required types.Message message,
+            required bool nextMessageInGroup,
+          }) =>
+              GestureDetector(
+            onSecondaryTap: () {
+              showMessageOptions(context, message, roomId);
+            },
+            child: BubbleBuilder(
+              convo: widget.convo,
+              message: message,
+              nextMessageInGroup: nextMessageInGroup,
+              enlargeEmoji: message.metadata!['enlargeEmoji'] ?? false,
+              child: child,
             ),
-            SliverFillRemaining(
-              child: Container(
-                decoration: const BoxDecoration(
-                  gradient: primaryGradient,
-                ),
-                child: Chat(
-                  keyboardDismissBehavior: Platform.isIOS
-                      ? ScrollViewKeyboardDismissBehavior.onDrag
-                      : ScrollViewKeyboardDismissBehavior.manual,
-                  customBottomWidget:
-                      CustomChatInput(key: Key(roomId), convo: widget.convo),
-                  textMessageBuilder: (
-                    types.TextMessage m, {
-                    required int messageWidth,
-                    required bool showName,
-                  }) =>
-                      TextMessageBuilder(
-                    convo: widget.convo,
-                    message: m,
-                    messageWidth: messageWidth,
-                  ),
-                  l10n: ChatL10nEn(
-                    emptyChatPlaceholder: '',
-                    attachmentButtonAccessibilityLabel: '',
-                    fileButtonAccessibilityLabel: '',
-                    inputPlaceholder: L10n.of(context).message,
-                    sendButtonAccessibilityLabel: '',
-                  ),
-                  timeFormat: DateFormat.jm(),
-                  messages: messages,
-                  onSendPressed: (types.PartialText partialText) {},
-                  user: types.User(id: userId),
-                  // disable image preview
-                  disableImageGallery: true,
-                  // custom avatar builder
-                  avatarBuilder: (types.User user) =>
-                      AvatarBuilder(userId: user.id, roomId: roomId),
-                  isLastPage: !chatState.hasMore,
-                  bubbleBuilder: (
-                    Widget child, {
-                    required types.Message message,
-                    required bool nextMessageInGroup,
-                  }) =>
-                      GestureDetector(
-                    onSecondaryTap: () {
-                      showMessageOptions(context, message, roomId);
-                    },
-                    child: BubbleBuilder(
-                      convo: widget.convo,
-                      message: message,
-                      nextMessageInGroup: nextMessageInGroup,
-                      enlargeEmoji: message.metadata!['enlargeEmoji'] ?? false,
-                      child: child,
-                    ),
-                  ),
-                  imageMessageBuilder: (
-                    types.ImageMessage message, {
-                    required int messageWidth,
-                  }) =>
-                      ImageMessageBuilder(
-                    convo: widget.convo,
-                    message: message,
-                    messageWidth: messageWidth,
-                  ),
-                  videoMessageBuilder: (
-                    types.VideoMessage message, {
-                    required int messageWidth,
-                  }) =>
-                      VideoMessageBuilder(
-                    convo: widget.convo,
-                    message: message,
-                    messageWidth: messageWidth,
-                  ),
-                  fileMessageBuilder: (
-                    types.FileMessage message, {
-                    required messageWidth,
-                  }) {
-                    return FileMessageBuilder(
-                      convo: widget.convo,
-                      message: message,
-                      messageWidth: messageWidth,
-                    );
-                  },
-                  customMessageBuilder: (
-                    types.CustomMessage message, {
-                    required int messageWidth,
-                  }) =>
-                      CustomMessageBuilder(
-                    message: message,
-                    messageWidth: messageWidth,
-                  ),
-                  showUserAvatars: true,
-                  onMessageLongPress: (
-                    BuildContext context,
-                    types.Message message,
-                  ) async {
-                    showMessageOptions(context, message, roomId);
-                  },
-                  onEndReached: ref
-                      .read(chatStateProvider(widget.convo).notifier)
-                      .handleEndReached,
-                  onEndReachedThreshold: 0.75,
-                  onBackgroundTap: () {
-                    final emojiRowVisible = ref.read(
-                      chatInputProvider(roomId).select((ci) {
-                        return ci.emojiRowVisible;
-                      }),
-                    );
-                    final inputNotifier =
-                        ref.read(chatInputProvider(roomId).notifier);
-                    if (emojiRowVisible) {
-                      inputNotifier.setCurrentMessageId(null);
-                      inputNotifier.emojiRowVisible(false);
-                    }
-                  },
-                  //Custom Theme class, see lib/common/store/chatTheme.dart
-                  theme: const ActerChatTheme(
-                    sendButtonIcon: Icon(Atlas.paper_airplane),
-                    documentIcon: Icon(Atlas.file_thin, size: 18),
-                  ),
-                ),
+          ),
+          imageMessageBuilder: (
+            types.ImageMessage message, {
+            required int messageWidth,
+          }) =>
+              ImageMessageBuilder(
+            convo: widget.convo,
+            message: message,
+            messageWidth: messageWidth,
+          ),
+          videoMessageBuilder: (
+            types.VideoMessage message, {
+            required int messageWidth,
+          }) =>
+              VideoMessageBuilder(
+            convo: widget.convo,
+            message: message,
+            messageWidth: messageWidth,
+          ),
+          fileMessageBuilder: (
+            types.FileMessage message, {
+            required messageWidth,
+          }) {
+            return FileMessageBuilder(
+              convo: widget.convo,
+              message: message,
+              messageWidth: messageWidth,
+            );
+          },
+          customMessageBuilder: (
+            types.CustomMessage message, {
+            required int messageWidth,
+          }) =>
+              CustomMessageBuilder(
+            message: message,
+            messageWidth: messageWidth,
+          ),
+          showUserAvatars: true,
+          onMessageLongPress: (
+            BuildContext context,
+            types.Message message,
+          ) async {
+            showMessageOptions(context, message, roomId);
+          },
+          onEndReached: ref
+              .read(chatStateProvider(widget.convo).notifier)
+              .handleEndReached,
+          onEndReachedThreshold: 0.75,
+          onBackgroundTap: () {
+            final emojiRowVisible = ref.read(
+              chatInputProvider(roomId).select((ci) {
+                return ci.emojiRowVisible;
+              }),
+            );
+            final inputNotifier = ref.read(chatInputProvider(roomId).notifier);
+            if (emojiRowVisible) {
+              inputNotifier.setCurrentMessageId(null);
+              inputNotifier.emojiRowVisible(false);
+            }
+          },
+          //Custom Theme class, see lib/common/store/chatTheme.dart
+          theme: const ActerChatTheme(
+            sendButtonIcon: Icon(Atlas.paper_airplane),
+            documentIcon: Icon(Atlas.file_thin, size: 18),
+          ),
+        ),
+      ),
+    );
+  }
+
+  SliverAppBar appBar(BuildContext context) {
+    final roomId = widget.convo.getRoomIdStr();
+    final convoProfile = ref.watch(chatProfileDataProvider(widget.convo));
+    final activeMembers = ref.watch(membersIdsProvider(roomId));
+    return SliverAppBar(
+      elevation: 0,
+      automaticallyImplyLeading: widget.inSidebar ? false : true,
+      centerTitle: true,
+      toolbarHeight: 70,
+      flexibleSpace: FrostEffect(
+        child: Container(),
+      ),
+      title: GestureDetector(
+        onTap: () => context.pushNamed(
+          Routes.chatProfile.name,
+          pathParameters: {'roomId': roomId},
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            convoProfile.when(
+              data: (profile) => Text(
+                profile.displayName ?? roomId,
+                overflow: TextOverflow.clip,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              skipLoadingOnReload: true,
+              error: (error, stackTrace) => Text(
+                L10n.of(context).errorLoadingProfile(error),
+              ),
+              loading: () => Skeletonizer(
+                child: Text(L10n.of(context).loading),
+              ),
+            ),
+            const SizedBox(height: 5),
+            activeMembers.when(
+              data: (members) {
+                int count = members.length;
+                return Text(
+                  L10n.of(context).membersCount(count),
+                  style: Theme.of(context).textTheme.bodySmall,
+                );
+              },
+              skipLoadingOnReload: false,
+              error: (error, stackTrace) => Text(
+                L10n.of(context).errorLoadingMembersCount(error),
+              ),
+              loading: () => Skeletonizer(
+                child: Text(L10n.of(context).membersCount(100)),
               ),
             ),
           ],
         ),
       ),
+      actions: [
+        GestureDetector(
+          onTap: () => context.pushNamed(
+            Routes.chatProfile.name,
+            pathParameters: {'roomId': roomId},
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 10),
+            child: RoomAvatar(
+              roomId: roomId,
+              showParent: true,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -6,7 +6,6 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/base_body_widget.dart';
 import 'package:acter/common/widgets/default_dialog.dart';
 import 'package:acter/common/widgets/render_html.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/member_list.dart';
 import 'package:acter/features/chat/widgets/room_avatar.dart';
 import 'package:acter/features/chat/widgets/skeletons/action_item_skeleton_widget.dart';
@@ -27,9 +26,11 @@ final _log = Logger('a3::chat::room_profile_page');
 
 class RoomProfilePage extends ConsumerStatefulWidget {
   final String roomId;
+  final bool inSidebar;
 
   const RoomProfilePage({
     required this.roomId,
+    required this.inSidebar,
     super.key,
   });
 
@@ -53,23 +54,14 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   }
 
   AppBar _buildAppBar(BuildContext context) {
-    final inSideBar = ref.watch(inSideBarProvider);
-    final isExpanded = ref.watch(hasExpandedPanel);
-
     return AppBar(
-      automaticallyImplyLeading: false,
-      leading: Visibility(
-        visible: inSideBar && isExpanded,
-        replacement: IconButton(
-          onPressed: () => context.pop(),
-          icon: const Icon(Icons.arrow_back_ios),
-        ),
-        child: IconButton(
-          onPressed: () =>
-              ref.read(hasExpandedPanel.notifier).update((state) => false),
-          icon: const Icon(Atlas.xmark_circle_thin),
-        ),
-      ),
+      // custom x-circle when we are in widescreen mode;
+      leading: widget.inSidebar
+          ? IconButton(
+              onPressed: () => context.pop(),
+              icon: const Icon(Atlas.xmark_circle_thin),
+            )
+          : null,
       backgroundColor: Colors.transparent,
       elevation: 0.0,
     );

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -48,10 +48,6 @@ final filteredChatsProvider =
   return foundRooms;
 });
 
-// for desktop only
-final inSideBarProvider = StateProvider<bool>((ref) => false);
-final hasExpandedPanel = StateProvider<bool>((ref) => false);
-
 // get status of room encryption
 final isRoomEncryptedProvider =
     FutureProvider.family<bool, String>((ref, roomId) async {

--- a/app/lib/features/chat/widgets/chat_layout_builder.dart
+++ b/app/lib/features/chat/widgets/chat_layout_builder.dart
@@ -1,16 +1,18 @@
-import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/features/chat/config.dart';
 import 'package:acter/features/chat/pages/chat_select_page.dart';
-import 'package:acter/features/chat/pages/room_profile_page.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/rooms_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-const sidebarMinWidth = 750;
+import 'package:go_router/go_router.dart';
 
 class ChatLayoutBuilder extends ConsumerWidget {
-  final List<Widget>? children;
-  const ChatLayoutBuilder({this.children, super.key});
+  // (bool inSideBar) -> Widget
+  final Widget Function(bool)? centerBuilder;
+  // (bool inSideBar) -> Widget
+  final Widget Function(bool)? expandedBuilder;
+  const ChatLayoutBuilder(
+      {this.centerBuilder, this.expandedBuilder, super.key,});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -18,49 +20,51 @@ class ChatLayoutBuilder extends ConsumerWidget {
       builder: (context, constraints) {
         if (constraints.maxWidth < sidebarMinWidth) {
           // we only have space to show the deepest child:
-          if (children != null) {
-            return children!.last;
+          if (expandedBuilder != null) {
+            return expandedBuilder!(false);
+          } else if (centerBuilder != null) {
+            return centerBuilder!(false);
           } else {
             // no children, show the room list
-            return const RoomsListWidget();
+            return RoomsListWidget(
+              onSelected: (String roomId) => context.pushNamed(
+                Routes.chatroom.name,
+                pathParameters: {'roomId': roomId},
+              ),
+            );
           }
-        }
-
-        // we have space to show more
-        final List<Flexible> wrappedChildren;
-
-        if (children != null) {
-          wrappedChildren = children!.indexed.map((entry) {
-            final child = entry.$2;
-            if (entry.$1 == 0) {
-              // the first entry gets twice the space, all following just 1
-              return Flexible(
-                flex: 2,
-                child: child,
-              );
-            } else {
-              return Flexible(
-                child: child,
-              );
-            }
-          }).toList();
-        } else {
-          // nothing else to show, show placeholder page:
-          wrappedChildren = [
-            const Flexible(
-              flex: 2,
-              child: ChatSelectPage(),
-            ),
-          ];
         }
 
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            const Flexible(
-              child: RoomsListWidget(),
+            Flexible(
+              child: RoomsListWidget(
+                onSelected: (String roomId) => context.goNamed(
+                  // we switch without "push"
+                  Routes.chatroom.name,
+                  pathParameters: {'roomId': roomId},
+                ),
+              ),
             ),
-            ...wrappedChildren,
+            // we have a room selected
+            if (centerBuilder != null)
+              Flexible(
+                flex: 3,
+                child: centerBuilder!(true),
+              ),
+            // we have an expanded as well
+            if (expandedBuilder != null)
+              Flexible(
+                flex: 2,
+                child: expandedBuilder!(true),
+              ),
+            // Fallback if neither is in our route
+            if (centerBuilder == null && expandedBuilder == null)
+              const Flexible(
+                flex: 2,
+                child: ChatSelectPage(),
+              ),
           ],
         );
       },

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -1,7 +1,6 @@
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/chat/models/room_list_filter_state/room_list_filter_state.dart';
-import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter/features/chat/widgets/convo_list.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -15,9 +14,13 @@ import 'package:go_router/go_router.dart';
 final bucketGlobal = PageStorageBucket();
 
 class RoomsListWidget extends ConsumerStatefulWidget {
+  final Function(String) onSelected;
   static const roomListMenuKey = Key('room-list');
 
-  const RoomsListWidget({super.key = roomListMenuKey});
+  const RoomsListWidget({
+    required this.onSelected,
+    super.key = roomListMenuKey,
+  });
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() =>
@@ -227,7 +230,6 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
   Widget build(BuildContext context) {
     final client = ref.watch(alwaysClientProvider);
     final hasFilters = ref.watch(hasRoomFilters);
-    final inSideBar = ref.watch(inSideBarProvider);
     return PageStorage(
       bucket: bucketGlobal,
       child: CustomScrollView(
@@ -307,17 +309,7 @@ class _RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
             child: client.isGuest()
                 ? empty
                 : ConvosList(
-                    onSelected: (String roomId) {
-                      inSideBar
-                          ? context.goNamed(
-                              Routes.chatroom.name,
-                              pathParameters: {'roomId': roomId},
-                            )
-                          : context.pushNamed(
-                              Routes.chatroom.name,
-                              pathParameters: {'roomId': roomId},
-                            );
-                    },
+                    onSelected: widget.onSelected,
                   ),
           ),
         ],

--- a/app/lib/router/shell_routers/chat_shell_router.dart
+++ b/app/lib/router/shell_routers/chat_shell_router.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/features/chat/pages/chat_select_page.dart';
 import 'package:acter/features/chat/pages/room_page.dart';
 import 'package:acter/features/chat/pages/room_profile_page.dart';
 import 'package:acter/features/chat/widgets/chat_layout_builder.dart';
@@ -32,7 +31,10 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            children: [RoomPage(roomId: roomId)],
+            centerBuilder: (inSidebar) => RoomPage(
+              roomId: roomId,
+              inSidebar: inSidebar,
+            ),
           ),
         );
       },
@@ -47,10 +49,14 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            children: [
-              RoomPage(roomId: roomId),
-              RoomProfilePage(roomId: roomId),
-            ],
+            centerBuilder: (inSidebar) => RoomPage(
+              roomId: roomId,
+              inSidebar: inSidebar,
+            ),
+            expandedBuilder: (inSidebar) => RoomProfilePage(
+              roomId: roomId,
+              inSidebar: inSidebar,
+            ),
           ),
         );
       },

--- a/app/lib/router/shell_routers/chat_shell_router.dart
+++ b/app/lib/router/shell_routers/chat_shell_router.dart
@@ -18,9 +18,7 @@ List<RouteBase> makeChatShellRoutes(ref) {
         selectedChatNotifier.select(null);
         return NoTransitionPage(
           key: state.pageKey,
-          child: const ChatLayoutBuilder(
-            child: ChatSelectPage(),
-          ),
+          child: const ChatLayoutBuilder(),
         );
       },
     ),
@@ -34,7 +32,7 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            child: RoomPage(roomId: roomId),
+            children: [RoomPage(roomId: roomId)],
           ),
         );
       },
@@ -49,7 +47,10 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            child: RoomProfilePage(roomId: roomId),
+            children: [
+              RoomPage(roomId: roomId),
+              RoomProfilePage(roomId: roomId),
+            ],
           ),
         );
       },


### PR DESCRIPTION
We've had several reports that through some oddities in navigation, the user could end up in a situation where rather than the chat list for selection they'd see the [chat-selection-empty-filler](https://github.com/acterglobal/a3/issues/1343).

This is due to the fact that in order to maintain the sidebar and expansion-bar (for the room profile page), we used some riverpod providers that were manually updated within build methods. As any manual updating of riverpod, this, too, is frickely and sometimes went out of sync with the actual screen view (maybe due to orientation changes and thus corresponding updates that aren't done).

This PR refactors the ChatLayoutBuilder and the internal pages to remove the riverpod states and instead properly pass along the right information within the widget-hierarchy. Through some clever changes this also removed a bunch of code for explicit back-button behaviour by now replacing most of that with proper "pushNamed"-calls rather than weird `goNamed` linking behaviours. Further more, the way the code has been refactored the empty-filler can only ever happen when we _also_ display the room list now.

Notice how in this screencast the screens and their arrows appear and disappear (or in case of the profile are replaced with a close button) purely depending on available view size and despite having routed into them in the large view, the proper link stacking behaviour is maintained regardless of resizes. 


https://github.com/acterglobal/a3/assets/40496/b24e0e96-aba0-4ca7-ad80-f1281cd0c8ed



Fixes https://github.com/acterglobal/a3-meta/issues/150 
Fixes https://github.com/acterglobal/a3/issues/1343
