### PR TITLE
Fix the white screen issue when entering a space

### DIFF
--- a/app/lib/features/space/pages/overview_page.dart
+++ b/app/lib/features/space/pages/overview_page.dart
@@ -30,7 +30,8 @@ class ActerSpaceChecker extends ConsumerWidget {
     final expCheck = expectation ?? (a) => a != null;
     return appSettings.when(
       data: (data) => expCheck(data) ? child : const SizedBox.shrink(),
-      error: (error, stackTrace) => Text(L10n.of(context).failedToLoadSpace(error)),
+      error: (error, stackTrace) =>
+          Text(L10n.of(context).failedToLoadSpace(error)),
       loading: () => const SizedBox.shrink(),
     );
   }
@@ -46,40 +47,31 @@ class SpaceOverview extends ConsumerWidget {
     // get platform of context.
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: primaryGradient),
-      child: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
-          ),
-          SliverToBoxAdapter(
-            child: AboutCard(spaceId: spaceIdOrAlias),
-          ),
-          SliverToBoxAdapter(
-            child: ActerSpaceChecker(
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
+            AboutCard(spaceId: spaceIdOrAlias),
+            ActerSpaceChecker(
               spaceId: spaceIdOrAlias,
               expectation: (a) => a == null,
               child: NonActerSpaceCard(spaceId: spaceIdOrAlias),
             ),
-          ),
-          SliverToBoxAdapter(
-            child: ActerSpaceChecker(
+            ActerSpaceChecker(
               spaceId: spaceIdOrAlias,
               expectation: (a) => a?.events().active() ?? false,
               child: EventsCard(spaceId: spaceIdOrAlias),
             ),
-          ),
-          SliverToBoxAdapter(
-            child: ActerSpaceChecker(
+            ActerSpaceChecker(
               spaceId: spaceIdOrAlias,
               expectation: (a) => a?.pins().active() ?? false,
               child: LinksCard(spaceId: spaceIdOrAlias),
             ),
-          ),
-          SliverToBoxAdapter(
-            child: ChatsCard(spaceId: spaceIdOrAlias),
-          ),
-          RelatedSpacesCard(spaceId: spaceIdOrAlias),
-        ],
+            ChatsCard(spaceId: spaceIdOrAlias),
+            RelatedSpacesCard(spaceId: spaceIdOrAlias),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/space/pages/related_spaces_page.dart
+++ b/app/lib/features/space/pages/related_spaces_page.dart
@@ -25,58 +25,52 @@ class RelatedSpacesPage extends ConsumerWidget {
     // get platform of context.
     return DecoratedBox(
       decoration: const BoxDecoration(gradient: primaryGradient),
-      child: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
-          ),
-          spaces.when(
-            data: (spaces) {
-              final canLinkSpace =
-                  spaces.membership?.canString('CanLinkSpaces') ?? false;
-              return RelatedSpaces(
-                spaceIdOrAlias: spaceIdOrAlias,
-                spaces: spaces,
-                crossAxisCount: crossAxisCount,
-                fallback: renderFallback(context, canLinkSpace),
-              );
-            },
-            error: (error, stack) => SliverToBoxAdapter(
-              child: Center(
+      child: SingleChildScrollView(
+        child: Column(
+          children: [
+            SpaceHeader(spaceIdOrAlias: spaceIdOrAlias),
+            spaces.when(
+              data: (spaces) {
+                final canLinkSpace =
+                    spaces.membership?.canString('CanLinkSpaces') ?? false;
+                return RelatedSpaces(
+                  spaceIdOrAlias: spaceIdOrAlias,
+                  spaces: spaces,
+                  crossAxisCount: crossAxisCount,
+                  fallback: renderFallback(context, canLinkSpace),
+                );
+              },
+              error: (error, stack) => Center(
                 child: Text(L10n.of(context).loadingFailed(error)),
               ),
-            ),
-            loading: () => SliverToBoxAdapter(
-              child: Center(
+              loading: () => Center(
                 child: Text(L10n.of(context).loading),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
 
   Widget renderFallback(BuildContext context, bool canLinkSpace) {
-    return SliverToBoxAdapter(
-      child: Center(
-        heightFactor: 1,
-        child: EmptyState(
-          title: L10n.of(context).noConnectedSpaces,
-          subtitle: L10n.of(context).inConnectedSpaces,
-          image: 'assets/images/empty_space.svg',
-          primaryButton: canLinkSpace
-              ? ElevatedButton(
-                  onPressed: () => context.pushNamed(
-                    Routes.createSpace.name,
-                    queryParameters: {
-                      'parentSpaceId': spaceIdOrAlias,
-                    },
-                  ),
-                  child: Text(L10n.of(context).createNewSpace),
-                )
-              : null,
-        ),
+    return Center(
+      heightFactor: 1,
+      child: EmptyState(
+        title: L10n.of(context).noConnectedSpaces,
+        subtitle: L10n.of(context).inConnectedSpaces,
+        image: 'assets/images/empty_space.svg',
+        primaryButton: canLinkSpace
+            ? ElevatedButton(
+                onPressed: () => context.pushNamed(
+                  Routes.createSpace.name,
+                  queryParameters: {
+                    'parentSpaceId': spaceIdOrAlias,
+                  },
+                ),
+                child: Text(L10n.of(context).createNewSpace),
+              )
+            : null,
       ),
     );
   }

--- a/app/lib/features/space/widgets/related_spaces_card.dart
+++ b/app/lib/features/space/widgets/related_spaces_card.dart
@@ -23,10 +23,8 @@ class RelatedSpacesCard extends ConsumerWidget {
           style: Theme.of(context).textTheme.bodySmall,
         ),
       ),
-      error: (error, stack) => SliverToBoxAdapter(
-        child: Text(L10n.of(context).loadingSpacesFailed(error)),
-      ),
-      loading: () => SliverToBoxAdapter(child: Text(L10n.of(context).loading)),
+      error: (error, stack) => Text(L10n.of(context).loadingSpacesFailed(error)),
+      loading: () => Text(L10n.of(context).loading),
     );
   }
 }

--- a/app/lib/features/space/widgets/relatest_spaces.dart
+++ b/app/lib/features/space/widgets/relatest_spaces.dart
@@ -81,18 +81,16 @@ class RelatedSpaces extends StatelessWidget {
     bool canLinkSpace = false,
     bool withTools = false,
   }) {
-    return SliverToBoxAdapter(
-      child: Row(
-        children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Text(title),
-            ),
+    return Row(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(title),
           ),
-          if (canLinkSpace && withTools) renderTools(context),
-        ],
-      ),
+        ),
+        if (canLinkSpace && withTools) renderTools(context),
+      ],
     );
   }
 
@@ -100,17 +98,15 @@ class RelatedSpaces extends StatelessWidget {
     if (!showParents || (spaces.parents.isEmpty && spaces.mainParent != null)) {
       return null;
     }
-    return SliverToBoxAdapter(
-      child: Row(
-        children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Text(L10n.of(context).parents),
-            ),
+    return Row(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(L10n.of(context).parents),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -119,11 +115,9 @@ class RelatedSpaces extends StatelessWidget {
       return null;
     }
     final space = spaces.mainParent!;
-    return SliverToBoxAdapter(
-      child: SpaceCard(
-        key: Key(space.getRoomIdStr()),
-        space: space,
-      ),
+    return SpaceCard(
+      key: Key(space.getRoomIdStr()),
+      space: space,
     );
   }
 
@@ -131,13 +125,9 @@ class RelatedSpaces extends StatelessWidget {
     if (!showParents || spaces.parents.isEmpty) {
       return null;
     }
-    return SliverGrid.builder(
+    return ListView.builder(
       itemCount: spaces.parents.length,
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
-        childAspectRatio: 4.0,
-        mainAxisExtent: 100,
-      ),
+      shrinkWrap: true,
       itemBuilder: (context, index) {
         final space = spaces.parents[index];
         return SpaceCard(
@@ -171,13 +161,9 @@ class RelatedSpaces extends StatelessWidget {
               canLinkSpace: canLinkSpace,
               withTools: true,
             ),
-      SliverGrid.builder(
+      ListView.builder(
         itemCount: spaces.knownSubspaces.length,
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: crossAxisCount,
-          childAspectRatio: 9.0,
-          mainAxisExtent: 100,
-        ),
+        shrinkWrap: true,
         itemBuilder: (context, index) {
           final space = spaces.knownSubspaces[index];
           return SpaceCard(
@@ -219,7 +205,8 @@ class RelatedSpaces extends StatelessWidget {
           key: Key('subspace-list-item-${item.roomIdStr()}'),
           space: item,
         ),
-        pagedBuilder: (controller, builder) => PagedSliverList(
+        pagedBuilder: (controller, builder) => PagedListView(
+          shrinkWrap: true,
           pagingController: controller,
           builderDelegate: builder,
         ),
@@ -256,31 +243,25 @@ class RelatedSpaces extends StatelessWidget {
 
     return [
       if (spaces.otherRelations.isNotEmpty || canLinkSpace)
-        SliverToBoxAdapter(
-          child: Row(
-            children: [
-              Expanded(child: Text(L10n.of(context).recommendedSpaces)),
-              IconButton(
-                icon: Icon(
-                  Atlas.plus_circle,
-                  color: Theme.of(context).colorScheme.neutral5,
-                ),
-                onPressed: () => context.pushNamed(
-                  Routes.linkRecommended.name,
-                  pathParameters: {'spaceId': spaceIdOrAlias},
-                ),
+        Row(
+          children: [
+            Expanded(child: Text(L10n.of(context).recommendedSpaces)),
+            IconButton(
+              icon: Icon(
+                Atlas.plus_circle,
+                color: Theme.of(context).colorScheme.neutral5,
               ),
-            ],
-          ),
+              onPressed: () => context.pushNamed(
+                Routes.linkRecommended.name,
+                pathParameters: {'spaceId': spaceIdOrAlias},
+              ),
+            ),
+          ],
         ),
       if (spaces.otherRelations.isNotEmpty)
-        SliverGrid.builder(
+        ListView.builder(
           itemCount: spaces.otherRelations.length,
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 4.0,
-            mainAxisExtent: 100,
-          ),
+          shrinkWrap: true,
           itemBuilder: (context, index) {
             final space = spaces.otherRelations[index];
             return SpaceCard(
@@ -326,7 +307,11 @@ class RelatedSpaces extends StatelessWidget {
     ];
 
     if (items.isNotEmpty) {
-      return SliverMainAxisGroup(slivers: items);
+      return SingleChildScrollView(
+        child: Column(
+          children: items,
+        ),
+      );
     } else {
       return fallback;
     }


### PR DESCRIPTION
Due to bad usage of `Slivers`, there were plenty of errors on the view part of the related-spaces classes. 

We really need to optimise code of related-spaces classes. But it was bit time taking so to quick fixed the white screen issue, I have removed `Slivers` from the affected class.

Reference Video:


https://github.com/acterglobal/a3/assets/51526480/b7d510f2-cb8b-4fe5-99c9-5becd732155e


fixes,
https://github.com/acterglobal/a3-meta/issues/152


Side notes:
- There were some `SliverGrid` need to remove for which will show single item on desktop view instead of grid.
- Need to optimise code of related-spaces to get out of this type of errors.