### PR TITLE
Fix accept of invitation in integration test according to PR#1597

### DIFF
--- a/native/test/src/tests/formatted_body.rs
+++ b/native/test/src/tests/formatted_body.rs
@@ -1,8 +1,12 @@
 use acter::{api::RoomMessage, ruma_common::OwnedEventId};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use core::time::Duration;
 use futures::{pin_mut, stream::StreamExt, FutureExt};
 use tokio::time::sleep;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
 use tracing::info;
 
 use crate::utils::random_users_with_random_convo;
@@ -24,6 +28,28 @@ async fn sisko_sends_rich_text_to_kyra() -> Result<()> {
     let kyra_sync = kyra.start_sync();
     kyra_sync.await_has_synced_history().await?;
 
+    for invited in kyra.invited_rooms().iter() {
+        info!(" - accepting {:?}", invited.room_id());
+        invited.join().await?;
+    }
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = kyra.clone();
+    let invited_room_id = room_id.clone();
+    Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        let invited = invited_room_id.clone();
+        async move {
+            if client.convo(invited.to_string()).await.is_err() {
+                bail!("kyra couldn't find invited room");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
     let kyra_convo = kyra
         .convo(room_id.to_string())
         .await
@@ -31,12 +57,6 @@ async fn sisko_sends_rich_text_to_kyra() -> Result<()> {
     let kyra_timeline = kyra_convo.timeline_stream();
     let kyra_stream = kyra_timeline.messages_stream();
     pin_mut!(kyra_stream);
-
-    kyra_stream.next().await;
-    for invited in kyra.invited_rooms().iter() {
-        info!(" - accepting {:?}", invited.room_id());
-        invited.join().await?;
-    }
 
     // sisko sends the formatted text message to kyra
     let draft = sisko.text_markdown_draft("**Hello**".to_string());

--- a/native/test/src/tests/reaction.rs
+++ b/native/test/src/tests/reaction.rs
@@ -13,8 +13,6 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
     let (mut sisko, mut kyra, mut worf, room_id) =
         random_users_with_random_convo("reaction").await?;
 
-    info!("1");
-
     let sisko_sync = sisko.start_sync();
     sisko_sync.await_has_synced_history().await?;
 
@@ -25,8 +23,6 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
     let sisko_timeline = sisko_convo.timeline_stream();
     let sisko_stream = sisko_timeline.messages_stream();
     pin_mut!(sisko_stream);
-
-    info!("2");
 
     let kyra_sync = kyra.start_sync();
     kyra_sync.await_has_synced_history().await?;
@@ -45,8 +41,6 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
         invited.join().await?;
     }
 
-    info!("3");
-
     let worf_sync = worf.start_sync();
     worf_sync.await_has_synced_history().await?;
 
@@ -64,12 +58,8 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
         invited.join().await?;
     }
 
-    info!("4");
-
     let draft = sisko.text_plain_draft("Hi, everyone".to_string());
     sisko_timeline.send_message(Box::new(draft)).await?;
-
-    info!("5");
 
     // text msg may reach via reset action or set action
     let mut i = 30;
@@ -114,8 +104,6 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
     info!("loop finished");
     let kyra_received = received.context("Even after 30 seconds, text msg not received")?;
 
-    info!("6");
-
     // text msg may reach via reset action or set action
     i = 30;
     received = None;
@@ -159,16 +147,12 @@ async fn sisko_reads_msg_reactions() -> Result<()> {
     info!("loop finished");
     let worf_received = received.context("Even after 30 seconds, text msg not received")?;
 
-    info!("7");
-
     kyra_timeline
         .toggle_reaction(kyra_received.to_string(), "👏".to_string())
         .await?;
     worf_timeline
         .toggle_reaction(worf_received.to_string(), "😎".to_string())
         .await?;
-
-    info!("8");
 
     // msg reaction may reach via set action
     i = 10;

--- a/native/test/src/tests/receipt.rs
+++ b/native/test/src/tests/receipt.rs
@@ -23,8 +23,6 @@ async fn sisko_detects_kyra_read() -> Result<()> {
     let sisko_stream = sisko_timeline.messages_stream();
     pin_mut!(sisko_stream);
 
-    info!("1");
-
     let kyra_sync = kyra.start_sync();
     kyra_sync.await_has_synced_history().await?;
     let mut kyra_stream = Box::pin(kyra.sync_stream(Default::default()).await);
@@ -34,12 +32,8 @@ async fn sisko_detects_kyra_read() -> Result<()> {
         invited.join().await?;
     }
 
-    info!("2");
-
     let draft = sisko.text_plain_draft("Hi, everyone".to_string());
     sisko_timeline.send_message(Box::new(draft)).await?;
-
-    info!("3");
 
     // text msg may reach via reset action or set action
     let mut i = 30;
@@ -84,8 +78,6 @@ async fn sisko_detects_kyra_read() -> Result<()> {
     info!("loop finished");
     let received = received.context("Even after 30 seconds, text msg not received")?;
 
-    info!("4 - {:?}", received);
-
     let kyra_convo = kyra
         .convo(room_id.to_string())
         .await
@@ -98,8 +90,6 @@ async fn sisko_detects_kyra_read() -> Result<()> {
             received.to_string(),
         )
         .await?;
-
-    info!("5");
 
     let mut event_rx = sisko
         .receipt_event_rx()

--- a/native/test/src/tests/receipt.rs
+++ b/native/test/src/tests/receipt.rs
@@ -1,8 +1,12 @@
 use acter::{api::RoomMessage, ruma_common::OwnedEventId};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use core::time::Duration;
 use futures::{pin_mut, stream::StreamExt, FutureExt};
 use tokio::time::sleep;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
 use tracing::info;
 
 use crate::utils::random_users_with_random_convo;
@@ -25,12 +29,28 @@ async fn sisko_detects_kyra_read() -> Result<()> {
 
     let kyra_sync = kyra.start_sync();
     kyra_sync.await_has_synced_history().await?;
-    let mut kyra_stream = Box::pin(kyra.sync_stream(Default::default()).await);
-    kyra_stream.next().await;
+
     for invited in kyra.invited_rooms().iter() {
         info!(" - accepting {:?}", invited.room_id());
         invited.join().await?;
     }
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = kyra.clone();
+    let invited_room_id = room_id.clone();
+    Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        let invited = invited_room_id.clone();
+        async move {
+            if client.convo(invited.to_string()).await.is_err() {
+                bail!("kyra couldn't find invited room");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
 
     let draft = sisko.text_plain_draft("Hi, everyone".to_string());
     sisko_timeline.send_message(Box::new(draft)).await?;

--- a/native/test/src/tests/reply.rs
+++ b/native/test/src/tests/reply.rs
@@ -1,8 +1,12 @@
 use acter::{api::RoomMessage, ruma_common::OwnedEventId};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use core::time::Duration;
 use futures::{pin_mut, stream::StreamExt, FutureExt};
 use tokio::time::sleep;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
 use tracing::info;
 
 use crate::utils::random_users_with_random_convo;
@@ -26,19 +30,33 @@ async fn sisko_reads_kyra_reply() -> Result<()> {
     let kyra_sync = kyra.start_sync();
     kyra_sync.await_has_synced_history().await?;
 
+    for invited in kyra.invited_rooms().iter() {
+        info!(" - accepting {:?}", invited.room_id());
+        invited.join().await?;
+    }
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = kyra.clone();
+    let invited_room_id = room_id.clone();
+    Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        let invited = invited_room_id.clone();
+        async move {
+            if client.convo(invited.to_string()).await.is_err() {
+                bail!("kyra couldn't find invited room");
+            } else {
+                Ok(())
+            }
+        }
+    })
+    .await?;
+
     let kyra_convo = kyra
         .convo(room_id.to_string())
         .await
         .expect("kyra should belong to convo");
     let kyra_timeline = kyra_convo.timeline_stream();
-    let kyra_stream = kyra_timeline.messages_stream();
-    pin_mut!(kyra_stream);
-
-    kyra_stream.next().await;
-    for invited in kyra.invited_rooms().iter() {
-        info!(" - accepting {:?}", invited.room_id());
-        invited.join().await?;
-    }
 
     let draft = sisko.text_plain_draft("Hi, everyone".to_string());
     sisko_timeline.send_message(Box::new(draft)).await?;


### PR DESCRIPTION
In PR#1597, `get_spaces_and_chats()` limited rooms into `Joined` state, but `client` calls `invitation_controller.load_invitations()` on first sync callback.
I changed time point of accept of invitation.
And used retry-loop to see if the convo can be available already, according to @gnunicorn hint.