### PR TITLE
Do not allow our sessions to be synced to iCloud

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -176,14 +176,14 @@ const aOptions = AndroidOptions(
   preferencesKeyPrefix: isDevBuild ? 'dev.flutter' : null,
 );
 const iOptions = IOSOptions(
-  synchronizable: true,
+  synchronizable: false,
   accessibility: KeychainAccessibility
       .first_unlock, // must have been unlocked since reboot
   groupId:
       appleKeychainAppGroupName, // to allow the background process to access the same store
 );
 const mOptions = MacOsOptions(
-  synchronizable: true,
+  synchronizable: false,
   accessibility: KeychainAccessibility
       .first_unlock, // must have been unlocked since reboot
   groupId:
@@ -313,12 +313,20 @@ class ActerSdk {
       sessionsStr = await storage.read(key: _sessionKey);
     } on PlatformException catch (error, stack) {
       if (error.code == '-25300') {
-      _log.severe('Ignoring read failure for missing key $_sessionKey');
-      } else  {
-        _log.severe('Ignoring read failure of session key $_sessionKey', error, stack);
+        _log.severe('Ignoring read failure for missing key $_sessionKey');
+      } else {
+        _log.severe(
+          'Ignoring read failure of session key $_sessionKey',
+          error,
+          stack,
+        );
       }
     } catch (error, stack) {
-      _log.severe('Ignoring read failure of session key $_sessionKey', error, stack);
+      _log.severe(
+        'Ignoring read failure of session key $_sessionKey',
+        error,
+        stack,
+      );
     }
 
     if (sessionsStr == null) {


### PR DESCRIPTION
Fixes #1690,

Looks like we were to eager when enabling `synchronizable: true` on the flutter_secure_store options. This disables it. I honestly do not know what that means for existing keys stored but I assume that once logged out this won't be happening again.

I think this is also causing and thus fixing https://github.com/acterglobal/a3-meta/issues/215 and https://github.com/acterglobal/a3/issues/1541 .