### PR TITLE
Chat room fixes

### DIFF
--- a/.changes/1771-fix-typing-notifications.md
+++ b/.changes/1771-fix-typing-notifications.md
@@ -1,0 +1,2 @@
+- [fix] do not send typing notifications if the user disabled that in the settings
+- [fix] only one room could be receiving typing state at a time despite multiple rooms actually being in that state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "ruma-common",
  "ruma-events",
  "sanitize-filename-reader-friendly",
+ "scc",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ base64ct = "1.6.0"
 derive-getters = "0.3.0"
 derive_builder = "0.20.0"
 icalendar = "0.16.1"
+scc = "2"
 
 [profile.release]
 panic = "unwind"

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -88,15 +88,14 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
     return OrientationBuilder(
       builder: (context, orientation) => Scaffold(
         resizeToAvoidBottomInset: orientation == Orientation.portrait,
-        body: CustomScrollView(
-          physics: const NeverScrollableScrollPhysics(),
-          slivers: [appBar(context), chatBody(context)],
+        body: Column(
+          children: [appBar(context), chatBody(context)],
         ),
       ),
     );
   }
 
-  SliverFillRemaining chatBody(BuildContext context) {
+  Widget chatBody(BuildContext context) {
     final userAppSettings = ref.watch(userAppSettingsProvider);
     final chatState = ref.watch(chatStateProvider(widget.convo));
     final userId = ref.watch(myUserIdStrProvider);
@@ -125,16 +124,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
       }
     }
 
