### PR TITLE
Revive Backup and Reset for new secure storage

### DIFF
--- a/app/lib/features/cli/commands/backup-and-reset.dart
+++ b/app/lib/features/cli/commands/backup-and-reset.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:acter/features/cli/util.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
@@ -15,10 +16,16 @@ class BackupAndResetCommand extends Command {
   final description =
       'Backup accounts and sessions and reset the state to fresh and clean';
 
-  BackupAndResetCommand();
+  BackupAndResetCommand() {
+    argParser.addFlag(
+      'dry',
+      help: 'dry run, do not actually write stuff',
+    );
+  }
 
   @override
   Future<void> run() async {
+    final isDry = argResults!.flag('dry');
     final now = DateTime.now();
     final tzMinTotal = now.timeZoneOffset.inMinutes;
     final separator = tzMinTotal.isNegative ? '-' : '+';
@@ -26,7 +33,10 @@ class BackupAndResetCommand extends Command {
     final tzRemainMins = (tzMinTotal % 60).abs().toString().padLeft(2, '0');
     final date = now.toIso8601String().replaceAll(':', '_');
     final String stamper = '$date$separator${tzHours}_$tzRemainMins';
-    print('Backup stamp will be: $stamper');
+    if (isDry) {
+      print(' --- ⚠️ Running in Dry mode, not actually changing your data -- ');
+    }
+    // print('Backup stamp will be: $stamper');
     final appInfo = await AppInfo.make();
     if (appInfo.sessions.isEmpty) {
       print('⚠️ No active sessions found.');
@@ -34,8 +44,8 @@ class BackupAndResetCommand extends Command {
       final encoded = json.encode(appInfo.sessions);
       final filePath = p.join(appInfo.appDocPath, 'sessions_backup_$stamper');
       final f = await File(filePath).create(exclusive: true);
-      f.writeAsString(encoded);
-      print('✔️ Sessions backed up ');
+      if (!isDry) f.writeAsString(encoded);
+      print('✔️ Sessions backed up to: $filePath');
     }
 
     if (appInfo.accounts.isEmpty) {
@@ -44,12 +54,17 @@ class BackupAndResetCommand extends Command {
       for (final a in appInfo.accounts) {
         final oldPath = p.join(appInfo.appDocPath, a);
         final newPath = p.join(appInfo.appDocPath, '${a}_backup_$stamper');
-        await Directory(oldPath).rename(newPath);
-        print('✔️ $a backed up ');
+        if (!isDry) await Directory(oldPath).rename(newPath);
+        print('✔️ $a backed up: $newPath');
       }
     }
 
-    await appInfo.preferences.clear();
+    if (!isDry) {
+      await ActerSdk.storage.write(
+        key: defaultSessionKey,
+        value: json.encode([]),
+      );
+    }
     print('✔️ All reset');
     exit(0);
   }

--- a/app/lib/features/cli/util.dart
+++ b/app/lib/features/cli/util.dart
@@ -1,20 +1,17 @@
 import 'dart:io';
 
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 final backupFormatFinder = RegExp(r'_backup_[0-9-_T.+]+$');
 
 class AppInfo {
   final String appDocPath;
-  final SharedPreferences preferences;
   final List<String> sessions;
   final List<FileSystemEntity> logFiles;
   final List<String> accounts;
 
   const AppInfo(
     this.appDocPath,
-    this.preferences,
     this.sessions,
     this.logFiles,
     this.accounts,
@@ -22,8 +19,7 @@ class AppInfo {
 
   static Future<AppInfo> make() async {
     String appDocPath = await appDir();
-    SharedPreferences pref = await sharedPrefs();
-    List<String> sessions = (pref.getStringList(defaultSessionKey) ?? []);
+    List<String> sessions = await ActerSdk.sessionKeys() ?? [];
 
     // directory
     final dir = Directory(appDocPath);
@@ -57,6 +53,6 @@ class AppInfo {
           .changed
           .compareTo(FileStat.statSync(a.path).changed),
     );
-    return AppInfo(appDocPath, pref, sessions, logFiles, accounts);
+    return AppInfo(appDocPath, sessions, logFiles, accounts);
   }
 }


### PR DESCRIPTION
In an attempt to help us with #1728  , this exposes the session reader for the secure storage key for the cli and allows to reset it via the cli. Also adds a `--dry` flag to allow for easier testing.