### PR TITLE
General fixes for pins

### DIFF
--- a/app/lib/features/pins/widgets/pin_item.dart
+++ b/app/lib/features/pins/widgets/pin_item.dart
@@ -57,29 +57,26 @@ class _PinItemState extends ConsumerState<PinItem> {
     final spaceId = pin.roomIdStr();
     final isLink = pin.isLink();
 
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Form(
-        key: _formkey,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Container(
-              alignment: Alignment.topLeft,
-              margin: const EdgeInsets.all(8),
-              child: SpaceChip(spaceId: spaceId),
-            ),
-            if (isLink) _buildPinLink(),
-            _PinDescriptionWidget(
-              pin: pin,
-              descriptionController: _descriptionController,
-              linkController: _linkController,
-              formkey: _formkey,
-            ),
-            const SizedBox(height: 20),
-          ],
-        ),
+    return Form(
+      key: _formkey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            alignment: Alignment.topLeft,
+            margin: const EdgeInsets.all(8),
+            child: SpaceChip(spaceId: spaceId),
+          ),
+          if (isLink) _buildPinLink(),
+          _PinDescriptionWidget(
+            pin: pin,
+            descriptionController: _descriptionController,
+            linkController: _linkController,
+            formkey: _formkey,
+          ),
+        ],
       ),
     );
   }
@@ -153,6 +150,7 @@ class _PinDescriptionWidgetConsumerState
     final pinEditNotifier = ref.watch(pinEditProvider(widget.pin).notifier);
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Container(
           margin: const EdgeInsets.symmetric(vertical: 8),
@@ -163,26 +161,25 @@ class _PinDescriptionWidgetConsumerState
                 : null,
             borderRadius: BorderRadius.circular(12),
           ),
-          constraints: BoxConstraints(
-            maxHeight: MediaQuery.of(context).size.height * 0.4,
-          ),
-          child: HtmlEditor(
-            key: PinItem.descriptionFieldKey,
-            editable: pinEdit.editMode,
-            editorState: textEditorState,
-            footer: const SizedBox(),
-            onChanged: (body, html) {
-              if (body.trim().isNotEmpty) {
-                final document = html != null
-                    ? ActerDocumentHelpers.fromHtml(html)
-                    : ActerDocumentHelpers.fromMarkdown(body);
-                textEditorState = EditorState(document: document);
-              } else {
-                textEditorState = EditorState(
-                  document: ActerDocumentHelpers.fromMarkdown(body),
-                );
-              }
-            },
+          child: IntrinsicHeight(
+            child: HtmlEditor(
+              key: PinItem.descriptionFieldKey,
+              editable: pinEdit.editMode,
+              editorState: textEditorState,
+              shrinkWrap: true,
+              onChanged: (body, html) {
+                if (body.trim().isNotEmpty) {
+                  final document = html != null
+                      ? ActerDocumentHelpers.fromHtml(html)
+                      : ActerDocumentHelpers.fromMarkdown(body);
+                  textEditorState = EditorState(document: document);
+                } else {
+                  textEditorState = EditorState(
+                    document: ActerDocumentHelpers.fromMarkdown(body),
+                  );
+                }
+              },
+            ),
           ),
         ),
         _ActionButtonsWidget(

--- a/app/lib/features/pins/widgets/pin_list_item.dart
+++ b/app/lib/features/pins/widgets/pin_list_item.dart
@@ -102,13 +102,7 @@ class _PinListItemConsumerState extends ConsumerState<PinListItem> {
 
   // handler for gesture interaction on pin
   Future<void> onTap(BuildContext context) async {
-    final bool isLink = widget.pin.isLink();
-    if (isLink) {
-      final target = widget.pin.url()!;
-      await openLink(target, context);
-    } else {
       await openItem(context);
-    }
   }
 
   @override
@@ -141,7 +135,6 @@ class _PinListItemConsumerState extends ConsumerState<PinListItem> {
     return InkWell(
       key: Key(widget.pin.eventIdStr()),
       onTap: () => onTap(context),
-      onLongPress: () => openItem(context),
       child: Card(
         child: Padding(
           padding: const EdgeInsets.all(8.0),

--- a/app/lib/features/pins/widgets/pin_list_item.dart
+++ b/app/lib/features/pins/widgets/pin_list_item.dart
@@ -1,6 +1,5 @@
 import 'package:acter/features/attachments/providers/attachment_providers.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/attachments/widgets/attachment_item.dart';
 import 'package:acter/features/home/widgets/space_chip.dart';
 import 'package:acter/features/pins/providers/pins_provider.dart';


### PR DESCRIPTION
- Single tap to open pin detail page instead of long press
- Removed un-used space from pin description
- Make pins description scrollable 
fixes, #1593 #1602 

Reference Video:

https://github.com/acterglobal/a3/assets/51526480/fb6440ef-0ead-4801-a2ab-3332a81cb76a


