### PR TITLE
Allow admins to redact space items

### DIFF
--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -5,7 +5,10 @@ import 'package:acter/common/providers/notifiers/notification_settings_notifier.
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:logging/logging.dart';
 import 'package:riverpod/riverpod.dart';
+
+final _log = Logger('a3::common::providers');
 
 // Loading Providers
 final loadingProvider = StateProvider<bool>((ref) => false);
@@ -77,3 +80,14 @@ final emailAddressesProvider = FutureProvider((ref) async {
   }
   return EmailAddresses(confirmed, unconfirmed);
 });
+
+final canRedactProvider = FutureProvider.autoDispose.family<bool, dynamic>(
+  ((ref, arg) async {
+    try {
+      return await arg.canRedact();
+    } catch (error) {
+      _log.severe('Fetching canRedact failed for $arg', error);
+      return false;
+    }
+  }),
+);

--- a/app/lib/common/widgets/redact_content.dart
+++ b/app/lib/common/widgets/redact_content.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::common::redact');
@@ -114,6 +115,7 @@ class RedactContentWidget extends ConsumerWidget {
         return;
       }
       EasyLoading.showToast(L10n.of(ctx).contentSuccessfullyRemoved);
+      if (ctx.canPop()) ctx.pop();
       if (onSuccess != null) {
         onSuccess!();
       }

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -142,6 +142,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
               eventId: event.eventId().toString(),
               onSuccess: () {
                 ref.invalidate(calendarEventProvider);
+                if (context.canPop()) context.pop();
                 if (context.mounted) {
                   context.goNamed(
                     Routes.spaceEvents.name,

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -181,7 +181,7 @@ class ActionBox extends ConsumerWidget {
               title: L10n.of(context).removeThisPost,
               eventId: news.eventId().toString(),
               onSuccess: () {
-                context.pop();
+                if (context.canPop()) context.pop();
                 ref.invalidate(newsListProvider);
               },
               senderId: senderId,

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/common_providers.dart';
-import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
@@ -165,37 +164,14 @@ class ActionBox extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final senderId = news.sender().toString();
-    final membership = ref.watch(roomMembershipProvider(roomId)).valueOrNull;
+    final canRedact = ref.watch(canRedactProvider(news));
     final isAuthor = senderId == userId;
     List<Widget> actions = [
       Text(L10n.of(context).actions),
       const Divider(),
     ];
 
-    if (!isAuthor) {
-      actions.add(
-        TextButton.icon(
-          key: NewsUpdateKeys.newsSidebarActionReportBtn,
-          onPressed: () => showAdaptiveDialog(
-            context: context,
-            builder: (context) => ReportContentWidget(
-              title: L10n.of(context).reportThisPost,
-              eventId: news.eventId().toString(),
-              description: L10n.of(context).reportPostContent,
-              senderId: senderId,
-              roomId: roomId,
-              isSpace: true,
-            ),
-          ),
-          icon: const Icon(Atlas.exclamation_chat_thin),
-          label: Text(L10n.of(context).reportThis),
-        ),
-      );
-    }
-
-    if (isAuthor &&
-        membership != null &&
-        membership.canString('CanRedactOwn')) {
+    if (canRedact.valueOrNull == true) {
       actions.add(
         TextButton.icon(
           key: NewsUpdateKeys.newsSidebarActionRemoveBtn,
@@ -216,6 +192,25 @@ class ActionBox extends ConsumerWidget {
           ),
           icon: const Icon(Atlas.trash_thin),
           label: Text(L10n.of(context).remove),
+        ),
+      );
+    } else if (!isAuthor) {
+      actions.add(
+        TextButton.icon(
+          key: NewsUpdateKeys.newsSidebarActionReportBtn,
+          onPressed: () => showAdaptiveDialog(
+            context: context,
+            builder: (context) => ReportContentWidget(
+              title: L10n.of(context).reportThisPost,
+              eventId: news.eventId().toString(),
+              description: L10n.of(context).reportPostContent,
+              senderId: senderId,
+              roomId: roomId,
+              isSpace: true,
+            ),
+          ),
+          icon: const Icon(Atlas.exclamation_chat_thin),
+          label: Text(L10n.of(context).reportThis),
         ),
       );
     }

--- a/app/lib/features/pins/pages/pin_page.dart
+++ b/app/lib/features/pins/pages/pin_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
@@ -37,6 +38,7 @@ class PinPage extends ConsumerWidget {
     final spaceId = pin.roomIdStr();
     List<PopupMenuEntry<String>> actions = [];
     final pinEditNotifier = ref.watch(pinEditProvider(pin).notifier);
+    final canRedact = ref.watch(canRedactProvider(pin));
     final membership = ref.watch(roomMembershipProvider(spaceId));
     if (membership.valueOrNull != null) {
       final memb = membership.requireValue!;
@@ -56,8 +58,7 @@ class PinPage extends ConsumerWidget {
         );
       }
 
-      if (memb.canString('CanRedactOwn') &&
-          memb.userId().toString() == pin.sender().toString()) {
+      if (canRedact.valueOrNull == true) {
         final roomId = pin.roomIdStr();
         actions.add(
           PopupMenuItem<String>(

--- a/app/lib/features/pins/pages/pin_page.dart
+++ b/app/lib/features/pins/pages/pin_page.dart
@@ -117,9 +117,7 @@ class PinPage extends ConsumerWidget {
         title: L10n.of(context).removeThisPin,
         eventId: pin.eventIdStr(),
         onSuccess: () {
-          if (context.mounted && context.canPop()) {
-            context.pop();
-          }
+          if (context.canPop()) context.pop();
         },
         senderId: pin.sender().toString(),
         roomId: roomId,

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -2414,6 +2414,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __newsEntryCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _newsEntryCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   ReactionManager? __newsEntryReactionsFuturePoll(
     int boxed,
     int postCobject,
@@ -2781,6 +2825,50 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_ActerPin");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = ActerPin._(this, tmp13_1);
+    return tmp7;
+  }
+
+  bool? __acterPinCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _acterPinCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -6863,6 +6951,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __taskCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _taskCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   CommentsManager? __taskCommentsFuturePoll(
     int boxed,
     int postCobject,
@@ -7190,6 +7322,50 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_TaskList");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = TaskList._(this, tmp13_1);
+    return tmp7;
+  }
+
+  bool? __taskListCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _taskListCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -16293,6 +16469,16 @@ class Api {
       int Function(
         int,
       )>();
+  late final _newsEntryCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__NewsEntry_can_redact");
+
+  late final _newsEntryCanRedact = _newsEntryCanRedactPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _newsEntryReactionsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -16677,6 +16863,16 @@ class Api {
           )>>("__ActerPin_refresh");
 
   late final _acterPinRefresh = _acterPinRefreshPtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _acterPinCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__ActerPin_can_redact");
+
+  late final _acterPinCanRedact = _acterPinCanRedactPtr.asFunction<
       int Function(
         int,
       )>();
@@ -20279,6 +20475,16 @@ class Api {
       int Function(
         int,
       )>();
+  late final _taskCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Task_can_redact");
+
+  late final _taskCanRedact = _taskCanRedactPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _taskCommentsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -21140,6 +21346,16 @@ class Api {
           )>>("__TaskList_refresh");
 
   late final _taskListRefresh = _taskListRefreshPtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _taskListCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__TaskList_can_redact");
+
+  late final _taskListCanRedact = _taskListCanRedactPtr.asFunction<
       int Function(
         int,
       )>();
@@ -26214,6 +26430,21 @@ class Api {
             int,
             int,
           )>();
+  late final _newsEntryCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _NewsEntryCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__NewsEntry_can_redact_future_poll");
+
+  late final _newsEntryCanRedactFuturePoll =
+      _newsEntryCanRedactFuturePollPtr.asFunction<
+          _NewsEntryCanRedactFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _newsEntryReactionsFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _NewsEntryReactionsFuturePollReturn Function(
@@ -26329,6 +26560,21 @@ class Api {
   late final _acterPinRefreshFuturePoll =
       _acterPinRefreshFuturePollPtr.asFunction<
           _ActerPinRefreshFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _acterPinCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _ActerPinCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__ActerPin_can_redact_future_poll");
+
+  late final _acterPinCanRedactFuturePoll =
+      _acterPinCanRedactFuturePollPtr.asFunction<
+          _ActerPinCanRedactFuturePollReturn Function(
             int,
             int,
             int,
@@ -27629,6 +27875,20 @@ class Api {
         int,
         int,
       )>();
+  late final _taskCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _TaskCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Task_can_redact_future_poll");
+
+  late final _taskCanRedactFuturePoll = _taskCanRedactFuturePollPtr.asFunction<
+      _TaskCanRedactFuturePollReturn Function(
+        int,
+        int,
+        int,
+      )>();
   late final _taskCommentsFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _TaskCommentsFuturePollReturn Function(
@@ -27726,6 +27986,21 @@ class Api {
   late final _taskListRefreshFuturePoll =
       _taskListRefreshFuturePollPtr.asFunction<
           _TaskListRefreshFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _taskListCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _TaskListCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__TaskList_can_redact_future_poll");
+
+  late final _taskListCanRedactFuturePoll =
+      _taskListCanRedactFuturePollPtr.asFunction<
+          _TaskListCanRedactFuturePollReturn Function(
             int,
             int,
             int,
@@ -33987,6 +34262,21 @@ class NewsEntry {
     return tmp2;
   }
 
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._newsEntryCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__NewsEntry_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__newsEntryCanRedactFuturePoll);
+    return tmp2;
+  }
+
   /// get the reaction manager
   Future<ReactionManager> reactions() {
     var tmp0 = 0;
@@ -34707,6 +34997,21 @@ class ActerPin {
     final tmp3_1 = _Box(_api, tmp3_0, "__ActerPin_refresh_future_drop");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp2 = _nativeFuture(tmp3_1, _api.__acterPinRefreshFuturePoll);
+    return tmp2;
+  }
+
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._acterPinCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__ActerPin_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__acterPinCanRedactFuturePoll);
     return tmp2;
   }
 
@@ -42311,6 +42616,21 @@ class Task {
     return tmp2;
   }
 
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._taskCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Task_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__taskCanRedactFuturePoll);
+    return tmp2;
+  }
+
   /// get the comments manager for this task
   Future<CommentsManager> comments() {
     var tmp0 = 0;
@@ -43649,6 +43969,21 @@ class TaskList {
     final tmp3_1 = _Box(_api, tmp3_0, "__TaskList_refresh_future_drop");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp2 = _nativeFuture(tmp3_1, _api.__taskListRefreshFuturePoll);
+    return tmp2;
+  }
+
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._taskListCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__TaskList_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__taskListCanRedactFuturePoll);
     return tmp2;
   }
 
@@ -56552,6 +56887,21 @@ class _NewsSlideSourceBinaryFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _NewsEntryCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _NewsEntryReactionsFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -56669,6 +57019,21 @@ class _ActerPinRefreshFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _ActerPinCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 
@@ -57985,6 +58350,21 @@ class _TaskRefreshFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _TaskCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _TaskCommentsFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -58087,6 +58467,21 @@ class _TaskListRefreshFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _TaskListCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -41262,6 +41262,8 @@ class Convo {
 
   /// redact an event from this room
   /// reason - The reason for the event being reported (optional).
+  /// it's the callers job to ensure the person has the privileges to
+  /// redact that content.
   Future<EventId> redactContent(
     String eventId,
     String? reason,
@@ -46822,6 +46824,8 @@ class Space {
 
   /// redact an event from this room
   /// reason - The reason for the event being reported (optional).
+  /// it's the callers job to ensure the person has the privileges to
+  /// redact that content.
   Future<EventId> redactContent(
     String eventId,
     String? reason,

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1303,6 +1303,8 @@ object Convo {
 
     /// redact an event from this room
     /// reason - The reason for the event being reported (optional).
+    /// it's the callers job to ensure the person has the privileges to
+    /// redact that content.
     fn redact_content(event_id: string, reason: Option<string>) -> Future<Result<EventId>>;
 
     fn is_joined() -> bool;
@@ -2048,6 +2050,8 @@ object Space {
 
     /// redact an event from this room
     /// reason - The reason for the event being reported (optional).
+    /// it's the callers job to ensure the person has the privileges to
+    /// redact that content.
     fn redact_content(event_id: string, reason: Option<string>) -> Future<Result<EventId>>;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -410,6 +410,9 @@ object NewsEntry {
 
     /// get event id
     fn event_id() -> EventId;
+    
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 
     /// get the reaction manager
     fn reactions() -> Future<Result<ReactionManager>>;
@@ -518,6 +521,9 @@ object ActerPin {
 
     /// replace the current pin with one with the latest state
     fn refresh() -> Future<Result<ActerPin>>;
+
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 
     /// get the comments manager for this pin
     fn comments() -> Future<Result<CommentsManager>>;
@@ -1521,6 +1527,9 @@ object Task {
 
     /// replace the current task with one with the latest state
     fn refresh() -> Future<Result<Task>>;
+    
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 
     /// get the comments manager for this task
     fn comments() -> Future<Result<CommentsManager>>;
@@ -1684,6 +1693,9 @@ object TaskList {
 
     /// replace the current task with one with the latest state
     fn refresh() -> Future<Result<TaskList>>;
+
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 
     /// the space this TaskList belongs to
     fn space() -> Space;

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -1,6 +1,6 @@
 use acter_core::{
     events::attachments::{AttachmentBuilder, AttachmentContent, FallbackAttachmentContent},
-    models::{self, ActerModel, AnyActerModel},
+    models::{self, can_redact, ActerModel, AnyActerModel},
 };
 use anyhow::{bail, Context, Result};
 use futures::stream::StreamExt;
@@ -87,6 +87,15 @@ impl Attachment {
 
     pub fn msg_content(&self) -> MsgContent {
         MsgContent::from(&self.inner.content)
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.inner.meta.sender.to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
+            .await?
     }
 
     pub async fn download_media(

--- a/native/acter/src/api/calendar_events.rs
+++ b/native/acter/src/api/calendar_events.rs
@@ -6,7 +6,7 @@ use acter_core::{
         rsvp::RsvpStatus,
         UtcDateTime,
     },
-    models::{self, ActerModel, AnyActerModel},
+    models::{self, can_redact, ActerModel, AnyActerModel},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -196,6 +196,15 @@ impl CalendarEvent {
                 };
                 Ok(CalendarEvent::new(client, room, inner))
             })
+            .await?
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.inner.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
             .await?
     }
 

--- a/native/acter/src/api/comments.rs
+++ b/native/acter/src/api/comments.rs
@@ -1,6 +1,6 @@
 use acter_core::{
     events::comments::CommentBuilder,
-    models::{self, ActerModel, AnyActerModel},
+    models::{self, can_redact, ActerModel, AnyActerModel},
 };
 use anyhow::{bail, Context, Result};
 use futures::stream::StreamExt;
@@ -63,6 +63,15 @@ impl Comment {
             room: self.room.clone(),
             inner: self.inner.reply_builder(),
         })
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
+            .await?
     }
 
     pub fn sender(&self) -> OwnedUserId {

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -3,7 +3,7 @@ use acter_core::{
         news::{self, FallbackNewsContent, NewsContent, NewsEntryBuilder, NewsSlideBuilder},
         Colorize, ColorizeBuilder, ObjRef,
     },
-    models::{self, ActerModel, AnyActerModel, ReactionManager},
+    models::{self, can_redact, ActerModel, AnyActerModel, ReactionManager},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -411,6 +411,15 @@ impl NewsEntry {
                 };
                 NewsEntry::new(client, room, content).await
             })
+            .await?
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.content.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
             .await?
     }
 

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -3,7 +3,7 @@ use acter_core::{
         pins::{self, PinBuilder},
         Icon,
     },
-    models::{self, ActerModel, AnyActerModel},
+    models::{self, can_redact, ActerModel, AnyActerModel},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -277,6 +277,15 @@ impl Pin {
                     content,
                 })
             })
+            .await?
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.content.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
             .await?
     }
 

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -1674,6 +1674,9 @@ impl Room {
             .await?
     }
 
+    /// sent a redaction message for this content
+    /// it's the callers job to ensure the person has the privileges to
+    /// redact that content.
     pub async fn redact_content(
         &self,
         event_id: String,
@@ -1688,16 +1691,6 @@ impl Room {
 
         RUNTIME
             .spawn(async move {
-                let evt = room.event(&event_id).await?;
-                let event_content = evt.event.deserialize_as::<RoomMessageEvent>()?;
-                let permitted = if event_content.sender() == my_id {
-                    room.can_user_redact_own(&my_id).await?
-                } else {
-                    room.can_user_redact_other(&my_id).await?
-                };
-                if !permitted {
-                    bail!("No permissions to redact this message");
-                }
                 let response = room.redact(&event_id, reason.as_deref(), None).await?;
                 Ok(response.event_id)
             })

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -3,7 +3,7 @@ use acter_core::{
         tasks::{self, Priority, TaskBuilder, TaskListBuilder},
         Color,
     },
-    models::{self, ActerModel, AnyActerModel, TaskStats},
+    models::{self, can_redact, ActerModel, AnyActerModel, TaskStats},
     statics::KEYS,
 };
 use anyhow::{bail, Context, Result};
@@ -391,6 +391,15 @@ impl TaskList {
             .await?
     }
 
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.content.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
+            .await?
+    }
+
     pub fn subscribe_stream(&self) -> impl Stream<Item = bool> {
         BroadcastStream::new(self.subscribe()).map(|_| true)
     }
@@ -617,6 +626,15 @@ impl Task {
                     content,
                 })
             })
+            .await?
+    }
+
+    pub async fn can_redact(&self) -> Result<bool> {
+        let sender = self.content.sender().to_owned();
+        let room = self.room.clone();
+
+        RUNTIME
+            .spawn(async move { Ok(can_redact(&room, &sender).await?) })
             .await?
     }
 

--- a/native/core/src/models.rs
+++ b/native/core/src/models.rs
@@ -285,6 +285,19 @@ impl EventMeta {
     }
 }
 
+pub async fn can_redact(room: &matrix_sdk::Room, sender_id: &UserId) -> crate::error::Result<bool> {
+    let client = room.client();
+    let Some(user_id) = client.user_id() else {
+        // not logged in means we can't redact
+        return Ok(false);
+    };
+    Ok(if sender_id == user_id {
+        room.can_user_redact_own(user_id).await?
+    } else {
+        room.can_user_redact_other(user_id).await?
+    })
+}
+
 #[enum_dispatch]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AnyActerModel {

--- a/native/core/src/models/tasks/task.rs
+++ b/native/core/src/models/tasks/task.rs
@@ -44,6 +44,10 @@ impl Task {
         &self.meta.room_id
     }
 
+    pub fn sender(&self) -> &UserId {
+        &self.meta.sender
+    }
+
     pub fn is_done(&self) -> bool {
         self.inner
             .progress_percent

--- a/native/core/src/models/tasks/task_list.rs
+++ b/native/core/src/models/tasks/task_list.rs
@@ -47,6 +47,10 @@ impl TaskList {
         format!("{}::{}", self.meta.event_id, KEYS::TASKS::TASKS)
     }
 
+    pub fn sender(&self) -> &UserId {
+        &self.meta.sender
+    }
+
     pub fn redacted(&self) -> bool {
         false
     }


### PR DESCRIPTION
Fixes #1658 by providing a new backend feature of `canRedact` on our space objects that directly checks for `CanRedactOwn` and `CanRedactOther` respectively. A generic provider then implements checking them and the UI is updated to use that new feature.

Before, I only see "Report" for news that aren't mine

https://github.com/acterglobal/a3/assets/40496/ac4c916b-28c4-4b0c-8195-ce07d0c57190

After, I see "remove" for news items of spaces I am admin of, too:

https://github.com/acterglobal/a3/assets/40496/edc5426c-fcd5-4105-b25a-7cb94262e923


For the reviewer: the change is split into two parts, the Rust-side and the UI-side. The majority of refactoring on the UI side comes from removing a level of indentation, but effectively only `membership.canString` has been replaced.

Fixes [a3-meta/#253](https://github.com/acterglobal/a3-meta/issues/253), too:


https://github.com/acterglobal/a3/assets/40496/e6f47669-b3cc-47db-883e-8bbdf54b623a



