### PR TITLE
Several smaller fixes on building aur package for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -495,9 +495,11 @@ jobs:
         with:
           name: Linux x64
       - run: |
-          sed -i "s/%{{VERSION}}%/${{ needs.tags.outputs.tag }}/" app/linux/packaging/aur/PKGBUILD-nightly
+          sed -i "s/%{{TAG}}%/${{ needs.tags.outputs.tag }}/" app/linux/packaging/aur/PKGBUILD-nightly
+          VERSION=${${{ needs.tags.outputs.tag }}//-/.}
+          sed -i "s/%{{VERSION}}%/$VERSION/" app/linux/packaging/aur/PKGBUILD-nightly
           sed -i "s/%{{PKGREL}}%/1/" app/linux/packaging/aur/PKGBUILD-nightly
-          sed -i "s/%{{LINUX_MD5}}%/`md5sum acter-nightly-linux-x64-2024-05-24.tar.bz2  | awk '{print $1}'`/" app/linux/packaging/aur/PKGBUILD-nightly
+          sed -i "s/%{{LINUX_MD5}}%/`md5sum acter-nightly-linux-x64-${{ needs.tags.outputs.tag }}.tar.bz2  | awk '{print $1}'`/" app/linux/packaging/aur/PKGBUILD-nightly
       - uses: KSXGitHub/github-actions-deploy-aur@v2.7.1
         with:
           pkgname: acter-nightly-bin

--- a/app/linux/packaging/aur/PKGBUILD-nightly
+++ b/app/linux/packaging/aur/PKGBUILD-nightly
@@ -19,7 +19,7 @@ backup=()
 options=()
 install=
 changelog=
-source=("https://github.com/acterglobal/a3/releases/download/nightly-${pkgver}/acter-nightly-linux-x64-${pkgver}.tar.bz2")
+source=("https://github.com/acterglobal/a3/releases/download/nightly-%{{TAG}}%/acter-nightly-linux-x64-%{{TAG}}%.tar.bz2")
 noextract=()
 md5sums=("%{{LINUX_MD5}}%")
 validpgpkeys=()
@@ -33,7 +33,7 @@ package() {
   install -dm644 "${pkgdir}/usr/share/licenses/${pkgname}"
 
   mv ./global.acter.a3.desktop "${pkgdir}/usr/share/applications"
-  mv ./acter-logo.png "${pkgdir}/usr/share/icons/acter/"
+  mv ./logo.png "${pkgdir}/usr/share/icons/acter/"
   mv ./LICENSE* "${pkgdir}/usr/share/licenses/${pkgname}/"
   # mv ./global.acter.a3.appdata.xml "${pkgdir}/usr/share/appdata/acter.appdata.xml"
   cp -ra ./data ./lib ./acter "${pkgdir}/usr/share/${pkgname}"


### PR DESCRIPTION
version for aur doesn't allow `-` so we need to have `tag` and version separated. secondly the `logo.png` had the wrong name and we had a faulty hard-coded version in the downloaded file for the md5sum.