### PR TITLE
Fix error in news_like_reaction_test

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -98,6 +98,7 @@ jobs:
           DEFAULT_HOMESERVER_NAME: "localhost"
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: "clang"
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAG: -C link-arg=-fuse-ld=/usr/local/bin/mold
+          RUST_LOG: "info"
         run: cargo nextest run --config-file .github/nextest-config.toml -p acter-test
 
       # file an error if this failed on `main` post-merge


### PR DESCRIPTION
Will fix the following error.

Error: missing field `msgtype` at line 1 column 123

Please reference [this log](https://github.com/acterglobal/a3/actions/runs/8922945832/job/24508996042?pr=1671)