### PR TITLE
reapply logging infrastructure

### DIFF
--- a/app/lib/common/utils/logging.dart
+++ b/app/lib/common/utils/logging.dart
@@ -2,13 +2,39 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
+final Map<(String, String), bool> logStateCache = {};
+
 Future<void> initLogging() async {
-  if (isDevBuild) {
-    Logger.root.level = Level.INFO;
-    Logger.root.onRecord.listen((record) {
-      debugPrint('${record.level.name}: ${record.time}: ${record.message}');
-    });
-  } else {
-    // FIXME: add code to support sending logs via rust API to file
-  }
+  Logger.root.level = Level.INFO;
+  final sdk = await ActerSdk.instance;
+  Logger.root.onRecord.listen((record) {
+    debugPrint('${record.level.name}: ${record.time}: ${record.message}');
+    String level = 'trace';
+    if (record.level == Level.WARNING) {
+      level = 'warn';
+    } else if (record.level == Level.SEVERE || record.level == Level.SHOUT) {
+      level = 'error';
+    } else if (record.level == Level.INFO) {
+      level = 'info';
+    } else if (record.level == Level.CONFIG) {
+      level = 'debug';
+    }
+
+    bool? curVal = logStateCache[(record.loggerName, level)];
+    if (curVal == null) {
+      curVal = sdk.api.wouldLog(record.loggerName, level);
+      logStateCache[(record.loggerName, level)] = curVal;
+    }
+
+    if (curVal) {
+      sdk.api.writeLog(
+        record.loggerName,
+        level,
+        '${record.message} ${record.error} ${record.object} ${record.stackTrace}',
+        null,
+        null,
+        null,
+      );
+    }
+  });
 }

--- a/app/lib/features/home/providers/notifiers/client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/client_notifier.dart
@@ -7,7 +7,6 @@ import 'package:riverpod/riverpod.dart';
 
 final _log = Logger('a3::home::client_notifier');
 
