### PR TITLE
Make space & chat selectors searchable, fix several issues along the way

### DIFF
--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -9,9 +9,6 @@ import 'package:riverpod/riverpod.dart';
 
 final _log = Logger('a3::common::chat');
 
-final chatSearchValueProvider =
-    StateProvider.autoDispose<String?>((ref) => null);
-
 /// Provider the profile data of a the given space, keeps up to date with underlying client
 final convoProvider =
     AsyncNotifierProvider.family<AsyncConvoNotifier, Convo?, Convo>(

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -89,6 +89,9 @@ final briefRoomItemWithMembershipProvider =
   );
 });
 
+final roomSearchValueProvider =
+    StateProvider.autoDispose<String?>((ref) => null);
+
 typedef _RoomIdAndName = (String, String?);
 
 final _briefGroupChatsWithName =
@@ -114,7 +117,7 @@ final roomSearchedChatsProvider =
     FutureProvider.autoDispose<List<String>>((ref) async {
   final allRoomList = await ref.watch(_briefGroupChatsWithName.future);
   final foundRooms = List<String>.empty(growable: true);
-  final searchValue = ref.watch(chatSearchValueProvider);
+  final searchValue = ref.watch(roomSearchValueProvider);
 
   if (searchValue == null || searchValue.isEmpty) {
     return allRoomList.map((i) {

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -47,9 +47,14 @@ final roomProfileDataProvider =
 
   final profile = room.getProfile();
   OptionString displayName = await profile.getDisplayName();
-  final avatar = (await profile.getAvatar(null)).data();
-  _log.info('$roomId : hasAvatar: ${avatar != null}');
-  return ProfileData(displayName.text(), avatar);
+  try {
+    final avatar = (await profile.getAvatar(null)).data();
+    _log.info('$roomId : hasAvatar: ${avatar != null}');
+    return ProfileData(displayName.text(), avatar);
+  } catch (error) {
+    _log.severe('Loading avatar for $roomId failed', error);
+    return ProfileData(displayName.text(), null);
+  }
 });
 
 /// Get the members invited of a given roomId the user knows about. Errors

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -162,12 +162,9 @@ final _spaceIdAndNames =
 
 typedef _SpaceIdAndName = (String, String?);
 
-final spaceSearchValueProvider =
-    StateProvider.autoDispose<String?>((ref) => null);
-
 final searchedSpacesProvider =
     FutureProvider.autoDispose<List<String>>((ref) async {
-  final searchValue = ref.watch(spaceSearchValueProvider);
+  final searchValue = ref.watch(roomSearchValueProvider);
   final allSpaces = await ref.watch(_spaceIdAndNames.future);
 
   if (searchValue == null || searchValue.isEmpty) {

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -81,23 +81,7 @@ final selectedSpaceDetailsProvider =
     return null;
   }
 
-  final spaces = await ref.watch(briefSpaceItemsProviderWithMembership.future);
-  return spaces.firstWhere((element) => element.roomId == selectedSpaceId);
-});
-
-// gives current context parent space id
-final parentSpaceProvider = StateProvider<String?>((ref) => null);
-
-/// gives current context parent space details based on id, will throw null if id is null
-final parentSpaceDetailsProvider =
-    FutureProvider.autoDispose<SpaceItem?>((ref) async {
-  final parentSpaceId = ref.watch(parentSpaceProvider);
-  if (parentSpaceId == null) {
-    return null;
-  }
-
-  final spaces = await ref.watch(briefSpaceItemsProviderWithMembership.future);
-  return spaces.firstWhere((element) => element.roomId == parentSpaceId);
+  return await ref.watch(briefSpaceItemProvider(selectedSpaceId).future);
 });
 
 class SpaceItem {
@@ -161,46 +145,49 @@ final hasSpaceWithPermissionProvider =
 /// Get the list of known spaces as SpaceItem filled in brief form
 /// (only spaceProfileData, no activeMembers) but with user membership attached.
 /// Stays up to date with underlying client info
-final briefSpaceItemsProviderWithMembership =
-    FutureProvider.autoDispose<List<SpaceItem>>((ref) async {
+final _spaceIdAndNames =
+    FutureProvider.autoDispose<List<_SpaceIdAndName>>((ref) async {
   final spaces = ref.watch(spacesProvider);
-  List<SpaceItem> items = [];
-  for (final element in spaces) {
-    final profileData =
-        await ref.watch(spaceProfileDataProvider(element).future);
-    final item = SpaceItem(
-      roomId: element.getRoomIdStr(),
-      membership: await element.getMyMembership(),
-      activeMembers: [],
-      spaceProfileData: profileData,
+  List<_SpaceIdAndName> items = [];
+  for (final space in spaces) {
+    items.add(
+      (
+        space.getRoomIdStr(),
+        (await space.getProfile().getDisplayName()).text()
+      ),
     );
-    items.add(item);
   }
   return items;
 });
+
+typedef _SpaceIdAndName = (String, String?);
 
 final spaceSearchValueProvider =
     StateProvider.autoDispose<String?>((ref) => null);
 
 final searchedSpacesProvider =
-    FutureProvider.autoDispose<List<SpaceItem>>((ref) async {
-  final allSpaces =
-      await ref.watch(briefSpaceItemsProviderWithMembership.future);
+    FutureProvider.autoDispose<List<String>>((ref) async {
   final searchValue = ref.watch(spaceSearchValueProvider);
+  final allSpaces = await ref.watch(_spaceIdAndNames.future);
+
   if (searchValue == null || searchValue.isEmpty) {
-    return allSpaces;
+    return allSpaces
+        .map(
+          (e) => e.$1,
+        )
+        .toList();
   }
 
   final searchTerm = searchValue.toLowerCase();
 
-  final foundSpaces = List<SpaceItem>.empty(growable: true);
+  final foundSpaces = List<String>.empty(growable: true);
 
-  for (final space in allSpaces) {
-    final sp = await ref.watch(spaceProvider(space.roomId).future);
-    final profileData = await ref.watch(spaceProfileDataProvider(sp).future);
-    final name = profileData.displayName ?? space.roomId;
-    if (name.toLowerCase().contains(searchTerm)) {
-      foundSpaces.add(space);
+  for (final item in allSpaces) {
+    if (item.$1.contains(searchTerm) ||
+        (item.$2 != null
+            ? item.$2!.toLowerCase().contains(searchTerm)
+            : false)) {
+      foundSpaces.add(item.$1);
     }
   }
 
@@ -211,7 +198,7 @@ final searchedSpacesProvider =
 /// (only spaceProfileData, no activeMembers). Stays up to date with underlying
 /// client info
 final briefSpaceItemProvider =
-    FutureProvider.autoDispose.family<SpaceItem?, String>((ref, spaceId) async {
+    FutureProvider.autoDispose.family<SpaceItem, String>((ref, spaceId) async {
   final space = await ref.watch(spaceProvider(spaceId).future);
   final profileData = await ref.watch(spaceProfileDataProvider(space).future);
   return SpaceItem(
@@ -220,49 +207,6 @@ final briefSpaceItemProvider =
     activeMembers: [],
     spaceProfileData: profileData,
   );
-});
-
-/// Get the SpaceItem of the given sapceId filled in brief form
-/// (only spaceProfileData, no activeMembers) with Membership.
-/// Stays up to date with underlying client info
-final briefSpaceItemWithMembershipProvider =
-    FutureProvider.autoDispose.family<SpaceItem, String>((ref, spaceId) async {
-  final space = await ref.watch(spaceProvider(spaceId).future);
-  final profileData = await ref.watch(spaceProfileDataProvider(space).future);
-  return SpaceItem(
-    roomId: space.getRoomIdStr(),
-    space: space,
-    membership: space.isJoined() ? await space.getMyMembership() : null,
-    activeMembers: [],
-    spaceProfileData: profileData,
-  );
-});
-
-/// Fetch the SpaceItems of spaces the user knows about, including profileData,
-/// and activeMembers (but without Membership). Stays up to date with underlying
-/// client info.
-final spaceItemsProvider =
-    FutureProvider.autoDispose<List<SpaceItem>>((ref) async {
-  final spaces = ref.watch(spacesProvider);
-  List<SpaceItem> items = [];
-  for (final element in spaces) {
-    final profileData = await ref.watch(
-      spaceProfileDataProvider(element).future,
-    );
-    late List<Member> members;
-    if (element.isJoined()) {
-      members = (await element.activeMembers()).toList();
-    } else {
-      members = [];
-    }
-    final item = SpaceItem(
-      roomId: element.getRoomIdStr(),
-      activeMembers: members,
-      spaceProfileData: profileData,
-    );
-    items.add(item);
-  }
-  return items;
 });
 
 /// Get the members invited of a given roomId the user knows about. Errors

--- a/app/lib/common/widgets/chat/chat_selector_drawer.dart
+++ b/app/lib/common/widgets/chat/chat_selector_drawer.dart
@@ -1,10 +1,6 @@
-import 'package:acter/common/providers/chat_providers.dart';
-
-import 'package:acter/common/widgets/room/brief_room_list_entry.dart';
+import 'package:acter/common/widgets/room/select_room_drawer.dart';
 import 'package:acter_avatar/acter_avatar.dart';
-import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 const Key selectChatDrawerKey = Key('chat-widgets-select-chat-drawer');
@@ -21,56 +17,13 @@ Future<String?> selectChatDrawer({
     enableDrag: true,
     context: context,
     isDismissible: true,
-    builder: (context) => Consumer(
-      builder: (context, ref, child) {
-        final chats = ref.watch(chatsProvider);
-        return Padding(
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            key: key,
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Row(
-                children: [
-                  Expanded(
-                    child: title ?? Text(L10n.of(context).selectChat),
-                  ),
-                  OutlinedButton.icon(
-                    icon: const Icon(Atlas.minus_circle_thin),
-                    onPressed: () {
-                      Navigator.pop(context, '');
-                    },
-                    label: Text(L10n.of(context).clear),
-                  ),
-                ],
-              ),
-              Flexible(
-                child: chats.isEmpty
-                    ? Text(L10n.of(context).noChatsFound)
-                    : ListView.builder(
-                        padding: const EdgeInsets.all(8),
-                        itemCount: chats.length,
-                        itemBuilder: (context, index) {
-                          final convo = chats[index];
-                          return BriefRoomEntry(
-                            roomId: convo.getRoomIdStr(),
-                            avatarDisplayMode: DisplayMode.GroupChat,
-                            keyPrefix: 'select-chat',
-                            selectedValue: currentChatId,
-                            canCheck: canCheck,
-                            onSelect: (roomId) {
-                              Navigator.pop(context, roomId);
-                            },
-                          );
-                        },
-                      ),
-              ),
-            ],
-          ),
-        );
-      },
+    builder: (context) => SelectRoomDrawer(
+      key: key,
+      canCheck: canCheck,
+      title: title ?? Text(L10n.of(context).selectChat),
+      avatarDisplayMode: DisplayMode.GroupChat,
+      keyPrefix: 'select-chat',
+      roomType: RoomType.groupChat,
     ),
   );
   if (selected == null) {

--- a/app/lib/common/widgets/chat/chat_selector_drawer.dart
+++ b/app/lib/common/widgets/chat/chat_selector_drawer.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/widgets/room/select_room_drawer.dart';
-import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -21,7 +20,6 @@ Future<String?> selectChatDrawer({
       key: key,
       canCheck: canCheck,
       title: title ?? Text(L10n.of(context).selectChat),
-      avatarDisplayMode: DisplayMode.GroupChat,
       keyPrefix: 'select-chat',
       roomType: RoomType.groupChat,
     ),

--- a/app/lib/common/widgets/room/brief_room_list_entry.dart
+++ b/app/lib/common/widgets/room/brief_room_list_entry.dart
@@ -9,16 +9,20 @@ class BriefRoomEntry extends ConsumerWidget {
   final String? selectedValue;
   final String canCheck;
   final String keyPrefix;
-  final Function(String) onSelect;
+  final Function(String)? onSelect;
   final DisplayMode avatarDisplayMode;
+  final Widget Function(bool)? trailingBuilder;
+  final Widget? subtitle;
   const BriefRoomEntry({
     super.key,
     required this.roomId,
     required this.canCheck,
-    required this.onSelect,
+    this.onSelect,
     required this.avatarDisplayMode,
     this.keyPrefix = 'brief-room',
     this.selectedValue,
+    this.trailingBuilder,
+    this.subtitle,
   });
 
   @override
@@ -28,6 +32,12 @@ class BriefRoomEntry extends ConsumerWidget {
       data: (roomData) => roomData.membership!.canString(canCheck),
       orElse: () => false,
     );
+    Widget? trailing;
+    if (trailingBuilder != null) {
+      trailing = trailingBuilder!(canLink);
+    } else if (selectedValue == roomId) {
+      trailing = const Icon(Icons.check_circle_outline);
+    }
     return ListTile(
       key: Key('$keyPrefix-$roomId'),
       enabled: canLink,
@@ -37,10 +47,9 @@ class BriefRoomEntry extends ConsumerWidget {
             Text(roomData.roomProfileData.displayName ?? roomId),
         orElse: () => Text(roomId),
       ),
-      trailing: selectedValue == roomId
-          ? const Icon(Icons.check_circle_outline)
-          : null,
-      onTap: canLink ? () => onSelect(roomId) : null,
+      subtitle: subtitle,
+      trailing: trailing,
+      onTap: canLink && onSelect != null ? () => onSelect!(roomId) : null,
     );
   }
 }

--- a/app/lib/common/widgets/room/select_room_drawer.dart
+++ b/app/lib/common/widgets/room/select_room_drawer.dart
@@ -21,7 +21,6 @@ class SelectRoomDrawer extends ConsumerStatefulWidget {
   final String? currentSpaceId;
   final Widget title;
   final String keyPrefix;
-  final DisplayMode avatarDisplayMode;
   final RoomType roomType;
 
   const SelectRoomDrawer({
@@ -31,12 +30,16 @@ class SelectRoomDrawer extends ConsumerStatefulWidget {
     required this.title,
     required this.roomType,
     required this.keyPrefix,
-    required this.avatarDisplayMode,
   });
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() =>
       _SelectRoomDrawerState();
+
+  DisplayMode get avatarDisplayMode => switch (roomType) {
+        RoomType.space => DisplayMode.Space,
+        RoomType.groupChat => DisplayMode.GroupChat
+      };
 }
 
 class _SelectRoomDrawerState extends ConsumerState<SelectRoomDrawer> {

--- a/app/lib/common/widgets/room/select_room_drawer.dart
+++ b/app/lib/common/widgets/room/select_room_drawer.dart
@@ -1,0 +1,187 @@
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+
+import 'package:acter/common/widgets/room/brief_room_list_entry.dart';
+import 'package:acter_avatar/acter_avatar.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+// ChildRoomType configures the sub child type of the `Spaces`
+enum RoomType {
+  groupChat,
+  space,
+}
+
+class SelectRoomDrawer extends ConsumerStatefulWidget {
+  final String canCheck;
+  final String? currentSpaceId;
+  final Widget title;
+  final String keyPrefix;
+  final DisplayMode avatarDisplayMode;
+  final RoomType roomType;
+
+  const SelectRoomDrawer({
+    super.key,
+    required this.canCheck,
+    this.currentSpaceId,
+    required this.title,
+    required this.roomType,
+    required this.keyPrefix,
+    required this.avatarDisplayMode,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _SelectRoomDrawerState();
+}
+
+class _SelectRoomDrawerState extends ConsumerState<SelectRoomDrawer> {
+  final TextEditingController searchTextController = TextEditingController();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // ensure we are synced up
+    searchTextController.text = ref.read(roomSearchValueProvider) ?? '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        key: widget.key,
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          title(context),
+          searchBar(context),
+          Flexible(
+            child: roomsList(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget title(BuildContext context) {
+    return AppBar(
+      backgroundColor: Colors.transparent,
+      automaticallyImplyLeading: false,
+      title: widget.title,
+      actions: [
+        TextButton.icon(
+          icon: const Icon(Atlas.minus_circle_thin),
+          onPressed: () {
+            Navigator.pop(context, '');
+          },
+          label: Text(L10n.of(context).clear),
+        ),
+      ],
+    );
+  }
+
+  Widget searchBar(BuildContext context) {
+    if (allRooms().length < 10) {
+      // small list, ignore
+      return const SizedBox.shrink();
+    }
+
+    final hasSearchTerm = (ref.read(roomSearchValueProvider) ?? '').isNotEmpty;
+
+    return SearchBar(
+      controller: searchTextController,
+      leading: const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Icon(Atlas.magnifying_glass),
+      ),
+      hintText: L10n.of(context).search,
+      trailing: hasSearchTerm
+          ? [
+              InkWell(
+                onTap: () {
+                  searchTextController.clear();
+                  ref.read(roomSearchValueProvider.notifier).state = '';
+                },
+                child: const Icon(Icons.clear),
+              ),
+            ]
+          : null,
+      onChanged: (value) {
+        ref.read(roomSearchValueProvider.notifier).state = value;
+      },
+    );
+  }
+
+  List<String> allRooms() {
+    return switch (widget.roomType) {
+      RoomType.space =>
+        ref.watch(spacesProvider).map((space) => space.getRoomIdStr()).toList(),
+      RoomType.groupChat => ref
+          .watch(chatsProvider.select((v) => v.where((d) => !d.isDm())))
+          .map((room) => room.getRoomIdStr())
+          .toList(),
+    };
+  }
+
+  Widget roomsList(BuildContext context) {
+    final searchValue = ref.watch(roomSearchValueProvider);
+    if (searchValue?.isNotEmpty == true) {
+      return searchedRoomsList(context);
+    }
+
+    return roomsListUI(allRooms());
+  }
+
+//Show space list based on the search term
+  Widget searchedRoomsList(BuildContext context) {
+    final searchedrooms = ref.watch(
+      switch (widget.roomType) {
+        RoomType.space => searchedSpacesProvider,
+        RoomType.groupChat => roomSearchedChatsProvider,
+      },
+    );
+
+    return searchedrooms.when(
+      data: (rooms) {
+        if (rooms.isEmpty) {
+          return Center(
+            heightFactor: 10,
+            child: Text(L10n.of(context).noChatsFoundMatchingYourSearchTerm),
+          );
+        }
+        return roomsListUI(rooms);
+      },
+      loading: () => const Center(
+        heightFactor: 10,
+        child: CircularProgressIndicator(),
+      ),
+      error: (e, s) => Center(child: Text(L10n.of(context).searchingFailed(e))),
+    );
+  }
+
+  Widget roomsListUI(List<String> rooms) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(8),
+      itemCount: rooms.length,
+      itemBuilder: (context, index) {
+        final roomId = rooms[index];
+        return BriefRoomEntry(
+          roomId: roomId,
+          avatarDisplayMode: widget.avatarDisplayMode,
+          keyPrefix: widget.keyPrefix,
+          selectedValue: current,
+          canCheck: widget.canCheck,
+          onSelect: (roomId) {
+            Navigator.pop(context, roomId);
+          },
+        );
+      },
+    );
+  }
+}

--- a/app/lib/common/widgets/spaces/space_selector_drawer.dart
+++ b/app/lib/common/widgets/spaces/space_selector_drawer.dart
@@ -1,163 +1,9 @@
-import 'package:acter/common/providers/space_providers.dart';
-
-import 'package:acter/common/widgets/room/brief_room_list_entry.dart';
+import 'package:acter/common/widgets/room/select_room_drawer.dart';
 import 'package:acter_avatar/acter_avatar.dart';
-import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 const Key selectSpaceDrawerKey = Key('space-widgets-select-space-drawer');
-
-class _SelectSpaceDrawer extends ConsumerStatefulWidget {
-  final String canCheck;
-  final String? currentSpaceId;
-  final Widget? title;
-  const _SelectSpaceDrawer({
-    super.key,
-    this.canCheck = 'CanLinkSpaces',
-    this.currentSpaceId,
-    this.title,
-  });
-
-  @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      __SelectSpaceDrawerState();
-}
-
-class __SelectSpaceDrawerState extends ConsumerState<_SelectSpaceDrawer> {
-  final TextEditingController searchTextController = TextEditingController();
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // ensure we are synced up
-    searchTextController.text = ref.read(spaceSearchValueProvider) ?? '';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(10),
-      child: Column(
-        key: widget.key,
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          title(context),
-          searchBar(context),
-          Flexible(
-            child: spacesList(context),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget title(BuildContext context) {
-    return AppBar(
-      backgroundColor: Colors.transparent,
-      automaticallyImplyLeading: false,
-      title: widget.title ?? Text(L10n.of(context).selectSpace),
-      actions: [
-        TextButton.icon(
-          icon: const Icon(Atlas.minus_circle_thin),
-          onPressed: () {
-            Navigator.pop(context, '');
-          },
-          label: Text(L10n.of(context).clear),
-        ),
-      ],
-    );
-  }
-
-  Widget searchBar(BuildContext context) {
-    final spaces = ref.watch(spacesProvider);
-    if (spaces.length < 10) {
-      // small list, ignore
-      return const SizedBox.shrink();
-    }
-
-    final hasSearchTerm = (ref.read(spaceSearchValueProvider) ?? '').isNotEmpty;
-
-    return SearchBar(
-      controller: searchTextController,
-      leading: const Padding(
-        padding: EdgeInsets.all(8.0),
-        child: Icon(Atlas.magnifying_glass),
-      ),
-      hintText: L10n.of(context).search,
-      trailing: hasSearchTerm
-          ? [
-              InkWell(
-                onTap: () {
-                  searchTextController.clear();
-                  ref.read(spaceSearchValueProvider.notifier).state = '';
-                },
-                child: const Icon(Icons.clear),
-              ),
-            ]
-          : null,
-      onChanged: (value) {
-        ref.read(spaceSearchValueProvider.notifier).state = value;
-      },
-    );
-  }
-
-  Widget spacesList(BuildContext context) {
-    final searchValue = ref.watch(spaceSearchValueProvider);
-    if (searchValue?.isNotEmpty == true) {
-      return searchedSpaceList(context);
-    }
-
-    final spaces =
-        ref.watch(spacesProvider).map((space) => space.getRoomIdStr()).toList();
-    return spaceListUI(spaces);
-  }
-
-//Show space list based on the search term
-  Widget searchedSpaceList(BuildContext context) {
-    final searchedSpaces = ref.watch(searchedSpacesProvider);
-    return searchedSpaces.when(
-      data: (spaces) {
-        if (spaces.isEmpty) {
-          return Center(
-            heightFactor: 10,
-            child: Text(L10n.of(context).noChatsFoundMatchingYourSearchTerm),
-          );
-        }
-        return spaceListUI(spaces);
-      },
-      loading: () => const Center(
-        heightFactor: 10,
-        child: CircularProgressIndicator(),
-      ),
-      error: (e, s) => Center(child: Text(L10n.of(context).searchingFailed(e))),
-    );
-  }
-
-  Widget spaceListUI(List<String> spaces) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(8),
-      itemCount: spaces.length,
-      itemBuilder: (context, index) {
-        final roomId = spaces[index];
-        return BriefRoomEntry(
-          roomId: roomId,
-          avatarDisplayMode: DisplayMode.Space,
-          keyPrefix: 'select-space',
-          selectedValue: current,
-          canCheck: widget.canCheck,
-          onSelect: (roomId) {
-            Navigator.pop(context, roomId);
-          },
-        );
-      },
-    );
-  }
-}
 
 Future<String?> selectSpaceDrawer({
   required BuildContext context,
@@ -171,11 +17,14 @@ Future<String?> selectSpaceDrawer({
     enableDrag: true,
     context: context,
     isDismissible: true,
-    builder: (context) => _SelectSpaceDrawer(
+    builder: (context) => SelectRoomDrawer(
       key: key,
       canCheck: canCheck,
       currentSpaceId: currentSpaceId,
-      title: title,
+      title: title ?? Text(L10n.of(context).selectSpace),
+      avatarDisplayMode: DisplayMode.Space,
+      keyPrefix: 'select-space',
+      roomType: RoomType.space,
     ),
   );
   if (selected == null) {

--- a/app/lib/common/widgets/spaces/space_selector_drawer.dart
+++ b/app/lib/common/widgets/spaces/space_selector_drawer.dart
@@ -10,6 +10,155 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 const Key selectSpaceDrawerKey = Key('space-widgets-select-space-drawer');
 
+class _SelectSpaceDrawer extends ConsumerStatefulWidget {
+  final String canCheck;
+  final String? currentSpaceId;
+  final Widget? title;
+  const _SelectSpaceDrawer({
+    super.key,
+    this.canCheck = 'CanLinkSpaces',
+    this.currentSpaceId,
+    this.title,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      __SelectSpaceDrawerState();
+}
+
+class __SelectSpaceDrawerState extends ConsumerState<_SelectSpaceDrawer> {
+  final TextEditingController searchTextController = TextEditingController();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // ensure we are synced up
+    searchTextController.text = ref.read(spaceSearchValueProvider) ?? '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        key: widget.key,
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          title(context),
+          searchBar(context),
+          Flexible(
+            child: spacesList(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget title(BuildContext context) {
+    return AppBar(
+      backgroundColor: Colors.transparent,
+      automaticallyImplyLeading: false,
+      title: widget.title ?? Text(L10n.of(context).selectSpace),
+      actions: [
+        TextButton.icon(
+          icon: const Icon(Atlas.minus_circle_thin),
+          onPressed: () {
+            Navigator.pop(context, '');
+          },
+          label: Text(L10n.of(context).clear),
+        ),
+      ],
+    );
+  }
+
+  Widget searchBar(BuildContext context) {
+    final spaces = ref.watch(spacesProvider);
+    if (spaces.length < 10) {
+      // small list, ignore
+      return const SizedBox.shrink();
+    }
+
+    final hasSearchTerm = (ref.read(spaceSearchValueProvider) ?? '').isNotEmpty;
+
+    return SearchBar(
+      controller: searchTextController,
+      leading: const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Icon(Atlas.magnifying_glass),
+      ),
+      hintText: L10n.of(context).search,
+      trailing: hasSearchTerm
+          ? [
+              InkWell(
+                onTap: () {
+                  searchTextController.clear();
+                  ref.read(spaceSearchValueProvider.notifier).state = '';
+                },
+                child: const Icon(Icons.clear),
+              ),
+            ]
+          : null,
+      onChanged: (value) {
+        ref.read(spaceSearchValueProvider.notifier).state = value;
+      },
+    );
+  }
+
+  Widget spacesList(BuildContext context) {
+    final searchValue = ref.watch(spaceSearchValueProvider);
+    if (searchValue?.isNotEmpty == true) {
+      return searchedSpaceList(context);
+    }
+
+    final spaces =
+        ref.watch(spacesProvider).map((space) => space.getRoomIdStr()).toList();
+    return spaceListUI(spaces);
+  }
+
+//Show space list based on the search term
+  Widget searchedSpaceList(BuildContext context) {
+    final searchedSpaces = ref.watch(searchedSpacesProvider);
+    return searchedSpaces.when(
+      data: (spaces) {
+        if (spaces.isEmpty) {
+          return Center(
+            heightFactor: 10,
+            child: Text(L10n.of(context).noChatsFoundMatchingYourSearchTerm),
+          );
+        }
+        return spaceListUI(spaces);
+      },
+      loading: () => const Center(
+        heightFactor: 10,
+        child: CircularProgressIndicator(),
+      ),
+      error: (e, s) => Center(child: Text(L10n.of(context).searchingFailed(e))),
+    );
+  }
+
+  Widget spaceListUI(List<String> spaces) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(8),
+      itemCount: spaces.length,
+      itemBuilder: (context, index) {
+        final roomId = spaces[index];
+        return BriefRoomEntry(
+          roomId: roomId,
+          avatarDisplayMode: DisplayMode.Space,
+          keyPrefix: 'select-space',
+          selectedValue: current,
+          canCheck: widget.canCheck,
+          onSelect: (roomId) {
+            Navigator.pop(context, roomId);
+          },
+        );
+      },
+    );
+  }
+}
+
 Future<String?> selectSpaceDrawer({
   required BuildContext context,
   Key? key = selectSpaceDrawerKey,
@@ -22,56 +171,11 @@ Future<String?> selectSpaceDrawer({
     enableDrag: true,
     context: context,
     isDismissible: true,
-    builder: (context) => Consumer(
-      builder: (context, ref, child) {
-        final spaces = ref.watch(spacesProvider);
-        return Padding(
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            key: key,
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Row(
-                children: [
-                  Expanded(
-                    child: title ?? Text(L10n.of(context).selectSpace),
-                  ),
-                  OutlinedButton.icon(
-                    icon: const Icon(Atlas.minus_circle_thin),
-                    onPressed: () {
-                      Navigator.pop(context, '');
-                    },
-                    label: Text(L10n.of(context).clear),
-                  ),
-                ],
-              ),
-              Flexible(
-                child: spaces.isEmpty
-                    ? Text(L10n.of(context).noSpacesFound)
-                    : ListView.builder(
-                        padding: const EdgeInsets.all(8),
-                        itemCount: spaces.length,
-                        itemBuilder: (context, index) {
-                          final space = spaces[index];
-                          return BriefRoomEntry(
-                            roomId: space.getRoomIdStr(),
-                            avatarDisplayMode: DisplayMode.Space,
-                            keyPrefix: 'select-space',
-                            selectedValue: current,
-                            canCheck: canCheck,
-                            onSelect: (roomId) {
-                              Navigator.pop(context, roomId);
-                            },
-                          );
-                        },
-                      ),
-              ),
-            ],
-          ),
-        );
-      },
+    builder: (context) => _SelectSpaceDrawer(
+      key: key,
+      canCheck: canCheck,
+      currentSpaceId: currentSpaceId,
+      title: title,
     ),
   );
   if (selected == null) {

--- a/app/lib/common/widgets/spaces/space_selector_drawer.dart
+++ b/app/lib/common/widgets/spaces/space_selector_drawer.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/widgets/room/select_room_drawer.dart';
-import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -22,7 +21,6 @@ Future<String?> selectSpaceDrawer({
       canCheck: canCheck,
       currentSpaceId: currentSpaceId,
       title: title ?? Text(L10n.of(context).selectSpace),
-      avatarDisplayMode: DisplayMode.Space,
       keyPrefix: 'select-space',
       roomType: RoomType.space,
     ),

--- a/app/lib/features/news/widgets/news_item.dart
+++ b/app/lib/features/news/widgets/news_item.dart
@@ -111,7 +111,7 @@ class _NewsItemState extends ConsumerState<NewsItem> {
                 padding: const EdgeInsets.all(16),
                 child: space.when(
                   data: (space) =>
-                      Text(space!.spaceProfileData.displayName ?? roomId),
+                      Text(space.spaceProfileData.displayName ?? roomId),
                   error: (e, st) => Text(L10n.of(context).errorLoadingSpace(e)),
                   loading: () => Skeletonizer(
                     child: Text(roomId),

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
@@ -36,7 +37,7 @@ class NewsSideBar extends ConsumerWidget {
     final userId = ref.watch(myUserIdStrProvider);
     final isLikedByMe = ref.watch(likedByMeProvider(news));
     final likesCount = ref.watch(totalLikesForNewsProvider(news));
-    final space = ref.watch(briefSpaceItemWithMembershipProvider(roomId));
+    final space = ref.watch(briefSpaceItemProvider(roomId));
     final style = Theme.of(context).textTheme.bodyLarge!.copyWith(fontSize: 13);
 
     return Column(
@@ -71,7 +72,6 @@ class NewsSideBar extends ConsumerWidget {
                   news: news,
                   userId: userId,
                   roomId: roomId,
-                  membership: space.membership!,
                 ),
               ),
             ),
@@ -151,19 +151,18 @@ class ActionBox extends ConsumerWidget {
   final String userId;
   final ffi.NewsEntry news;
   final String roomId;
-  final ffi.Member membership;
 
   const ActionBox({
     super.key,
     required this.news,
     required this.userId,
     required this.roomId,
-    required this.membership,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final senderId = news.sender().toString();
+    final membership = ref.watch(roomMembershipProvider(roomId)).valueOrNull;
     final isAuthor = senderId == userId;
     List<Widget> actions = [
       Text(L10n.of(context).actions),
@@ -191,7 +190,9 @@ class ActionBox extends ConsumerWidget {
       );
     }
 
-    if (isAuthor && membership.canString('CanRedactOwn')) {
+    if (isAuthor &&
+        membership != null &&
+        membership.canString('CanRedactOwn')) {
       actions.add(
         TextButton.icon(
           key: NewsUpdateKeys.newsSidebarActionRemoveBtn,

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -111,11 +111,7 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
   Widget searchUI() {
     return Search(
       onChanged: (value) {
-        if (widget.childRoomType == ChildRoomType.chat) {
-          ref.read(chatSearchValueProvider.notifier).update((state) => value);
-        } else if (widget.childRoomType == ChildRoomType.space) {
-          ref.read(spaceSearchValueProvider.notifier).update((state) => value);
-        }
+        ref.read(roomSearchValueProvider.notifier).update((state) => value);
       },
       searchController: searchTextEditingController,
     );
@@ -156,7 +152,7 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //List of chats excluding DMs that can be linked according to the selected parent space
   Widget chatsList() {
-    final searchValue = ref.watch(chatSearchValueProvider);
+    final searchValue = ref.watch(roomSearchValueProvider);
     if (searchValue?.isNotEmpty == true) {
       return searchedChatsList();
     }
@@ -210,7 +206,7 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
 
 //List of spaces that can be linked according to the selected parent space
   Widget spacesList() {
-    final searchValue = ref.watch(spaceSearchValueProvider);
+    final searchValue = ref.watch(roomSearchValueProvider);
     if (searchValue?.isNotEmpty == true) {
       return searchedSpaceList();
     }


### PR DESCRIPTION

Massively refactors the chat & space selectors: clean up several providers that aren't useful in their current state as they fetch too much information not locally needed, fixes #1595 . While on it refactors the space selection drawer to include a similar search (if there are more than 10 items in the list) and make it a single widget used for both chat and space selection. Use the same Brief room view for all of these instances removes further code.


https://github.com/acterglobal/a3/assets/40496/25fa7e13-6b47-4a7e-89a3-1b2b36843f95



Fixes #1595 , fixes #1625 .
