### PR TITLE
Cleaning up the Main shell and main navigation

### DIFF
--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -271,7 +271,6 @@ class HomeShellState extends ConsumerState<HomeShell> {
 
   Widget bottomNavigationWidget(BuildContext context) {
     final keyboardVisibility = ref.watch(keyboardVisibleProvider);
-    final bottomBarNav = ref.watch(bottomBarNavProvider(context));
     if (keyboardVisibility.valueOrNull != false) {
       return const SizedBox.shrink();
     }
@@ -280,7 +279,7 @@ class HomeShellState extends ConsumerState<HomeShell> {
         SizedBox(
           height: 50,
           child: Row(
-            children: bottomBarNav
+            children: bottomBarItems
                 .map(
                   (bottomBarNav) => Expanded(
                     child: Center(
@@ -305,7 +304,7 @@ class HomeShellState extends ConsumerState<HomeShell> {
               initialLocation: index == widget.navigationShell.currentIndex,
             );
           },
-          items: bottomBarNav,
+          items: bottomBarItems,
           type: BottomNavigationBarType.fixed,
         ),
       ],

--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -250,7 +250,6 @@ class HomeShellState extends ConsumerState<HomeShell> {
         Breakpoints.large: SlotLayout.from(
           key: const Key('primaryNavigation'),
           builder: (BuildContext ctx) => SidebarWidget(
-            labelType: NavigationRailLabelType.all,
             navigationShell: widget.navigationShell,
           ),
         ),

--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -1,7 +1,6 @@
 import 'package:acter/common/dialogs/logout_confirmation.dart';
 import 'package:acter/common/notifications/notifications.dart';
 import 'package:acter/common/providers/keyboard_visbility_provider.dart';
-import 'package:acter/common/themes/app_theme.dart';
 
 import 'package:acter/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart';
 import 'package:acter/common/utils/constants.dart';
@@ -108,6 +107,64 @@ class HomeShellState extends ConsumerState<HomeShell> {
     });
   }
 
+  Widget buildLoggedOutScreen(BuildContext context, bool softLogout) {
+    // We have a special case
+    return Scaffold(
+      body: Container(
+        margin: const EdgeInsets.only(top: kToolbarHeight),
+        child: Center(
+          child: Column(
+            children: [
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 15),
+                height: 100,
+                width: 100,
+                child: SvgPicture.asset(
+                  'assets/images/undraw_access_denied_re_awnf.svg',
+                ),
+              ),
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 15),
+                child: RichText(
+                  textAlign: TextAlign.center,
+                  text: TextSpan(
+                    text: L10n.of(context).access,
+                    style: Theme.of(context).textTheme.headlineLarge,
+                    children: <TextSpan>[
+                      TextSpan(
+                        text: ' ${L10n.of(context).denied}',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.error,
+                          fontSize: 32,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 15),
+                child: Text(
+                  L10n.of(context).yourSessionHasBeenTerminatedByServer,
+                ),
+              ),
+              softLogout
+                  ? OutlinedButton(
+                      onPressed: onLoginAgain,
+                      child: Text(L10n.of(context).loginAgain),
+                    )
+                  : OutlinedButton(
+                      onPressed: onClearDB,
+                      child: Text(L10n.of(context).clearDBAndReLogin),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // get platform of context.
@@ -120,68 +177,11 @@ class HomeShellState extends ConsumerState<HomeShell> {
         ),
       );
     }
-    final syncState = ref.watch(syncStateProvider);
-    final hasFirstSynced = !syncState.initialSync;
-    final errorMsg = syncState.errorMsg;
-
+    final errorMsg = ref.watch(syncStateProvider.select((v) => v.errorMsg));
     if (errorMsg != null) {
       final softLogout = errorMsg == 'SoftLogout';
       if (softLogout || errorMsg == 'Unauthorized') {
-        // We have a special case
-        return Scaffold(
-          body: Container(
-            margin: const EdgeInsets.only(top: kToolbarHeight),
-            child: Center(
-              child: Column(
-                children: [
-                  Container(
-                    margin: const EdgeInsets.symmetric(vertical: 15),
-                    height: 100,
-                    width: 100,
-                    child: SvgPicture.asset(
-                      'assets/images/undraw_access_denied_re_awnf.svg',
-                    ),
-                  ),
-                  Container(
-                    margin: const EdgeInsets.symmetric(vertical: 15),
-                    child: RichText(
-                      textAlign: TextAlign.center,
-                      text: TextSpan(
-                        text: L10n.of(context).access,
-                        style: Theme.of(context).textTheme.headlineLarge,
-                        children: <TextSpan>[
-                          TextSpan(
-                            text: ' ${L10n.of(context).denied}',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Theme.of(context).colorScheme.error,
-                              fontSize: 32,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Container(
-                    margin: const EdgeInsets.symmetric(vertical: 15),
-                    child: Text(
-                      L10n.of(context).yourSessionHasBeenTerminatedByServer,
-                    ),
-                  ),
-                  softLogout
-                      ? OutlinedButton(
-                          onPressed: onLoginAgain,
-                          child: Text(L10n.of(context).loginAgain),
-                        )
-                      : OutlinedButton(
-                          onPressed: onClearDB,
-                          child: Text(L10n.of(context).clearDBAndReLogin),
-                        ),
-                ],
-              ),
-            ),
-          ),
-        );
+        return buildLoggedOutScreen(context, softLogout);
       }
     }
 
@@ -203,7 +203,7 @@ class HomeShellState extends ConsumerState<HomeShell> {
               children: [
                 const CrossSigning(),
                 Expanded(
-                  child: buildBody(context, hasFirstSynced),
+                  child: buildBody(context),
                 ),
               ],
             ),
@@ -222,110 +222,122 @@ class HomeShellState extends ConsumerState<HomeShell> {
     logoutConfirmationDialog(context, ref);
   }
 
-  Widget buildBody(BuildContext context, bool hasFirstSynced) {
-    final keyboardVisibility = ref.watch(keyboardVisibleProvider);
-    final bottomBarNav = ref.watch(bottomBarNavProvider(context));
-    return AdaptiveLayout(
-      key: _key,
-      topNavigation: !hasFirstSynced
-          ? SlotLayout(
-              config: <Breakpoint, SlotLayoutConfig?>{
-                Breakpoints.smallAndUp: SlotLayout.from(
-                  key: const Key('LoadingIndicator'),
-                  builder: (BuildContext ctx) {
-                    return LinearProgressIndicator(
-                      semanticsLabel: L10n.of(context).loadingFirstSync,
-                    );
-                  },
-                ),
-              },
-            )
-          : null,
-      primaryNavigation: isDesktop
-          ? SlotLayout(
-              config: <Breakpoint, SlotLayoutConfig?>{
-                // adapt layout according to platform.
-                Breakpoints.small: SlotLayout.from(
-                  key: const Key('primaryNavigation'),
-                  builder: (BuildContext ctx) => SidebarWidget(
-                    labelType: NavigationRailLabelType.selected,
-                    navigationShell: widget.navigationShell,
-                  ),
-                ),
-                Breakpoints.mediumAndUp: SlotLayout.from(
-                  key: const Key('primaryNavigation'),
-                  builder: (BuildContext ctx) => SidebarWidget(
-                    labelType: NavigationRailLabelType.all,
-                    navigationShell: widget.navigationShell,
-                  ),
-                ),
-              },
-            )
-          : null,
-      body: SlotLayout(
-        config: <Breakpoint, SlotLayoutConfig>{
-          Breakpoints.smallAndUp: SlotLayout.from(
-            key: const Key('Body Small'),
-            builder: (BuildContext ctx) => widget.navigationShell,
-          ),
-        },
-      ),
-      bottomNavigation: !isDesktop && keyboardVisibility.valueOrNull != true
-          ? SlotLayout(
-              config: <Breakpoint, SlotLayoutConfig>{
-                //In desktop, we have ability to adjust windows res,
-                // adjust to navbar as primary to smaller views.
-                Breakpoints.smallAndUp: SlotLayout.from(
-                  key: Keys.mainNav,
-                  inAnimation: AdaptiveScaffold.bottomToTop,
-                  outAnimation: AdaptiveScaffold.topToBottom,
-                  builder: (BuildContext ctx) => Stack(
-                    children: [
-                      SizedBox(
-                        height: 50,
-                        child: Row(
-                          children: bottomBarNav
-                              .map(
-                                (bottomBarNav) => Expanded(
-                                  child: Center(
-                                    child: SizedBox(
-                                      key: bottomBarNav.tutorialGlobalKey,
-                                      height: 40,
-                                      width: 40,
-                                    ),
-                                  ),
-                                ),
-                              )
-                              .toList(),
-                        ),
-                      ),
-                      BottomNavigationBar(
-                        showSelectedLabels: false,
-                        showUnselectedLabels: false,
-                        currentIndex: widget.navigationShell.currentIndex,
-                        onTap: (index) {
-                          widget.navigationShell.goBranch(
-                            index,
-                            initialLocation:
-                                index == widget.navigationShell.currentIndex,
-                          );
-                        },
-                        items: bottomBarNav,
-                        type: BottomNavigationBarType.fixed,
-                      ),
-                    ],
-                  ),
-                ),
-              },
-            )
-          : null,
+  Widget topNavigationWidget(BuildContext context) {
+    final hasFirstSynced =
+        ref.watch(syncStateProvider.select((v) => !v.initialSync));
+    if (hasFirstSynced) {
+      return const SizedBox.shrink();
+    }
+    return LinearProgressIndicator(
+      semanticsLabel: L10n.of(context).loadingFirstSync,
     );
   }
 
-  void onBottomNavigated(int index) {
-    widget.navigationShell.goBranch(
-      index,
-      initialLocation: index == widget.navigationShell.currentIndex,
+  SlotLayout topNavigationLayout() {
+    return SlotLayout(
+      config: <Breakpoint, SlotLayoutConfig?>{
+        Breakpoints.smallAndUp: SlotLayout.from(
+          key: const Key('LoadingIndicator'),
+          builder: topNavigationWidget,
+        ),
+      },
+    );
+  }
+
+  SlotLayout primaryNavigationLayout() {
+    return SlotLayout(
+      config: <Breakpoint, SlotLayoutConfig?>{
+        Breakpoints.large: SlotLayout.from(
+          key: const Key('primaryNavigation'),
+          builder: (BuildContext ctx) => SidebarWidget(
+            labelType: NavigationRailLabelType.all,
+            navigationShell: widget.navigationShell,
+          ),
+        ),
+      },
+    );
+  }
+
+  SlotLayout bodySlot() {
+    return SlotLayout(
+      config: <Breakpoint, SlotLayoutConfig>{
+        Breakpoints.standard: SlotLayout.from(
+          key: const Key('Body Small'),
+          builder: (BuildContext ctx) => widget.navigationShell,
+        ),
+      },
+    );
+  }
+
+  Widget bottomNavigationWidget(BuildContext context) {
+    final keyboardVisibility = ref.watch(keyboardVisibleProvider);
+    final bottomBarNav = ref.watch(bottomBarNavProvider(context));
+    if (keyboardVisibility.valueOrNull != false) {
+      return const SizedBox.shrink();
+    }
+    return Stack(
+      children: [
+        SizedBox(
+          height: 50,
+          child: Row(
+            children: bottomBarNav
+                .map(
+                  (bottomBarNav) => Expanded(
+                    child: Center(
+                      child: SizedBox(
+                        key: bottomBarNav.tutorialGlobalKey,
+                        height: 40,
+                        width: 40,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+        BottomNavigationBar(
+          showSelectedLabels: false,
+          showUnselectedLabels: false,
+          currentIndex: widget.navigationShell.currentIndex,
+          onTap: (index) {
+            widget.navigationShell.goBranch(
+              index,
+              initialLocation: index == widget.navigationShell.currentIndex,
+            );
+          },
+          items: bottomBarNav,
+          type: BottomNavigationBarType.fixed,
+        ),
+      ],
+    );
+  }
+
+  SlotLayout bottomNavigationLayout() {
+    return SlotLayout(
+      config: <Breakpoint, SlotLayoutConfig>{
+        Breakpoints.small: SlotLayout.from(
+          key: Keys.mainNav,
+          inAnimation: AdaptiveScaffold.bottomToTop,
+          outAnimation: AdaptiveScaffold.topToBottom,
+          builder: bottomNavigationWidget,
+        ),
+        Breakpoints.medium: SlotLayout.from(
+          key: Keys.mainNav,
+          inAnimation: AdaptiveScaffold.bottomToTop,
+          outAnimation: AdaptiveScaffold.topToBottom,
+          builder: bottomNavigationWidget,
+        ),
+      },
+    );
+  }
+
+  Widget buildBody(BuildContext context) {
+    return AdaptiveLayout(
+      key: _key,
+      topNavigation: topNavigationLayout(),
+      primaryNavigation: primaryNavigationLayout(),
+      body: bodySlot(),
+      bottomNavigation: bottomNavigationLayout(),
     );
   }
 }

--- a/app/lib/features/home/providers/navigation.dart
+++ b/app/lib/features/home/providers/navigation.dart
@@ -1,11 +1,10 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/features/activities/providers/activities_providers.dart';
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/home/data/models/nav_item.dart';
+import 'package:acter/features/home/widgets/activities_icon.dart';
 import 'package:acter/features/home/widgets/custom_selected_icon.dart';
 import 'package:acter/router/providers/router_providers.dart';
 import 'package:acter/router/utils.dart';
@@ -82,41 +81,10 @@ final spaceItemsProvider = FutureProvider.autoDispose
   }).toList();
 });
 
-final activitiesIconProvider = Provider.family<Widget, BuildContext>(
-  (ref, context) {
-    final activites = ref.watch(hasActivitiesProvider);
-    const baseIcon = Icon(
-      Atlas.audio_wave_thin,
-      key: MainNavKeys.activities,
-    );
-    switch (activites) {
-      case HasActivities.important:
-        return Badge(
-          backgroundColor: Theme.of(context).colorScheme.badgeImportant,
-          child: baseIcon,
-        );
-      case HasActivities.urgent:
-        return Badge(
-          backgroundColor: Theme.of(context).colorScheme.badgeUrgent,
-          child: baseIcon,
-        );
-      case HasActivities.unread:
-        return Badge(
-          backgroundColor: Theme.of(context).colorScheme.badgeUnread,
-          child: baseIcon,
-        );
-      default:
-        // read and none, we do not show any icon to prevent notification fatigue
-        return baseIcon;
-    }
-  },
-);
-
 // provider that returns a string value
 final sidebarItemsProvider = Provider.autoDispose
     .family<List<SidebarNavigationItem>, BuildContext>((ref, context) {
   final config = ref.watch(spaceItemsProvider(context));
-  final activitiesIcon = ref.watch(activitiesIconProvider(context));
   final features = [
     SidebarNavigationItem(
       icon: const Icon(
@@ -146,7 +114,6 @@ final sidebarItemsProvider = Provider.autoDispose
       tutorialGlobalKey: dashboardKey,
     ),
     SidebarNavigationItem(
-      // icon: const Badge(child: Icon(Atlas.chats_thin)), // TODO: Badge example
       icon: const Icon(
         Atlas.chats_thin,
         key: MainNavKeys.chats,
@@ -160,7 +127,7 @@ final sidebarItemsProvider = Provider.autoDispose
       tutorialGlobalKey: chatsKey,
     ),
     SidebarNavigationItem(
-      icon: activitiesIcon,
+      icon: const ActivitiesIcon(),
       label: Column(
         children: [
           Text(
@@ -202,86 +169,78 @@ final currentSelectedSidebarIndexProvider =
   return index < 0 ? fallbackSidebarIdx : index;
 });
 
-final bottomBarNavProvider =
-    Provider.family<List<BottomBarNavigationItem>, BuildContext>(
-        (ref, context) {
-  final activitiesIcon = ref.watch(activitiesIconProvider(context));
-
-  return [
-    BottomBarNavigationItem(
-      icon: const Icon(
-        Atlas.home_thin,
-        key: MainNavKeys.dashboardHome,
-      ),
-      activeIcon: const CustomSelectedIcon(
-        icon: Icon(Atlas.home_bold),
-        key: MainNavKeys.dashboardHome,
-      ),
-      label: 'Dashboard',
-      initialLocation: Routes.dashboard.route,
-      tutorialGlobalKey: dashboardKey,
+final bottomBarItems = [
+  BottomBarNavigationItem(
+    icon: const Icon(
+      Atlas.home_thin,
+      key: MainNavKeys.dashboardHome,
     ),
-    BottomBarNavigationItem(
-      icon: const Icon(
-        key: MainNavKeys.updates,
-        Atlas.megaphone_thin,
-      ),
-      activeIcon: const CustomSelectedIcon(
-        icon: Icon(Atlas.megaphone_thin),
-        key: MainNavKeys.updates,
-      ),
-      label: 'Updates',
-      initialLocation: Routes.updates.route,
-      tutorialGlobalKey: updateKey,
+    activeIcon: const CustomSelectedIcon(
+      icon: Icon(Atlas.home_bold),
+      key: MainNavKeys.dashboardHome,
     ),
-    BottomBarNavigationItem(
-      icon: const Icon(
-        Atlas.chats_thin,
-        key: MainNavKeys.chats,
-      ),
-      activeIcon: const CustomSelectedIcon(
-        icon: Icon(Atlas.chats_thin),
-        key: MainNavKeys.chats,
-      ),
-      label: 'Chat',
-      initialLocation: Routes.chat.route,
-      tutorialGlobalKey: chatsKey,
+    label: 'Dashboard',
+    initialLocation: Routes.dashboard.route,
+    tutorialGlobalKey: dashboardKey,
+  ),
+  BottomBarNavigationItem(
+    icon: const Icon(
+      key: MainNavKeys.updates,
+      Atlas.megaphone_thin,
     ),
-    BottomBarNavigationItem(
-      icon: activitiesIcon,
-      activeIcon: CustomSelectedIcon(
-        icon: activitiesIcon,
-      ),
-      label: 'Activities',
-      initialLocation: Routes.activities.route,
-      tutorialGlobalKey: activityKey,
+    activeIcon: const CustomSelectedIcon(
+      icon: Icon(Atlas.megaphone_thin),
+      key: MainNavKeys.updates,
     ),
-    BottomBarNavigationItem(
-      icon: const Icon(
+    label: 'Updates',
+    initialLocation: Routes.updates.route,
+    tutorialGlobalKey: updateKey,
+  ),
+  BottomBarNavigationItem(
+    icon: const Icon(
+      Atlas.chats_thin,
+      key: MainNavKeys.chats,
+    ),
+    activeIcon: const CustomSelectedIcon(
+      icon: Icon(Atlas.chats_thin),
+      key: MainNavKeys.chats,
+    ),
+    label: 'Chat',
+    initialLocation: Routes.chat.route,
+    tutorialGlobalKey: chatsKey,
+  ),
+  BottomBarNavigationItem(
+    icon: const ActivitiesIcon(),
+    activeIcon: const CustomSelectedIcon(
+      icon: ActivitiesIcon(),
+    ),
+    label: 'Activities',
+    initialLocation: Routes.activities.route,
+    tutorialGlobalKey: activityKey,
+  ),
+  BottomBarNavigationItem(
+    icon: const Icon(
+      Atlas.magnifying_glass_thin,
+      key: MainNavKeys.quickJump,
+    ),
+    activeIcon: const CustomSelectedIcon(
+      key: MainNavKeys.quickJump,
+      icon: Icon(
         Atlas.magnifying_glass_thin,
-        key: MainNavKeys.quickJump,
       ),
-      activeIcon: const CustomSelectedIcon(
-        key: MainNavKeys.quickJump,
-        icon: Icon(
-          Atlas.magnifying_glass_thin,
-        ),
-      ),
-      label: 'Search',
-      initialLocation: Routes.search.route,
-      tutorialGlobalKey: jumpToKey,
     ),
-  ];
-});
+    label: 'Search',
+    initialLocation: Routes.search.route,
+    tutorialGlobalKey: jumpToKey,
+  ),
+];
 
-final currentSelectedBottomBarIndexProvider =
-    Provider.autoDispose.family<int, BuildContext>((ref, context) {
+final currentSelectedBottomBarIndexProvider = Provider.autoDispose((ref) {
   final location = ref.watch(currentRoutingLocation);
-  final bottomBarNav = ref.watch(bottomBarNavProvider(context));
 
   _log.info('bottom location: $location');
   final index =
-      bottomBarNav.indexWhere((t) => location.startsWith(t.initialLocation));
+      bottomBarItems.indexWhere((t) => location.startsWith(t.initialLocation));
   _log.info('bottom index: $index');
 
   return index < 0 ? fallbackBottomBarIdx : index;

--- a/app/lib/features/home/widgets/activities_icon.dart
+++ b/app/lib/features/home/widgets/activities_icon.dart
@@ -1,0 +1,39 @@
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/features/activities/providers/activities_providers.dart';
+import 'package:acter/features/home/data/keys.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ActivitiesIcon extends ConsumerWidget {
+  const ActivitiesIcon({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activities = ref.watch(hasActivitiesProvider);
+    const baseIcon = Icon(
+      Atlas.audio_wave_thin,
+      key: MainNavKeys.activities,
+    );
+    switch (activities) {
+      case HasActivities.important:
+        return Badge(
+          backgroundColor: Theme.of(context).colorScheme.badgeImportant,
+          child: baseIcon,
+        );
+      case HasActivities.urgent:
+        return Badge(
+          backgroundColor: Theme.of(context).colorScheme.badgeUrgent,
+          child: baseIcon,
+        );
+      case HasActivities.unread:
+        return Badge(
+          backgroundColor: Theme.of(context).colorScheme.badgeUnread,
+          child: baseIcon,
+        );
+      default:
+        // read and none, we do not show any icon to prevent notification fatigue
+        return baseIcon;
+    }
+  }
+}

--- a/app/lib/features/home/widgets/sidebar_widget.dart
+++ b/app/lib/features/home/widgets/sidebar_widget.dart
@@ -1,12 +1,17 @@
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/user_avatar.dart';
+import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/home/pages/home_shell.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
-import 'package:acter/features/home/providers/navigation.dart';
+import 'package:acter/features/home/widgets/activities_icon.dart';
+import 'package:acter/router/providers/router_providers.dart';
+import 'package:acter/router/utils.dart';
+import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,144 +19,341 @@ import 'package:logging/logging.dart';
 
 final _log = Logger('a3::home::sidebar');
 
+class _MyUserAvatar extends ConsumerWidget {
+  const _MyUserAvatar();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      key: Keys.avatar,
+      margin: const EdgeInsets.only(top: 8),
+      child: InkWell(
+        onTap: () => context.goNamed(Routes.settings.name),
+        child: const UserAvatarWidget(size: 20),
+      ),
+    );
+  }
+}
+
+class _SidebarItemIndicator extends ConsumerStatefulWidget {
+  final List<Routes> routes;
+  final bool reversed;
+  const _SidebarItemIndicator({
+    required this.routes,
+    this.reversed = false,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      __SidebarItemIndicatorState();
+}
+
+class __SidebarItemIndicatorState extends ConsumerState<_SidebarItemIndicator>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      value: widget.reversed ? 1 : 0,
+      vsync: this, // the SingleTickerProviderStateMixin
+      duration: const Duration(milliseconds: 400),
+    );
+    ref.listenManual(currentRoutingLocation, (previous, next) {
+      bool matches = false;
+      for (final route in widget.routes) {
+        if (next.startsWith(route.route)) {
+          matches = true;
+          break;
+        }
+      }
+      if (widget.reversed) {
+        if (!matches) {
+          _controller.forward();
+        } else {
+          _controller.reverse();
+        }
+      } else {
+        if (matches) {
+          _controller.forward();
+        } else {
+          _controller.reverse();
+        }
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context).navigationRailTheme;
+    return NavigationIndicator(
+      animation: _controller,
+      color: theme.indicatorColor,
+      shape: theme.indicatorShape,
+    );
+  }
+}
+
+class _SidebarItem extends StatelessWidget {
+  final Widget icon;
+  final Widget label;
+  final Widget? indicator;
+  final void Function() onTap;
+  final Key? tutorialGlobalKey;
+
+  const _SidebarItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.indicator,
+    this.tutorialGlobalKey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget inner = InkWell(
+      onTap: onTap,
+      child: icon,
+    );
+
+    if (indicator != null) {
+      inner = Stack(
+        children: [
+          Center(child: indicator!),
+          Center(child: inner),
+        ],
+      );
+    }
+
+    return Container(
+      height: 40,
+      width: 40,
+      key: tutorialGlobalKey,
+      margin: const EdgeInsets.all(12.0),
+      child: inner,
+    );
+  }
+}
+
 class SidebarWidget extends ConsumerWidget {
-  final NavigationRailLabelType labelType;
   final StatefulNavigationShell navigationShell;
 
   const SidebarWidget({
     super.key = Keys.mainNav,
-    required this.labelType,
     required this.navigationShell,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sidebarNavItems = ref.watch(sidebarItemsProvider(context));
-    final isGuest = ref.watch(alwaysClientProvider).isGuest();
+    final size = MediaQuery.of(context).size;
 
-    return Stack(
-      children: [
-        Container(
-          margin: const EdgeInsets.only(top: 80),
-          width: 70,
+    List<Widget> menu = [
+      const _MyUserAvatar(),
+      const Divider(indent: 18, endIndent: 18),
+      ..._menuItems(context, ref),
+    ];
+
+    if (size.height < 600) {
+      // we don't have enough space to show more,
+      // only show our main menu
+      return SingleChildScrollView(
+        child: SizedBox(
+          width: 72,
           child: Column(
-            children: sidebarNavItems
-                .map(
-                  (sidebarNav) => Container(
-                    key: sidebarNav.tutorialGlobalKey,
-                    margin: const EdgeInsets.all(12.0),
-                    height: 40,
-                    width: 40,
-                  ),
-                )
-                .toList(),
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              ...menu,
+              ..._trailing(context),
+            ],
           ),
         ),
-        AdaptiveScaffold.standardNavigationRail(
-          // main logic
-          destinations: sidebarNavItems,
-          selectedIndex: sidebarNavItems.indexed
-              .firstWhere(
-                (v) => v.$2.branch?.index == navigationShell.currentIndex,
-                orElse: () => (1, sidebarNavItems[0]),
-              )
-              .$1,
-          onDestinationSelected: (tabIndex) {
-            final item = sidebarNavItems[tabIndex];
-            if (item.location != null) {
-              // go to the initial location of the selected tab (by index)
-              if (item.isSpaceTab) {
-                context.go(item.location!);
-              } else if (item.pushToNavigate) {
-                context.push(item.location!);
-              }
-            } else if (item.branch != null) {
-              navigationShell.goBranch(
-                item.branch!.index,
-                initialLocation:
-                    item.branch!.index == navigationShell.currentIndex,
-              );
-            } else {
-              _log.severe(
-                "Sidebar navigation item doesn't have any proper target: $item",
-              );
-            }
-          },
+      );
+    }
 
-          // configuration
-          labelType: labelType,
-          padding: const EdgeInsets.all(0),
-          leading: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Visibility(
-                visible: !isGuest,
-                child: Container(
-                  key: Keys.avatar,
-                  margin: const EdgeInsets.only(top: 8),
-                  child: InkWell(
-                    onTap: () => context.goNamed(Routes.settings.name),
-                    child: const UserAvatarWidget(size: 20),
-                  ),
-                ),
+    return SizedBox(
+      width: 72,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const _MyUserAvatar(),
+          const Divider(indent: 18, endIndent: 18),
+          ..._menuItems(context, ref),
+          const Divider(indent: 18, endIndent: 18),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: _spacesList(context, ref),
               ),
-              Container(
-                height: 1,
-                margin:
-                    const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
-                color: Theme.of(context).colorScheme.primaryContainer,
+            ),
+          ),
+          ..._trailing(context),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _trailing(BuildContext context) {
+    return [
+      const Divider(indent: 18, endIndent: 18),
+      InkWell(
+        onTap: () => openBugReport(context),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Column(
+            children: [
+              const Icon(Atlas.bug_file_thin),
+              Text(
+                L10n.of(context).report,
+                style: Theme.of(context).textTheme.labelSmall,
+                softWrap: false,
               ),
             ],
           ),
-          trailing: Expanded(
-            child: Column(
-              children: [
-                const Spacer(),
-                const Divider(indent: 18, endIndent: 18),
-                InkWell(
-                  onTap: () => openBugReport(context),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    child: Column(
-                      children: [
-                        const Icon(Atlas.bug_file_thin),
-                        Text(
-                          L10n.of(context).report,
-                          style: Theme.of(context).textTheme.labelSmall,
-                          softWrap: false,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Visibility(
-                  visible: isGuest,
-                  child: InkWell(
-                    key: Keys.loginBtn,
-                    onTap: () => context.pushNamed(Routes.authLogin.name),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 5),
-                      child: Column(
-                        children: [
-                          const Icon(Atlas.entrance_thin),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 5),
-                            child: Text(
-                              L10n.of(context).logIn,
-                              style: Theme.of(context).textTheme.labelSmall,
-                              softWrap: false,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ).build(context),
-      ],
+        ),
+      ),
+    ];
+  }
+
+  void goToBranch(ShellBranch branch) {
+    navigationShell.goBranch(
+      branch.index,
+      initialLocation: branch.index == navigationShell.currentIndex,
     );
+  }
+
+  List<_SidebarItem> _menuItems(BuildContext context, WidgetRef ref) {
+    return [
+      _SidebarItem(
+        icon: const Icon(
+          Atlas.magnifying_glass_thin,
+          key: MainNavKeys.quickJump,
+        ),
+        label: Text(
+          'Jump',
+          style: Theme.of(context).textTheme.labelSmall,
+          softWrap: false,
+        ),
+        onTap: () => context.pushNamed(Routes.quickJump.name),
+        tutorialGlobalKey: jumpToKey,
+        indicator: const _SidebarItemIndicator(routes: [Routes.quickJump]),
+      ),
+      _SidebarItem(
+        icon: const Icon(
+          Atlas.home_thin,
+          key: MainNavKeys.dashboardHome,
+        ),
+        label: Text(
+          'Home',
+          style: Theme.of(context).textTheme.labelSmall,
+          softWrap: false,
+        ),
+        onTap: () => goToBranch(ShellBranch.homeShell),
+        tutorialGlobalKey: dashboardKey,
+        indicator: const _SidebarItemIndicator(
+          reversed: true,
+          routes: [
+            Routes.quickJump,
+            Routes.chat,
+            Routes.activities,
+          ],
+        ),
+      ),
+      _SidebarItem(
+        icon: const Icon(
+          Atlas.chats_thin,
+          key: MainNavKeys.chats,
+        ),
+        label: Text(
+          'Chat',
+          style: Theme.of(context).textTheme.labelSmall,
+          softWrap: false,
+        ),
+        onTap: () => goToBranch(ShellBranch.chatsShell),
+        indicator: const _SidebarItemIndicator(routes: [Routes.chat]),
+        tutorialGlobalKey: chatsKey,
+      ),
+      _SidebarItem(
+        icon: const ActivitiesIcon(),
+        label: Column(
+          children: [
+            Text(
+              'Activities',
+              style: Theme.of(context).textTheme.labelSmall,
+              softWrap: false,
+            ),
+            const SizedBox(height: 10),
+            const Divider(indent: 10, endIndent: 10),
+          ],
+        ),
+        onTap: () => goToBranch(ShellBranch.activitiesShell),
+        indicator: const _SidebarItemIndicator(routes: [Routes.activities]),
+        tutorialGlobalKey: activityKey,
+      ),
+    ];
+  }
+
+  List<_SidebarItem> _spacesList(BuildContext context, WidgetRef ref) {
+    final spaces = ref.watch(spacesProvider);
+
+    return spaces.map((space) {
+      final profileData = ref.watch(spaceProfileDataProvider(space));
+      final roomId = space.getRoomIdStr();
+      final canonicalParent = ref.watch(canonicalParentProvider(roomId));
+      return profileData.when(
+        loading: () => _SidebarItem(
+          icon: const Icon(Atlas.arrows_dots_rotate_thin),
+          label: Text(
+            roomId,
+            style: Theme.of(context).textTheme.labelSmall,
+            softWrap: false,
+          ),
+          onTap: () => context
+              .goNamed(Routes.space.name, pathParameters: {'spaceId': roomId}),
+        ),
+        error: (err, trace) => _SidebarItem(
+          icon: const Icon(Atlas.warning_bold),
+          label: Text(
+            '$roomId: $err',
+            style: Theme.of(context).textTheme.labelSmall,
+            softWrap: false,
+          ),
+          onTap: () => context
+              .goNamed(Routes.space.name, pathParameters: {'spaceId': roomId}),
+        ),
+        data: (info) => _SidebarItem(
+          icon: ActerAvatar(
+            mode: DisplayMode.Space,
+            avatarInfo: AvatarInfo(
+              uniqueId: roomId,
+              displayName: info.displayName,
+              avatar: info.getAvatarImage(),
+            ),
+            avatarsInfo: canonicalParent.valueOrNull != null
+                ? [
+                    AvatarInfo(
+                      uniqueId:
+                          canonicalParent.valueOrNull!.space.getRoomIdStr(),
+                      displayName:
+                          canonicalParent.valueOrNull!.profile.displayName,
+                      avatar:
+                          canonicalParent.valueOrNull!.profile.getAvatarImage(),
+                    ),
+                  ]
+                : [],
+            size: 48,
+          ),
+          label: Text(
+            info.displayName ?? roomId,
+            style: Theme.of(context).textTheme.labelSmall,
+            softWrap: false,
+          ),
+          onTap: () => context
+              .goNamed(Routes.space.name, pathParameters: {'spaceId': roomId}),
+        ),
+      );
+    }).toList();
   }
 }

--- a/app/lib/features/home/widgets/sidebar_widget.dart
+++ b/app/lib/features/home/widgets/sidebar_widget.dart
@@ -15,9 +15,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:logging/logging.dart';
-
-final _log = Logger('a3::home::sidebar');
 
 class _MyUserAvatar extends ConsumerWidget {
   const _MyUserAvatar();


### PR DESCRIPTION
- [x] Remove any `isDesktop` and make the Main Shell fully responsive:

https://github.com/acterglobal/a3/assets/40496/8c633700-f8f9-4bab-97a7-09b25aef0700

- [x] Rewrite the Sidebar widget to be more proper for our use case with:
    - [x] sticky main items
    - [x] scrolling only on spaces
    - [x] hiding of spaces if there isn't enough space

See it in action, too:

https://github.com/acterglobal/a3/assets/40496/cc29bb1f-d88d-4d46-8809-b2d7915cccd9


Hopefully this addresses #1754 - but there is no clear reasoning here why that happens ...


As a big part of all this, this removes a bunch of providers that are `BuildContext` dependent and thus cleans up a bunch of unnecessary redraws.