### PR TITLE
Fixing NoClientException at startup

### DIFF
--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -93,8 +93,10 @@ class HomeShellState extends ConsumerState<HomeShell> {
   }
 
   Future<void> initNotifications() async {
-    final client = ref.read(alwaysClientProvider);
-    _initPushForClient(client);
+    final client = ref.read(clientProvider);
+    if (client != null) {
+      _initPushForClient(client);
+    }
     ref.listenManual(clientProvider, (previous, next) {
       if (next != null) {
         _initPushForClient(next);


### PR DESCRIPTION
Noticed a NoClientException at startup coming from the initState of the HomeShell:
```
[GoRouter] Using MaterialApp configuration
flutter: Routing updated: /dashboard
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Instance of 'NoClientException'
#1      ProviderContainer.read (package:riverpod/src/framework/container.dart:241:21)
#2      ConsumerStatefulElement.read (package:flutter_riverpod/src/consumer.dart:623:59)
#3      HomeShellState.initNotifications (package:acter/features/home/pages/home_shell.dart:96:24)
#4      HomeShellState.initState (package:acter/features/home/pages/home_shell.dart:76:5)
#5      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:5611:55)
```


Made the code more robust to continue without failure.