### PR TITLE
Chat multi-media improvements

### DIFF
--- a/app/lib/common/widgets/acter_video_player.dart
+++ b/app/lib/common/widgets/acter_video_player.dart
@@ -61,24 +61,14 @@ class _ActerVideoPlayerState extends State<ActerVideoPlayer> {
       return Container();
     }
 
-    final Size screenSize = MediaQuery.of(context).size;
-    final double aspectRatio = _controller.value.aspectRatio;
-
     return AspectRatio(
-      aspectRatio: aspectRatio,
-      child: FittedBox(
-        fit: BoxFit.cover,
-        child: SizedBox(
-          width: screenSize.width,
-          height: screenSize.height,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              VideoPlayer(_controller),
-              controlsOverlay(),
-            ],
-          ),
-        ),
+      aspectRatio: _controller.value.aspectRatio,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          VideoPlayer(_controller),
+          controlsOverlay(),
+        ],
       ),
     );
   }

--- a/app/lib/common/widgets/image_dialog.dart
+++ b/app/lib/common/widgets/image_dialog.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
+import 'package:acter/common/themes/app_theme.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:zoom_hover_pinch_image/zoom_hover_pinch_image.dart';
 
 class ImageDialog extends ConsumerWidget {
   final String title;
@@ -16,11 +18,13 @@ class ImageDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
     return Dialog(
       insetPadding: EdgeInsets.zero,
       child: Container(
-        height: MediaQuery.of(context).size.height,
-        width: MediaQuery.of(context).size.width,
+        height: height,
+        width: width,
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
@@ -31,6 +35,8 @@ class ImageDialog extends ConsumerWidget {
                   child: Text(
                     title,
                     style: Theme.of(context).textTheme.titleSmall,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 IconButton(
@@ -47,32 +53,38 @@ class ImageDialog extends ConsumerWidget {
             ),
             const SizedBox(height: 15),
             Expanded(
-              child: Image.file(
-                imageFile,
-                frameBuilder: (
-                  BuildContext context,
-                  Widget child,
-                  int? frame,
-                  bool wasSynchronouslyLoaded,
-                ) {
-                  if (wasSynchronouslyLoaded) {
-                    return child;
-                  }
-                  return AnimatedOpacity(
-                    opacity: frame == null ? 0 : 1,
-                    duration: const Duration(seconds: 1),
-                    curve: Curves.easeOut,
-                    child: child,
-                  );
-                },
-                errorBuilder: (
-                  BuildContext context,
-                  Object url,
-                  StackTrace? error,
-                ) {
-                  return Text(L10n.of(context).couldNotLoadImage(error.toString()));
-                },
-                fit: BoxFit.fitWidth,
+              child: Zoom(
+                clipBehavior: false,
+                width: isDesktop ? width / 3 : width,
+                child: Image.file(
+                  imageFile,
+                  frameBuilder: (
+                    BuildContext context,
+                    Widget child,
+                    int? frame,
+                    bool wasSynchronouslyLoaded,
+                  ) {
+                    if (wasSynchronouslyLoaded) {
+                      return child;
+                    }
+                    return AnimatedOpacity(
+                      opacity: frame == null ? 0 : 1,
+                      duration: const Duration(seconds: 1),
+                      curve: Curves.easeOut,
+                      child: child,
+                    );
+                  },
+                  errorBuilder: (
+                    BuildContext context,
+                    Object url,
+                    StackTrace? error,
+                  ) {
+                    return Text(
+                      L10n.of(context).couldNotLoadImage(error.toString()),
+                    );
+                  },
+                  fit: BoxFit.fitWidth,
+                ),
               ),
             ),
           ],

--- a/app/lib/common/widgets/video_dialog.dart
+++ b/app/lib/common/widgets/video_dialog.dart
@@ -30,6 +30,8 @@ class VideoDialog extends StatelessWidget {
                   child: Text(
                     title,
                     style: Theme.of(context).textTheme.titleSmall,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 IconButton(
@@ -45,9 +47,7 @@ class VideoDialog extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 15),
-            Expanded(
-              child: Center(child: ActerVideoPlayer(videoFile: videoFile)),
-            ),
+            Expanded(child: ActerVideoPlayer(videoFile: videoFile)),
           ],
         ),
       ),

--- a/app/lib/features/chat/models/media_chat_state/media_chat_state.dart
+++ b/app/lib/features/chat/models/media_chat_state/media_chat_state.dart
@@ -32,6 +32,7 @@ class MediaChatState with _$MediaChatState {
     @Default(MediaChatLoadingState.loading())
     MediaChatLoadingState mediaChatLoadingState,
     File? mediaFile,
+    File? videoThumbnailFile,
     @Default(false) bool isDownloading,
   }) = _MediaChatState;
 }

--- a/app/lib/features/chat/models/media_chat_state/media_chat_state.freezed.dart
+++ b/app/lib/features/chat/models/media_chat_state/media_chat_state.freezed.dart
@@ -12,7 +12,7 @@ part of 'media_chat_state.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$MediaChatLoadingState {
@@ -608,6 +608,7 @@ mixin _$MediaChatState {
   MediaChatLoadingState get mediaChatLoadingState =>
       throw _privateConstructorUsedError;
   File? get mediaFile => throw _privateConstructorUsedError;
+  File? get videoThumbnailFile => throw _privateConstructorUsedError;
   bool get isDownloading => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -624,6 +625,7 @@ abstract class $MediaChatStateCopyWith<$Res> {
   $Res call(
       {MediaChatLoadingState mediaChatLoadingState,
       File? mediaFile,
+      File? videoThumbnailFile,
       bool isDownloading});
 
   $MediaChatLoadingStateCopyWith<$Res> get mediaChatLoadingState;
@@ -644,6 +646,7 @@ class _$MediaChatStateCopyWithImpl<$Res, $Val extends MediaChatState>
   $Res call({
     Object? mediaChatLoadingState = null,
     Object? mediaFile = freezed,
+    Object? videoThumbnailFile = freezed,
     Object? isDownloading = null,
   }) {
     return _then(_value.copyWith(
@@ -654,6 +657,10 @@ class _$MediaChatStateCopyWithImpl<$Res, $Val extends MediaChatState>
       mediaFile: freezed == mediaFile
           ? _value.mediaFile
           : mediaFile // ignore: cast_nullable_to_non_nullable
+              as File?,
+      videoThumbnailFile: freezed == videoThumbnailFile
+          ? _value.videoThumbnailFile
+          : videoThumbnailFile // ignore: cast_nullable_to_non_nullable
               as File?,
       isDownloading: null == isDownloading
           ? _value.isDownloading
@@ -683,6 +690,7 @@ abstract class _$$MediaChatStateImplCopyWith<$Res>
   $Res call(
       {MediaChatLoadingState mediaChatLoadingState,
       File? mediaFile,
+      File? videoThumbnailFile,
       bool isDownloading});
 
   @override
@@ -702,6 +710,7 @@ class __$$MediaChatStateImplCopyWithImpl<$Res>
   $Res call({
     Object? mediaChatLoadingState = null,
     Object? mediaFile = freezed,
+    Object? videoThumbnailFile = freezed,
     Object? isDownloading = null,
   }) {
     return _then(_$MediaChatStateImpl(
@@ -712,6 +721,10 @@ class __$$MediaChatStateImplCopyWithImpl<$Res>
       mediaFile: freezed == mediaFile
           ? _value.mediaFile
           : mediaFile // ignore: cast_nullable_to_non_nullable
+              as File?,
+      videoThumbnailFile: freezed == videoThumbnailFile
+          ? _value.videoThumbnailFile
+          : videoThumbnailFile // ignore: cast_nullable_to_non_nullable
               as File?,
       isDownloading: null == isDownloading
           ? _value.isDownloading
@@ -727,6 +740,7 @@ class _$MediaChatStateImpl implements _MediaChatState {
   const _$MediaChatStateImpl(
       {this.mediaChatLoadingState = const MediaChatLoadingState.loading(),
       this.mediaFile,
+      this.videoThumbnailFile,
       this.isDownloading = false});
 
   @override
@@ -735,12 +749,14 @@ class _$MediaChatStateImpl implements _MediaChatState {
   @override
   final File? mediaFile;
   @override
+  final File? videoThumbnailFile;
+  @override
   @JsonKey()
   final bool isDownloading;
 
   @override
   String toString() {
-    return 'MediaChatState(mediaChatLoadingState: $mediaChatLoadingState, mediaFile: $mediaFile, isDownloading: $isDownloading)';
+    return 'MediaChatState(mediaChatLoadingState: $mediaChatLoadingState, mediaFile: $mediaFile, videoThumbnailFile: $videoThumbnailFile, isDownloading: $isDownloading)';
   }
 
   @override
@@ -752,13 +768,15 @@ class _$MediaChatStateImpl implements _MediaChatState {
                 other.mediaChatLoadingState == mediaChatLoadingState) &&
             (identical(other.mediaFile, mediaFile) ||
                 other.mediaFile == mediaFile) &&
+            (identical(other.videoThumbnailFile, videoThumbnailFile) ||
+                other.videoThumbnailFile == videoThumbnailFile) &&
             (identical(other.isDownloading, isDownloading) ||
                 other.isDownloading == isDownloading));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, mediaChatLoadingState, mediaFile, isDownloading);
+  int get hashCode => Object.hash(runtimeType, mediaChatLoadingState, mediaFile,
+      videoThumbnailFile, isDownloading);
 
   @JsonKey(ignore: true)
   @override
@@ -772,12 +790,15 @@ abstract class _MediaChatState implements MediaChatState {
   const factory _MediaChatState(
       {final MediaChatLoadingState mediaChatLoadingState,
       final File? mediaFile,
+      final File? videoThumbnailFile,
       final bool isDownloading}) = _$MediaChatStateImpl;
 
   @override
   MediaChatLoadingState get mediaChatLoadingState;
   @override
   File? get mediaFile;
+  @override
+  File? get videoThumbnailFile;
   @override
   bool get isDownloading;
   @override

--- a/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
@@ -100,6 +100,9 @@ class MediaChatNotifier extends StateNotifier<MediaChatState> {
     }
   }
 
+  //FIXME : This is temporarily solution for media thumb management which lead to security issue.
+  // Reference https://github.com/acterglobal/a3/issues/1586
+  // Reference https://github.com/acterglobal/a3/issues/1250
   static Future<File?> getThumbnailData(String mediaPath) async {
     try {
       final tempDir = await getTemporaryDirectory();

--- a/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
@@ -5,9 +5,11 @@ import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/features/chat/models/media_chat_state/media_chat_state.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:fc_native_video_thumbnail/fc_native_video_thumbnail.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 final _log = Logger('a3::chat::media_chat_notifier');
 
@@ -33,8 +35,10 @@ class MediaChatNotifier extends StateNotifier<MediaChatState> {
         //Get media path if already downloaded
         final mediaPath = await _convo!.mediaPath(messageInfo.messageId, false);
         if (mediaPath.text() != null) {
+          final videoThumbnailFile = await getThumbnailData(mediaPath.text()!);
           state = state.copyWith(
             mediaFile: File(mediaPath.text()!),
+            videoThumbnailFile: videoThumbnailFile,
             mediaChatLoadingState: const MediaChatLoadingState.loaded(),
           );
         } else {
@@ -77,8 +81,10 @@ class MediaChatNotifier extends StateNotifier<MediaChatState> {
         );
         String? mediaPath = result.text();
         if (mediaPath != null) {
+          final videoThumbnailFile = await getThumbnailData(mediaPath);
           state = state.copyWith(
             mediaFile: File(mediaPath),
+            videoThumbnailFile: videoThumbnailFile,
             isDownloading: false,
           );
         }
@@ -92,5 +98,37 @@ class MediaChatNotifier extends StateNotifier<MediaChatState> {
         );
       }
     }
+  }
+
+  static Future<File?> getThumbnailData(String mediaPath) async {
+    try {
+      final tempDir = await getTemporaryDirectory();
+      final videoName = mediaPath.split('/').last.split('.').first;
+      final destPath = p.join(tempDir.path, '$videoName.jpg');
+      final destFile = File(destPath);
+
+      if (await destFile.exists()) {
+        return destFile;
+      }
+
+      final thumbnailGenerated =
+          await FcNativeVideoThumbnail().getVideoThumbnail(
+        srcFile: mediaPath,
+        destFile: destPath,
+        width: 300,
+        height: 300,
+        keepAspectRatio: true,
+        format: 'jpeg',
+        quality: 90,
+      );
+
+      if (thumbnailGenerated) {
+        return destFile;
+      }
+    } catch (err, s) {
+      // Handle platform errors.
+      _log.severe('Error', err, s);
+    }
+    return null;
   }
 }

--- a/app/lib/features/chat/widgets/image_message_builder.dart
+++ b/app/lib/features/chat/widgets/image_message_builder.dart
@@ -113,7 +113,6 @@ class ImageMessageBuilder extends ConsumerWidget {
   }
 
   Widget imageUI(BuildContext context, MediaChatState mediaState) {
-    final size = MediaQuery.of(context).size;
     return InkWell(
       onTap: () {
         showAdaptiveDialog(
@@ -131,9 +130,9 @@ class ImageMessageBuilder extends ConsumerWidget {
             ? BorderRadius.circular(6)
             : BorderRadius.circular(15),
         child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: isReplyContent ? size.height * 0.2 : size.height * 0.3,
-            maxWidth: isReplyContent ? size.width * 0.2 : size.width * 0.3,
+          constraints: const BoxConstraints(
+            maxWidth: 300,
+            maxHeight: 300,
           ),
           child: Image.file(
             mediaState.mediaFile!,

--- a/app/lib/features/chat/widgets/image_message_builder.dart
+++ b/app/lib/features/chat/widgets/image_message_builder.dart
@@ -113,6 +113,7 @@ class ImageMessageBuilder extends ConsumerWidget {
   }
 
   Widget imageUI(BuildContext context, MediaChatState mediaState) {
+    final size = MediaQuery.of(context).size;
     return InkWell(
       onTap: () {
         showAdaptiveDialog(
@@ -130,39 +131,43 @@ class ImageMessageBuilder extends ConsumerWidget {
             ? BorderRadius.circular(6)
             : BorderRadius.circular(15),
         child: ConstrainedBox(
-          constraints: const BoxConstraints(
-            maxWidth: 300,
-            maxHeight: 300,
+          constraints: BoxConstraints(
+            maxWidth: isReplyContent ? size.height * 0.2 : 300,
+            maxHeight: isReplyContent ? size.width * 0.2 : 300,
           ),
-          child: Image.file(
-            mediaState.mediaFile!,
-            frameBuilder: (
-              BuildContext context,
-              Widget child,
-              int? frame,
-              bool wasSynchronouslyLoaded,
-            ) {
-              if (wasSynchronouslyLoaded) {
-                return child;
-              }
-              return AnimatedOpacity(
-                opacity: frame == null ? 0 : 1,
-                duration: const Duration(seconds: 1),
-                curve: Curves.easeOut,
-                child: child,
-              );
-            },
-            errorBuilder: (
-              BuildContext context,
-              Object url,
-              StackTrace? error,
-            ) {
-              return Text(L10n.of(context).couldNotLoadImage(error.toString()));
-            },
-            fit: BoxFit.cover,
-          ),
+          child: imageFileView(context, mediaState),
         ),
       ),
+    );
+  }
+
+  Widget imageFileView(BuildContext context, MediaChatState mediaState) {
+    return Image.file(
+      mediaState.mediaFile!,
+      frameBuilder: (
+        BuildContext context,
+        Widget child,
+        int? frame,
+        bool wasSynchronouslyLoaded,
+      ) {
+        if (wasSynchronouslyLoaded) {
+          return child;
+        }
+        return AnimatedOpacity(
+          opacity: frame == null ? 0 : 1,
+          duration: const Duration(seconds: 1),
+          curve: Curves.easeOut,
+          child: child,
+        );
+      },
+      errorBuilder: (
+        BuildContext context,
+        Object url,
+        StackTrace? error,
+      ) {
+        return Text(L10n.of(context).couldNotLoadImage(error.toString()));
+      },
+      fit: BoxFit.cover,
     );
   }
 }

--- a/app/lib/features/chat/widgets/video_message_builder.dart
+++ b/app/lib/features/chat/widgets/video_message_builder.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/models/types.dart';
-import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/common/widgets/video_dialog.dart';
 import 'package:acter/features/chat/models/media_chat_state/media_chat_state.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
@@ -8,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 class VideoMessageBuilder extends ConsumerWidget {
   final types.VideoMessage message;
@@ -116,27 +116,72 @@ class VideoMessageBuilder extends ConsumerWidget {
     BuildContext context,
     MediaChatState mediaState,
   ) {
-    return ClipRRect(
-      borderRadius:
-          isReplyContent ? BorderRadius.circular(6) : BorderRadius.circular(15),
-      child: Container(
-        constraints: const BoxConstraints(
-          maxWidth: 300,
-          maxHeight: 300,
-        ),
-        child: ActerVideoPlayer(
-          videoFile: mediaState.mediaFile!,
-          onTapFullScreen: () {
-            showAdaptiveDialog(
-              context: context,
-              barrierDismissible: false,
-              useRootNavigator: false,
-              builder: (ctx) => VideoDialog(
-                title: message.name,
-                videoFile: mediaState.mediaFile!,
+    return InkWell(
+      onTap: () {
+        showAdaptiveDialog(
+          context: context,
+          barrierDismissible: false,
+          useRootNavigator: false,
+          builder: (ctx) => VideoDialog(
+            title: message.name,
+            videoFile: mediaState.mediaFile!,
+          ),
+        );
+      },
+      child: ClipRRect(
+        borderRadius: isReplyContent
+            ? BorderRadius.circular(6)
+            : BorderRadius.circular(15),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: 300,
+            maxHeight: 300,
+          ),
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Image.file(
+                mediaState.videoThumbnailFile!,
+                frameBuilder: (
+                  BuildContext context,
+                  Widget child,
+                  int? frame,
+                  bool wasSynchronouslyLoaded,
+                ) {
+                  if (wasSynchronouslyLoaded) {
+                    return child;
+                  }
+                  return AnimatedOpacity(
+                    opacity: frame == null ? 0 : 1,
+                    duration: const Duration(seconds: 1),
+                    curve: Curves.easeOut,
+                    child: child,
+                  );
+                },
+                errorBuilder: (
+                  BuildContext context,
+                  Object url,
+                  StackTrace? error,
+                ) {
+                  return Text(
+                    L10n.of(context).couldNotLoadImage(error.toString()),
+                  );
+                },
+                fit: BoxFit.cover,
               ),
-            );
-          },
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.black26,
+                  borderRadius: BorderRadius.circular(30.0),
+                ),
+                child: Icon(
+                  Icons.play_arrow,
+                  size: 50.0,
+                  semanticLabel: L10n.of(context).play,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/chat/widgets/video_message_builder.dart
+++ b/app/lib/features/chat/widgets/video_message_builder.dart
@@ -119,8 +119,11 @@ class VideoMessageBuilder extends ConsumerWidget {
     return ClipRRect(
       borderRadius:
           isReplyContent ? BorderRadius.circular(6) : BorderRadius.circular(15),
-      child: SizedBox(
-        height: 150,
+      child: Container(
+        constraints: const BoxConstraints(
+          maxWidth: 300,
+          maxHeight: 300,
+        ),
         child: ActerVideoPlayer(
           videoFile: mediaState.mediaFile!,
           onTapFullScreen: () {

--- a/app/lib/features/chat/widgets/video_message_builder.dart
+++ b/app/lib/features/chat/widgets/video_message_builder.dart
@@ -140,35 +140,7 @@ class VideoMessageBuilder extends ConsumerWidget {
           child: Stack(
             alignment: Alignment.center,
             children: [
-              Image.file(
-                mediaState.videoThumbnailFile!,
-                frameBuilder: (
-                  BuildContext context,
-                  Widget child,
-                  int? frame,
-                  bool wasSynchronouslyLoaded,
-                ) {
-                  if (wasSynchronouslyLoaded) {
-                    return child;
-                  }
-                  return AnimatedOpacity(
-                    opacity: frame == null ? 0 : 1,
-                    duration: const Duration(seconds: 1),
-                    curve: Curves.easeOut,
-                    child: child,
-                  );
-                },
-                errorBuilder: (
-                  BuildContext context,
-                  Object url,
-                  StackTrace? error,
-                ) {
-                  return Text(
-                    L10n.of(context).couldNotLoadImage(error.toString()),
-                  );
-                },
-                fit: BoxFit.cover,
-              ),
+              videoThumbFileView(context, mediaState),
               Container(
                 decoration: BoxDecoration(
                   color: Colors.black26,
@@ -184,6 +156,38 @@ class VideoMessageBuilder extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+
+  Widget videoThumbFileView(BuildContext context, MediaChatState mediaState) {
+    return Image.file(
+      mediaState.videoThumbnailFile!,
+      frameBuilder: (
+        BuildContext context,
+        Widget child,
+        int? frame,
+        bool wasSynchronouslyLoaded,
+      ) {
+        if (wasSynchronouslyLoaded) {
+          return child;
+        }
+        return AnimatedOpacity(
+          opacity: frame == null ? 0 : 1,
+          duration: const Duration(seconds: 1),
+          curve: Curves.easeOut,
+          child: child,
+        );
+      },
+      errorBuilder: (
+        BuildContext context,
+        Object url,
+        StackTrace? error,
+      ) {
+        return Text(
+          L10n.of(context).couldNotLoadImage(error.toString()),
+        );
+      },
+      fit: BoxFit.cover,
     );
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -126,6 +126,7 @@ dependencies:
   stack_trace: ^1.11.1
   tutorial_coach_mark: ^1.2.11
   flutter_typeahead: ^5.2.0
+  zoom_hover_pinch_image: ^1.0.3
 
 # FIXME keep until a new version has been published
 dependency_overrides:


### PR DESCRIPTION
This PR contains serval improvements in chat multi-media.

1) Video chat message:
- Now chat message will display video thumb image instead of entire video player in chat message itself which was leading to performance issue sometimes.
- Now we will have video message view with relevant aspect ratio.


https://github.com/acterglobal/a3/assets/51526480/01d650a1-16d5-4c9e-8606-a0ec20e9f354



2) Full screen video message:
- Full screen video message will utilise entire screen based on the aspect ratio.
- Fixes minor title text overlapping issue.


https://github.com/acterglobal/a3/assets/51526480/b6ea62c1-9683-4b1a-9dd3-c662846d2c68



3) Support of zoom image:
- Now on the full screen image view, user can zoom in and out the image.


https://github.com/acterglobal/a3/assets/51526480/c68a5504-989c-4809-90ea-67142dcd74ca


fixes, #1416 