-    final messages = chatState.messages
-        .where(
-          // filter only items we can show
-          (m) => m is! types.UnsupportedMessage,
-        )
-        .toList()
-        .reversed
-        .toList();
-
-    return SliverFillRemaining(
+    return Expanded(
       child: Container(
         decoration: const BoxDecoration(
           gradient: primaryGradient,
@@ -168,7 +158,7 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
             sendButtonAccessibilityLabel: '',
           ),
           timeFormat: DateFormat.jm(),
-          messages: messages,
+          messages: ref.watch(chatMessagesProvider(widget.convo)),
           onSendPressed: (types.PartialText partialText) {},
           user: types.User(id: userId),
           // disable image preview
@@ -255,11 +245,11 @@ class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
     );
   }
 
-  SliverAppBar appBar(BuildContext context) {
+  Widget appBar(BuildContext context) {
     final roomId = widget.convo.getRoomIdStr();
     final convoProfile = ref.watch(chatProfileDataProvider(widget.convo));
     final activeMembers = ref.watch(membersIdsProvider(roomId));
-    return SliverAppBar(
+    return AppBar(
       elevation: 0,
       automaticallyImplyLeading: widget.inSidebar ? false : true,
       centerTitle: true,

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -14,7 +14,9 @@ import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/providers/app_settings_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:riverpod/riverpod.dart';
 
 final autoDownloadMediaProvider =
@@ -40,6 +42,20 @@ final chatStateProvider =
     StateNotifierProvider.family<ChatRoomNotifier, ChatRoomState, Convo>(
   (ref, convo) => ChatRoomNotifier(ref: ref, convo: convo),
 );
+
+final chatMessagesProvider =
+    StateProvider.autoDispose.family<List<Message>, Convo>(
+  (ref, convo) => ref
+      .watch(chatStateProvider(convo).select((value) => value.messages))
+      .where(
+        // filter only items we can show
+        (m) => m is! types.UnsupportedMessage,
+      )
+      .toList()
+      .reversed
+      .toList(),
+);
+
 
 final isAuthorOfSelectedMessage =
     StateProvider.family<bool, String>((ref, roomId) {

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -14590,7 +14590,7 @@ class Api {
     return tmp9;
   }
 
-  TypingEvent? __clientTypingEventRxStreamPoll(
+  TypingEvent? __clientSubscribeToTypingEventStreamStreamPoll(
     int boxed,
     int postCobject,
     int port,
@@ -14608,7 +14608,7 @@ class Api {
     tmp3 = tmp2;
     tmp5 = tmp4;
     tmp7 = tmp6;
-    final tmp8 = _clientTypingEventRxStreamPoll(
+    final tmp8 = _clientSubscribeToTypingEventStreamStreamPoll(
       tmp1,
       tmp3,
       tmp5,
@@ -15956,16 +15956,6 @@ class Api {
           int Function(
             int,
           )>();
-  late final _typingEventRoomIdPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-            ffi.Int64,
-          )>>("__TypingEvent_room_id");
-
-  late final _typingEventRoomId = _typingEventRoomIdPtr.asFunction<
-      int Function(
-        int,
-      )>();
   late final _typingEventUserIdsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -24384,16 +24374,23 @@ class Api {
           _ClientDeviceChangedEventRxReturn Function(
             int,
           )>();
-  late final _clientTypingEventRxPtr = _lookup<
+  late final _clientSubscribeToTypingEventStreamPtr = _lookup<
       ffi.NativeFunction<
-          _ClientTypingEventRxReturn Function(
+          ffi.Int64 Function(
             ffi.Int64,
-          )>>("__Client_typing_event_rx");
+            ffi.Int64,
+            ffi.Uint64,
+            ffi.Uint64,
+          )>>("__Client_subscribe_to_typing_event_stream");
 
-  late final _clientTypingEventRx = _clientTypingEventRxPtr.asFunction<
-      _ClientTypingEventRxReturn Function(
-        int,
-      )>();
+  late final _clientSubscribeToTypingEventStream =
+      _clientSubscribeToTypingEventStreamPtr.asFunction<
+          int Function(
+            int,
+            int,
+            int,
+            int,
+          )>();
   late final _clientReceiptEventRxPtr = _lookup<
       ffi.NativeFunction<
           _ClientReceiptEventRxReturn Function(
@@ -30111,18 +30108,18 @@ class Api {
             int,
             int,
           )>();
-  late final _clientTypingEventRxStreamPollPtr = _lookup<
+  late final _clientSubscribeToTypingEventStreamStreamPollPtr = _lookup<
       ffi.NativeFunction<
-          _ClientTypingEventRxStreamPollReturn Function(
+          _ClientSubscribeToTypingEventStreamStreamPollReturn Function(
             ffi.Int64,
             ffi.Int64,
             ffi.Int64,
             ffi.Int64,
-          )>>("__Client_typing_event_rx_stream_poll");
+          )>>("__Client_subscribe_to_typing_event_stream_stream_poll");
 
-  late final _clientTypingEventRxStreamPoll =
-      _clientTypingEventRxStreamPollPtr.asFunction<
-          _ClientTypingEventRxStreamPollReturn Function(
+  late final _clientSubscribeToTypingEventStreamStreamPoll =
+      _clientSubscribeToTypingEventStreamStreamPollPtr.asFunction<
+          _ClientSubscribeToTypingEventStreamStreamPollReturn Function(
             int,
             int,
             int,
@@ -33131,27 +33128,12 @@ class ReceiptRecord {
   }
 }
 
-/// Deliver typing event from rust to flutter
+/// Deliver typing event from rust
 class TypingEvent {
   final Api _api;
   final _Box _box;
 
   TypingEvent._(this._api, this._box);
-
-  /// Get transaction id or flow id
-  RoomId roomId() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._typingEventRoomId(
-      tmp0,
-    );
-    final tmp3 = tmp1;
-    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_RoomId");
-    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = RoomId._(_api, tmp3_1);
-    return tmp2;
-  }
 
   /// Get list of user id
   FfiListUserId userIds() {
@@ -50083,22 +50065,37 @@ class Client {
   }
 
   /// Return the typing event receiver
-  Stream<TypingEvent>? typingEventRx() {
+  Stream<TypingEvent> subscribeToTypingEventStream(
+    String roomId,
+  ) {
+    final tmp1 = roomId;
     var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._clientTypingEventRx(
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._clientSubscribeToTypingEventStream(
       tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
     );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    if (tmp3 == 0) {
-      return null;
-    }
-    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-    final tmp4_1 = _Box(_api, tmp4_0, "__Client_typing_event_rx_stream_drop");
-    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
-    final tmp2 = _nativeStream(tmp4_1, _api.__clientTypingEventRxStreamPoll);
-    return tmp2;
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(
+        _api, tmp7_0, "__Client_subscribe_to_typing_event_stream_stream_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeStream(
+        tmp7_1, _api.__clientSubscribeToTypingEventStreamStreamPoll);
+    return tmp6;
   }
 
   /// Return the receipt event receiver
@@ -56064,13 +56061,6 @@ class _ClientDeviceChangedEventRxReturn extends ffi.Struct {
   external int arg1;
 }
 
-class _ClientTypingEventRxReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Int64()
-  external int arg1;
-}
-
 class _ClientReceiptEventRxReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -60254,7 +60244,7 @@ class _ClientDeviceChangedEventRxStreamPollReturn extends ffi.Struct {
   external int arg1;
 }
 
-class _ClientTypingEventRxStreamPollReturn extends ffi.Struct {
+class _ClientSubscribeToTypingEventStreamStreamPollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Int64()

--- a/native/acter/Cargo.toml
+++ b/native/acter/Cargo.toml
@@ -50,6 +50,7 @@ ruma-client-api = { workspace = true }
 ruma-common = { workspace = true, features = ["client", "unstable-unspecified"] }
 ruma-events = { workspace = true }
 sanitize-filename-reader-friendly = "2.2.1"
+scc = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { workspace = true }

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -300,11 +300,8 @@ object ReceiptRecord {
     fn receipt_thread() -> ReceiptThread;
 }
 
-/// Deliver typing event from rust to flutter
+/// Deliver typing event from rust
 object TypingEvent {
-    /// Get transaction id or flow id
-    fn room_id() -> RoomId;
-
     /// Get list of user id
     fn user_ids() -> Vec<UserId>;
 } 
@@ -2535,7 +2532,7 @@ object Client {
     fn device_changed_event_rx() -> Option<Stream<DeviceChangedEvent>>;
 
     /// Return the typing event receiver
-    fn typing_event_rx() -> Option<Stream<TypingEvent>>;
+    fn subscribe_to_typing_event_stream(room_id: string) -> Stream<TypingEvent>;
 
     /// Return the receipt event receiver
     fn receipt_event_rx() -> Option<Stream<ReceiptEvent>>;

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", features = ["rt", "macros"] }
 async-recursion = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 chrono-tz = { version = "0.8", default-features = false, features = ["serde"] }
-scc = "2"
+scc = { workspace = true }
 derive-getters = { workspace = true }
 derive_builder = { workspace = true }
 enum_dispatch = "0.3.12"

--- a/native/test/src/tests/typing.rs
+++ b/native/test/src/tests/typing.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use core::time::Duration;
 use tokio::time::sleep;
 use tokio_retry::{
@@ -49,24 +49,18 @@ async fn kyra_detects_sisko_typing() -> Result<()> {
     })
     .await?;
 
+    let mut event_rx = kyra.subscribe_to_typing_event(room_id.to_string());
     let sent = sisko_convo.typing_notice(true).await?;
     println!("sent: {sent:?}");
-
-    let mut event_rx = kyra
-        .typing_event_rx()
-        .context("kyra needs typing event receiver")?;
 
     let mut i = 10;
     let mut found = false;
     while i > 0 {
-        match event_rx.try_next() {
-            Ok(Some(event)) => {
+        match event_rx.try_recv() {
+            Ok(event) => {
                 info!("received: {event:?}");
                 found = true;
                 break;
-            }
-            Ok(None) => {
-                println!("received: none");
             }
             Err(e) => {
                 info!("received error: {:?}", e);


### PR DESCRIPTION
When wanting to working on some stuff for #1763, I noticed some improvements to be done on the chat:

- [x] Simplify chat room design to just use columns
- [x] Move message filtering and sorting into provider
- [x] fix typing notifications:
   - [x] settings was ignored when sending typing notifications
   - [x] have one typing notification stream per room - previously the stream meant we'd only be holding _the latest_ typing notification, which means we'd only ever show the typing for _one_ room max (despite having the state per room).   