-// ignore_for_file: avoid_print
 class ClientNotifier extends StateNotifier<Client?> {
   ClientNotifier(Ref ref) : super(null) {
     _loadUp(ref);

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -666,12 +666,11 @@ class Api {
     return tmp1;
   }
 
-  /// Allow flutter to call logging on rust side
-  void writeLog(
-    String text,
+  bool wouldLog(
+    String target,
     String level,
   ) {
-    final tmp0 = text;
+    final tmp0 = target;
     final tmp4 = level;
     var tmp1 = 0;
     var tmp2 = 0;
@@ -695,7 +694,7 @@ class Api {
     tmp5_1.setAll(0, tmp4_0);
     tmp5 = tmp5_0.address;
     tmp7 = tmp6;
-    final tmp8 = _writeLog(
+    final tmp8 = _wouldLog(
       tmp1,
       tmp2,
       tmp3,
@@ -703,22 +702,125 @@ class Api {
       tmp6,
       tmp7,
     );
-    final tmp10 = tmp8.arg0;
-    final tmp11 = tmp8.arg1;
-    final tmp12 = tmp8.arg2;
-    final tmp13 = tmp8.arg3;
-    if (tmp10 == 0) {
-      debugAllocation("handle error", tmp11, tmp12);
-      final ffi.Pointer<ffi.Uint8> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
-      final tmp10_0 =
-          utf8.decode(tmp11_0.asTypedList(tmp12), allowMalformed: true);
-      if (tmp12 > 0) {
-        final ffi.Pointer<ffi.Void> tmp11_0;
-        tmp11_0 = ffi.Pointer.fromAddress(tmp11);
-        this.__deallocate(tmp11_0, tmp13, 1);
-      }
-      throw tmp10_0;
+    final tmp10 = tmp8;
+    final tmp9 = tmp10 > 0;
+    return tmp9;
+  }
+
+  /// Log the entry to the rust logging
+  void writeLog(
+    String target,
+    String level,
+    String message,
+    String? file,
+    int? line,
+    String? modulePath,
+  ) {
+    final tmp0 = target;
+    final tmp4 = level;
+    final tmp8 = message;
+    final tmp12 = file;
+    final tmp18 = line;
+    final tmp22 = modulePath;
+    var tmp1 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp9 = 0;
+    var tmp10 = 0;
+    var tmp11 = 0;
+    var tmp13 = 0;
+    var tmp15 = 0;
+    var tmp16 = 0;
+    var tmp17 = 0;
+    var tmp19 = 0;
+    var tmp21 = 0;
+    var tmp23 = 0;
+    var tmp25 = 0;
+    var tmp26 = 0;
+    var tmp27 = 0;
+    final tmp0_0 = utf8.encode(tmp0);
+    tmp2 = tmp0_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp1_0 = this.__allocate(tmp2 * 1, 1);
+    final Uint8List tmp1_1 = tmp1_0.asTypedList(tmp2);
+    tmp1_1.setAll(0, tmp0_0);
+    tmp1 = tmp1_0.address;
+    tmp3 = tmp2;
+    final tmp4_0 = utf8.encode(tmp4);
+    tmp6 = tmp4_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp5_0 = this.__allocate(tmp6 * 1, 1);
+    final Uint8List tmp5_1 = tmp5_0.asTypedList(tmp6);
+    tmp5_1.setAll(0, tmp4_0);
+    tmp5 = tmp5_0.address;
+    tmp7 = tmp6;
+    final tmp8_0 = utf8.encode(tmp8);
+    tmp10 = tmp8_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp9_0 = this.__allocate(tmp10 * 1, 1);
+    final Uint8List tmp9_1 = tmp9_0.asTypedList(tmp10);
+    tmp9_1.setAll(0, tmp8_0);
+    tmp9 = tmp9_0.address;
+    tmp11 = tmp10;
+    if (tmp12 == null) {
+      tmp13 = 0;
+    } else {
+      tmp13 = 1;
+      final tmp14 = tmp12;
+      final tmp14_0 = utf8.encode(tmp14);
+      tmp16 = tmp14_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp15_0 = this.__allocate(tmp16 * 1, 1);
+      final Uint8List tmp15_1 = tmp15_0.asTypedList(tmp16);
+      tmp15_1.setAll(0, tmp14_0);
+      tmp15 = tmp15_0.address;
+      tmp17 = tmp16;
     }
+    if (tmp18 == null) {
+      tmp19 = 0;
+    } else {
+      tmp19 = 1;
+      final tmp20 = tmp18;
+      tmp21 = tmp20;
+    }
+    if (tmp22 == null) {
+      tmp23 = 0;
+    } else {
+      tmp23 = 1;
+      final tmp24 = tmp22;
+      final tmp24_0 = utf8.encode(tmp24);
+      tmp26 = tmp24_0.length;
+
+      final ffi.Pointer<ffi.Uint8> tmp25_0 = this.__allocate(tmp26 * 1, 1);
+      final Uint8List tmp25_1 = tmp25_0.asTypedList(tmp26);
+      tmp25_1.setAll(0, tmp24_0);
+      tmp25 = tmp25_0.address;
+      tmp27 = tmp26;
+    }
+    _writeLog(
+      tmp1,
+      tmp2,
+      tmp3,
+      tmp5,
+      tmp6,
+      tmp7,
+      tmp9,
+      tmp10,
+      tmp11,
+      tmp13,
+      tmp15,
+      tmp16,
+      tmp17,
+      tmp19,
+      tmp21,
+      tmp23,
+      tmp25,
+      tmp26,
+      tmp27,
+    );
     return;
   }
 
@@ -13898,19 +14000,65 @@ class Api {
 
   late final _rotateLogFile =
       _rotateLogFilePtr.asFunction<_RotateLogFileReturn Function()>();
-  late final _writeLogPtr = _lookup<
+  late final _wouldLogPtr = _lookup<
       ffi.NativeFunction<
-          _WriteLogReturn Function(
+          ffi.Uint8 Function(
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__would_log");
+
+  late final _wouldLog = _wouldLogPtr.asFunction<
+      int Function(
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+      )>();
+  late final _writeLogPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Uint8,
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+            ffi.Uint8,
+            ffi.Uint32,
+            ffi.Uint8,
             ffi.Int64,
             ffi.Uint64,
             ffi.Uint64,
           )>>("__write_log");
 
   late final _writeLog = _writeLogPtr.asFunction<
-      _WriteLogReturn Function(
+      void Function(
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
         int,
         int,
         int,
@@ -50331,17 +50479,6 @@ class _RotateLogFileReturn extends ffi.Struct {
   external int arg5;
   @ffi.Uint64()
   external int arg6;
-}
-
-class _WriteLogReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-  @ffi.Uint64()
-  external int arg2;
-  @ffi.Uint64()
-  external int arg3;
 }
 
 class _ParseMarkdownReturn extends ffi.Struct {

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -17,8 +17,11 @@ fn set_proxy(proxy: Option<string>);
 /// Rotate the logging file
 fn rotate_log_file() -> Result<string>;
 
-/// Allow flutter to call logging on rust side
-fn write_log(text: string, level: string) -> Result<()>;
+// would this get logged?
+fn would_log(target: string, level: string) -> bool;
+
+/// Log the entry to the rust logging
+fn write_log(target: string, level: string, message: string, file: Option<string>, line: Option<u32>, module_path: Option<string>);
 
 /// Create a new client for homeserver at url with storage at data_path
 fn login_new_client(base_path: string, media_cache_base_path: string, username: string, password: string, default_homeserver_name: string, default_homeserver_url: string, device_name: Option<string>) -> Future<Result<Client>>;

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -141,15 +141,5 @@ mod api {
         }
     }
 }
-
-fn init_logging(log_dir: String, filter: String) -> Result<()> {
-    platform::init_logging(log_dir, filter)
-}
-
-fn rotate_log_file() -> Result<String> {
-    platform::rotate_log_file()
-}
-
-fn write_log(text: String, level: String) -> Result<()> {
-    platform::write_log(text, level)
-}
+// reexport
+pub use platform::{init_logging, rotate_log_file, would_log, write_log};

--- a/native/acter/src/platform/mod.rs
+++ b/native/acter/src/platform/mod.rs
@@ -17,4 +17,4 @@ mod desktop;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use desktop::*;
 
-pub use native::{rotate_log_file, sanitize, write_log};
+pub use native::{rotate_log_file, sanitize, would_log, write_log};


### PR DESCRIPTION
Since we've fixed the operation not permitted problem of iOS & Mac, let's try again to reintroduce the unified log files that includes flutter errors (as they are needed for rageshakes now).

This is marked as minor as the code had already been reviewed.