### PR TITLE
Fix ios 15 security platform exception

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -178,6 +178,7 @@ dependencies = [
     "ios-aarch64-apple-ios-sim",
     "ios-aarch64-apple-ios-sim-release",
     "ios-x86_64-apple-ios",
+    "ios-x86_64-apple-ios-release",
     "post-ios-sim",
     "make-ios-swift-sim",
 ]

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -308,7 +308,18 @@ class ActerSdk {
       await storage.read(key: _sessionKey);
     }
     _log.info('Secure Store: attempting to check if $_sessionKey exists');
-    final sessionsStr = await storage.read(key: _sessionKey);
+    String? sessionsStr;
+    try {
+      sessionsStr = await storage.read(key: _sessionKey);
+    } on PlatformException catch (error, stack) {
+      if (error.code == '-25300') {
+      _log.severe('Ignoring read failure for missing key $_sessionKey');
+      } else  {
+        _log.severe('Ignoring read failure of session key $_sessionKey', error, stack);
+      }
+    } catch (error, stack) {
+      _log.severe('Ignoring read failure of session key $_sessionKey', error, stack);
+    }
 
     if (sessionsStr == null) {
       _log.info('Secure Store: session key not found, checking for migration');


### PR DESCRIPTION
Reported in several instances, I was finally able to reproduce this error with the iOS simulator running _ios 15_ (which isn't supported anymore by Apple, but let's not go there...): PlatformException with a Security-Problem on first and all subsequent starts.

This is due to a bug in return handling of [secure storage](https://github.com/mogol/flutter_secure_storage/pull/662) that doesn't properly handle the iOS15 behavior of raising an exception in case a key isn't found. This PR fixes that by wrapping the read failure, logging it and continue as if the reading went to `null` (so no open sessions). This fixes it on my iOS.

Additionally make `cargo make --profile release ios-sim` work.
