### PR TITLE
revert send message error and fix timeline event state error overflow

### DIFF
--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:acter/common/models/types.dart';
-import 'package:acter/common/providers/network_provider.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 
@@ -637,13 +636,6 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
     if (mentionKey.currentState!.controller!.text.isEmpty) return;
     final lang = L10n.of(context);
     final roomId = widget.convo.getRoomIdStr();
-    // check internet connectivity
-    final isConnected = ref.read(hasNetworkProvider);
-    if (!isConnected) {
-      EasyLoading.showError(L10n.of(context).limitedInternConnection);
-      ref.read(chatInputProvider(roomId).notifier).sendingFailed();
-      return;
-    }
     ref.read(chatInputProvider(roomId).notifier).startSending();
     try {
       // end the typing notification


### PR DESCRIPTION
- This will revert #1701 as this seems to not check whether server is reachable.
- Also this fixes the UI overflow issue on timeline message error state.

<img width="393" alt="Screenshot 2024-05-06 at 8 06 09 PM" src="https://github.com/acterglobal/a3/assets/68579938/4fb9dba4-7052-4dcd-b786-9eca12976058"> 
<img width="395" alt="Screenshot 2024-05-06 at 8 07 36 PM" src="https://github.com/acterglobal/a3/assets/68579938/c9cb8b82-3eae-4d76-b0b0-54f49478bea8">

