### PR TITLE
Fix sticky zoom bubble 

### DIFF
--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -143,8 +143,13 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
           keyboardDismissBehavior: Platform.isIOS
               ? ScrollViewKeyboardDismissBehavior.onDrag
               : ScrollViewKeyboardDismissBehavior.manual,
-          customBottomWidget:
-              CustomChatInput(key: Key(roomId), convo: widget.convo),
+          customBottomWidget: CustomChatInput(
+            key: Key('chat-input-$roomId'),
+            roomId: widget.convo.getRoomIdStr(),
+            onTyping: (typing) async {
+              widget.convo.typingNotice(typing);
+            },
+          ),
           textMessageBuilder: (
             types.TextMessage m, {
             required int messageWidth,
@@ -194,7 +199,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
             required int messageWidth,
           }) =>
               ImageMessageBuilder(
-            convo: widget.convo,
+            roomId: widget.convo.getRoomIdStr(),
             message: message,
             messageWidth: messageWidth,
           ),

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -57,6 +57,12 @@ final timelineStreamProvider = StateProvider.family<TimelineStream, Convo>(
   (ref, convo) => convo.timelineStream(),
 );
 
+final timelineStreamProviderForId =
+    FutureProvider.family<TimelineStream, String>((ref, roomId) async {
+  final chat = await ref.watch(chatProvider(roomId).future);
+  return ref.watch(timelineStreamProvider(chat));
+});
+
 final filteredChatsProvider =
     FutureProvider.autoDispose<List<Convo>>((ref) async {
   final allRooms = ref.watch(chatsProvider);

--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -531,7 +531,7 @@ class _OriginalMessageBuilder extends ConsumerWidget {
             constraints: const BoxConstraints(maxHeight: 50),
             margin: const EdgeInsets.all(12),
             child: ImageMessageBuilder(
-              convo: convo,
+              roomId: convo.getRoomIdStr(),
               message: repliedMessage,
               messageWidth: repliedMessage.size.toInt(),
               isReplyContent: true,

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -22,6 +22,7 @@ import 'package:atlas_icons/atlas_icons.dart';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -825,123 +826,135 @@ class _TextInputWidget extends ConsumerWidget {
         chatFocus.requestFocus();
       }
     });
-    // return CallbackShortcuts(
-    //   bindings: <ShortcutActivator, VoidCallback>{
-    //     const SingleActivator(LogicalKeyboardKey.enter): () {
-    //       onSendButtonPressed();
-    //     },
-    //   },
-    //   child: Focus(
-    //     child:
-    return FlutterMentions(
-      key: mentionKey,
-      // restore input if available, but only as a read on startup
-      defaultText:
-          ref.read(chatInputProvider(roomId).select((value) => value.message)),
-      suggestionPosition: SuggestionPosition.Top,
-      suggestionListWidth: width >= 770 ? width * 0.6 : width * 0.8,
-      onMentionAdd: (roomMember) => onMentionAdd(roomMember, ref),
-      suggestionListDecoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.background,
-        borderRadius: BorderRadius.circular(6),
-      ),
-      onChanged: (String value) async {
-        ref.read(chatInputProvider(roomId).notifier).updateMessage(value);
-        if (onTyping != null) {
-          onTyping!(value.isNotEmpty);
-        }
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.enter): () {
+          onSendButtonPressed();
+        },
       },
-      textInputAction: TextInputAction.newline,
-      enabled: ref.watch(_allowEdit(roomId)),
-      onSubmitted: (value) => onSendButtonPressed(),
-      style: Theme.of(context).textTheme.bodyMedium,
-      cursorColor: Theme.of(context).colorScheme.primary,
-      maxLines: 6,
-      minLines: 1,
-      focusNode: chatFocus,
-      onTap: () => onTextTap(
-        ref.read(chatInputProvider(roomId)).emojiPickerVisible,
-        ref,
-      ),
-      decoration: InputDecoration(
-        isCollapsed: true,
-        prefixIcon: isEncrypted
-            ? Icon(
-                Icons.shield,
-                size: 18,
-                color: Theme.of(context).colorScheme.primary.withOpacity(0.8),
-              )
-            : null,
-        suffixIcon: InkWell(
-          onTap: () => onSuffixTap(
+      child: Focus(
+        child: FlutterMentions(
+          key: mentionKey,
+          // restore input if available, but only as a read on startup
+          defaultText: ref
+              .read(chatInputProvider(roomId).select((value) => value.message)),
+          suggestionPosition: SuggestionPosition.Top,
+          suggestionListWidth: width >= 770 ? width * 0.6 : width * 0.8,
+          onMentionAdd: (roomMember) => onMentionAdd(roomMember, ref),
+          suggestionListDecoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.background,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          onChanged: (String value) async {
+            ref.read(chatInputProvider(roomId).notifier).updateMessage(value);
+            if (onTyping != null) {
+              onTyping!(value.isNotEmpty);
+            }
+          },
+          textInputAction: TextInputAction.newline,
+          enabled: ref.watch(_allowEdit(roomId)),
+          onSubmitted: (value) => onSendButtonPressed(),
+          style: Theme.of(context).textTheme.bodyMedium,
+          cursorColor: Theme.of(context).colorScheme.primary,
+          maxLines: 6,
+          minLines: 1,
+          focusNode: chatFocus,
+          onTap: () => onTextTap(
             ref.read(chatInputProvider(roomId)).emojiPickerVisible,
-            context,
             ref,
           ),
-          child: const Icon(Icons.emoji_emotions),
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(30),
-          borderSide: BorderSide(
-            width: 0.5,
-            style: BorderStyle.solid,
-            color: Theme.of(context).colorScheme.surface,
-          ),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(30),
-          borderSide: BorderSide(
-            width: 0.5,
-            style: BorderStyle.solid,
-            color: Theme.of(context).colorScheme.onSecondaryContainer,
-          ),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(30),
-          borderSide: BorderSide(
-            width: 0.5,
-            style: BorderStyle.solid,
-            color: Theme.of(context).colorScheme.onBackground,
-          ),
-        ),
-        hintText: isEncrypted
-            ? L10n.of(context).newEncryptedMessage
-            : L10n.of(context).newMessage,
-        hintStyle: Theme.of(context).textTheme.labelLarge!.copyWith(
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
-        contentPadding: const EdgeInsets.all(15),
-        hintMaxLines: 1,
-      ),
-      mentions: [
-        Mention(
-          trigger: '@',
-          style: TextStyle(
-            height: 0.5,
-            background: Paint()
-              ..color = Theme.of(context).colorScheme.neutral2
-              ..strokeWidth = 13
-              ..strokeJoin = StrokeJoin.round
-              ..style = PaintingStyle.stroke,
-          ),
-          data: chatMentions.valueOrNull ?? [],
-          suggestionBuilder: (Map<String, dynamic> mentionRecord) {
-            final authorId = mentionRecord['id'];
-            final title = mentionRecord['displayName'];
-            return ListTile(
-              leading: MentionProfileBuilder(
-                roomId: roomId,
-                authorId: authorId,
+          decoration: InputDecoration(
+            isCollapsed: true,
+            prefixIcon: isEncrypted
+                ? Icon(
+                    Icons.shield,
+                    size: 18,
+                    color:
+                        Theme.of(context).colorScheme.primary.withOpacity(0.8),
+                  )
+                : null,
+            suffixIcon: InkWell(
+              onTap: () => onSuffixTap(
+                ref.read(chatInputProvider(roomId)).emojiPickerVisible,
+                context,
+                ref,
               ),
-              title: title != null
-                  ? Wrap(
-                      children: [
-                        Text(
-                          title,
-                          style: Theme.of(context).textTheme.bodySmall,
-                        ),
-                        const SizedBox(width: 15),
-                        Text(
+              child: const Icon(Icons.emoji_emotions),
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(30),
+              borderSide: BorderSide(
+                width: 0.5,
+                style: BorderStyle.solid,
+                color: Theme.of(context).colorScheme.surface,
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(30),
+              borderSide: BorderSide(
+                width: 0.5,
+                style: BorderStyle.solid,
+                color: Theme.of(context).colorScheme.onSecondaryContainer,
+              ),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(30),
+              borderSide: BorderSide(
+                width: 0.5,
+                style: BorderStyle.solid,
+                color: Theme.of(context).colorScheme.onBackground,
+              ),
+            ),
+            hintText: isEncrypted
+                ? L10n.of(context).newEncryptedMessage
+                : L10n.of(context).newMessage,
+            hintStyle: Theme.of(context).textTheme.labelLarge!.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+            contentPadding: const EdgeInsets.all(15),
+            hintMaxLines: 1,
+          ),
+          mentions: [
+            Mention(
+              trigger: '@',
+              style: TextStyle(
+                height: 0.5,
+                background: Paint()
+                  ..color = Theme.of(context).colorScheme.neutral2
+                  ..strokeWidth = 13
+                  ..strokeJoin = StrokeJoin.round
+                  ..style = PaintingStyle.stroke,
+              ),
+              data: chatMentions.valueOrNull ?? [],
+              suggestionBuilder: (Map<String, dynamic> mentionRecord) {
+                final authorId = mentionRecord['id'];
+                final title = mentionRecord['displayName'];
+                return ListTile(
+                  leading: MentionProfileBuilder(
+                    roomId: roomId,
+                    authorId: authorId,
+                  ),
+                  title: title != null
+                      ? Wrap(
+                          children: [
+                            Text(
+                              title,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                            const SizedBox(width: 15),
+                            Text(
+                              authorId,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall!
+                                  .copyWith(
+                                    color:
+                                        Theme.of(context).colorScheme.neutral5,
+                                  ),
+                            ),
+                          ],
+                        )
+                      : Text(
                           authorId,
                           style: Theme.of(context)
                               .textTheme
@@ -950,20 +963,12 @@ class _TextInputWidget extends ConsumerWidget {
                                 color: Theme.of(context).colorScheme.neutral5,
                               ),
                         ),
-                      ],
-                    )
-                  : Text(
-                      authorId,
-                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                            color: Theme.of(context).colorScheme.neutral5,
-                          ),
-                    ),
-            );
-          },
+                );
+              },
+            ),
+          ],
         ),
-      ],
-      //   ),
-      // ),
+      ),
     );
   }
 

--- a/app/lib/features/chat/widgets/image_message_builder.dart
+++ b/app/lib/features/chat/widgets/image_message_builder.dart
@@ -2,7 +2,6 @@ import 'package:acter/common/models/types.dart';
 import 'package:acter/common/widgets/image_dialog.dart';
 import 'package:acter/features/chat/models/media_chat_state/media_chat_state.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
@@ -13,11 +12,11 @@ class ImageMessageBuilder extends ConsumerWidget {
   final types.ImageMessage message;
   final int messageWidth;
   final bool isReplyContent;
-  final Convo convo;
+  final String roomId;
 
   const ImageMessageBuilder({
     super.key,
-    required this.convo,
+    required this.roomId,
     required this.message,
     required this.messageWidth,
     this.isReplyContent = false,
@@ -25,7 +24,6 @@ class ImageMessageBuilder extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final roomId = convo.getRoomIdStr();
     final ChatMessageInfo messageInfo = (messageId: message.id, roomId: roomId);
     final mediaState = ref.watch(mediaChatStateProvider(messageInfo));
     if (mediaState.mediaChatLoadingState.isLoading ||

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -719,10 +719,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "45f76488f37400b96392f9e555461e65c1eae742"
-      url: "https://github.com/gtalha07/flutter_mentions.git"
+      resolved-ref: "312397587e6ea1ff5b594efcb5fddfdccae52e29"
+      url: "https://github.com/acterglobal/flutter_mentions.git"
     source: git
-    version: "2.0.2"
+    version: "3.0.1"
   flutter_parsed_text:
     dependency: transitive
     description:
@@ -743,10 +743,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_portal
-      sha256: "0e3f9428dbe9f5253b0e65cdc5ce4fa65a1d8cd6ec2a3f3770b46785aa3c57fd"
+      sha256: "4601b3dc24f385b3761721bd852a3f6c09cddd4e943dd184ed58ee1f43006257"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "1.1.4"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   fc_native_video_thumbnail: ^0.7.0
   flutter_mentions:
     git:
-      url: https://github.com/gtalha07/flutter_mentions.git
+      url: https://github.com/acterglobal/flutter_mentions.git
   flutter_matrix_html:
     git:
       url: https://github.com/acterglobal/flutter_matrix_html.git


### PR DESCRIPTION
I've finally figured out what is causing the weird sticky zoom bubble reported and investigated in #1732 : us re-rendering that area too often.

Basically, if we rerender the area while the user holding press to select, we refresh some internal states and as the way that flutter states updates works means we are destroying an internal object. Now when the user is still holding and starts to move, the event is issued to the new UI element that has been rendered in its place. But the old is never cleaned up because that probably is supposed to happen upon that move. Ergo: we have a sticky bubble. And the reason is that we are causing rerenders too often, replacing the underlying widget while it still in use.

So, what to do? Well, this PR does two things:
1. upgrades the flutter_mentions fork dependencies to use latest flutter portal (not the cause, but still useful to do)
2. it reduces the complexity and ref.watch cycles of the custom input for the chat, reducing the rerenders _by a lot_, which were totally pointless. By a) using `.select` on `ref.watch` for the internal state and b) reducing the input to `roomId` to stop flutter assuming something has changed... 


I guess this comes to show again that one still must be careful in using `ref.watch` and be as explicit with the providers as possible to reduce unnecessary re-rendering and stateful bugs like this.


This is how I was able to reproduce this on `main`:


https://github.com/acterglobal/a3/assets/40496/d9d4af76-eac4-4873-b386-e3412073b8a4


And this is with the patch applied :tada: :

https://github.com/acterglobal/a3/assets/40496/8e875f15-4ecc-43cd-b854-c04da2110e81







