### PR TITLE
Fixes : Linking subspaces doesn't show straight away

### DIFF
--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -107,8 +107,6 @@ class SpaceRelationsOverview {
   Member? membership;
   List<Space> knownSubspaces;
   List<Convo> knownChats;
-  List<Space> formerlyKnownSubspaces;
-  List<Convo> formerlyKnownChats;
   Space? mainParent;
   List<Space> parents;
   List<Space> otherRelations;
@@ -118,8 +116,6 @@ class SpaceRelationsOverview {
     required this.membership,
     required this.knownSubspaces,
     required this.knownChats,
-    required this.formerlyKnownSubspaces,
-    required this.formerlyKnownChats,
     required this.mainParent,
     required this.parents,
     required this.otherRelations,
@@ -232,9 +228,7 @@ final spaceRelationsOverviewProvider = FutureProvider.autoDispose
   bool hasMoreSubspaces = false;
   bool hasMoreChats = false;
   final List<Space> knownSubspaces = [];
-  final List<Space> formerlyKnownSubspaces = [];
   final List<Convo> knownChats = [];
-  final List<Convo> formerlyKnownChats = [];
   List<Space> otherRelated = [];
   for (final related in relatedSpaces.children()) {
     String targetType = related.targetType();
@@ -242,10 +236,6 @@ final spaceRelationsOverviewProvider = FutureProvider.autoDispose
     if (targetType == 'ChatRoom') {
       try {
         final chat = await ref.watch(chatProvider(roomId).future);
-        if (!chat.isJoined()) {
-          formerlyKnownChats.add(chat);
-          continue;
-        }
         knownChats.add(chat);
       } catch (e) {
         hasMoreChats = true;
@@ -253,11 +243,8 @@ final spaceRelationsOverviewProvider = FutureProvider.autoDispose
     } else {
       try {
         final space = await ref.watch(spaceProvider(roomId).future);
-        if (!space.isJoined()) {
-          formerlyKnownSubspaces.add(space);
-          continue;
-        }
-        if (await space.isChildSpaceOf(spaceId)) {
+        final isChildSpaceOf = await space.isChildSpaceOf(spaceId);
+        if (isChildSpaceOf) {
           knownSubspaces.add(space);
         } else {
           otherRelated.add(space);
@@ -305,9 +292,7 @@ final spaceRelationsOverviewProvider = FutureProvider.autoDispose
     membership: membership,
     parents: parents,
     knownChats: knownChats,
-    formerlyKnownChats: formerlyKnownChats,
     knownSubspaces: knownSubspaces,
-    formerlyKnownSubspaces: formerlyKnownSubspaces,
     otherRelations: otherRelated,
     mainParent: mainParent,
     hasMoreSubspaces: hasMoreSubspaces,

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -383,6 +383,7 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
         for (final roomId in currentRooms) {
           update.addRoom(roomId);
         }
+        //FIXME : Below is not working at all.
         await room.setJoinRule(update);
       }
     }
@@ -404,7 +405,7 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
       if (room != null) {
         room.addParentRoom(selectedParentSpaceId, true);
         // ignore: use_build_context_synchronously
-        await checkJoinRule(context, room, selectedParentSpaceId);
+        checkJoinRule(context, room, selectedParentSpaceId);
       }
     }
 

--- a/native/test/src/tests/spaces.rs
+++ b/native/test/src/tests/spaces.rs
@@ -1,4 +1,7 @@
-use acter::new_space_settings_builder;
+use acter::{
+    new_join_rule_builder, new_space_settings_builder,
+    ruma_events::room::join_rules::{AllowRule, JoinRule, Restricted},
+};
 use acter_core::statics::KEYS;
 use anyhow::{bail, Result};
 use tokio::sync::broadcast::error::TryRecvError;
@@ -129,7 +132,6 @@ async fn leaving_spaces() -> Result<()> {
     })
     .await?;
 
-    println!("all triggered");
     Retry::spawn(retry_strategy.clone(), || async {
         if first_listener.is_empty() {
             // not yet.
@@ -270,6 +272,114 @@ async fn create_subspace() -> Result<()> {
         Ok(())
     })
     .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn change_subspace_join_rule() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (user, _sync_state, _engine) = random_user_with_template("subspace_create", TMPL).await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 1 {
+                bail!("not all spaces found");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let mut spaces = user.spaces().await?;
+
+    assert_eq!(spaces.len(), 1);
+
+    let first = spaces.pop().unwrap();
+
+    let mut cfg = new_space_settings_builder();
+    cfg.set_name("subspace".to_owned());
+    cfg.set_parent(first.room_id().to_string());
+
+    let settings = cfg.build()?;
+    let subspace_id = user.create_acter_space(Box::new(settings)).await?;
+
+    let fetcher_client = user.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            if client.spaces().await?.len() != 2 {
+                bail!("not the right number of spaces found");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let space = user.space(subspace_id.to_string()).await?;
+    let space_relations = space.space_relations().await?;
+    let space_parent = space_relations
+        .main_parent()
+        .expect("Subspace doesn't have the parent");
+    assert_eq!(space_parent.room_id(), first.room_id());
+    assert_eq!(space.join_rule_str(), "restricted");
+
+    let mut update = new_join_rule_builder();
+    update.join_rule("private".to_string());
+
+    space.set_join_rule(Box::new(update)).await?;
+
+    let retry_strategy = FibonacciBackoff::from_millis(500).map(jitter).take(10);
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let space = user.space(subspace_id.to_string()).await?;
+        if space.join_rule_str() != "private" {
+            bail!("update did not occur");
+        }
+        Ok(())
+    })
+    .await?;
+
+    // let's move it back to restricted
+    assert_eq!(space.join_rule_str(), "private");
+    let join_rule = space.join_rule();
+
+    assert!(matches!(join_rule, JoinRule::Private));
+
+    let mut update = new_join_rule_builder();
+    update.join_rule("restricted".to_string());
+    update.add_room(space_parent.room_id().to_string());
+
+    space.set_join_rule(Box::new(update)).await?;
+
+    let retry_strategy = FibonacciBackoff::from_millis(500).map(jitter).take(10);
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let space = user.space(subspace_id.to_string()).await?;
+        if space.join_rule_str() != "restricted" {
+            bail!("update did not occur");
+        }
+        Ok(())
+    })
+    .await?;
+
+    let space = user.space(subspace_id.to_string()).await?;
+    let join_rule = space.join_rule();
+    let target = JoinRule::Restricted(Restricted::new(vec![AllowRule::room_membership(
+        space_parent.room_id(),
+    )]));
+
+    if join_rule != target {
+        bail!(
+            "Join rule is incorrect: {:?}, expected {:?}",
+            join_rule,
+            target
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- Remove unused code from the space provider
- fixes, #1700 

Also during fixes of #1700, I come to know that code related to update join rule (`await room.setJoinRule(update);`) not working at all and never get back from `await` state. Added `//FIXME` comment over there.

Reference video:


https://github.com/acterglobal/a3/assets/51526480/4656eaf3-02e3-4a19-9593-7267688caed2



