### PR TITLE
Bookmarking spaces

### DIFF
--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -23,6 +23,10 @@ final spacesProvider =
   return SpaceListNotifier(ref: ref, client: client);
 });
 
+final bookmarkedSpacesProvider = Provider(
+  (ref) => ref.watch(spacesProvider).where((s) => s.isBookmarked()).toList(),
+);
+
 /// List of spaces other than current space and it's parent space
 final otherSpacesForInviteMembersProvider = FutureProvider.autoDispose
     .family<List<Space>, String>((ref, spaceId) async {

--- a/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.dart
+++ b/app/lib/features/chat/models/room_list_filter_state/room_list_filter_state.dart
@@ -17,7 +17,7 @@ Future<bool> roomListFilterStateAppliesToRoom(
       }
       break;
     case FilterSelection.favorites:
-      if (!convo.isFavorite()) {
+      if (!convo.isBookmarked()) {
         return false;
       }
       break;

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -231,12 +231,12 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
         // Bookmark
         convoLoader.when(
           data: (conv) {
-            final isFav = conv.isFavorite();
+            final isBookmarked = conv.isBookmarked();
             return _actionItem(
               context: context,
-              iconData: isFav ? Icons.bookmark : Icons.bookmark_border,
+              iconData: isBookmarked ? Icons.bookmark : Icons.bookmark_border,
               actionName: L10n.of(context).bookmark,
-              onTap: () async => await conv.setFavorite(!isFav),
+              onTap: () async => await conv.setBookmarked(!isBookmarked),
             );
           },
           error: (e, st) => Skeletonizer(

--- a/app/lib/features/space/widgets/space_toolbar.dart
+++ b/app/lib/features/space/widgets/space_toolbar.dart
@@ -19,6 +19,8 @@ class SpaceToolbar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final membership = ref.watch(roomMembershipProvider(spaceId)).valueOrNull;
+    final isBookmarked = ref.watch(spaceProvider(spaceId).select(
+        (asyncValue) => (asyncValue.valueOrNull?.isBookmarked()) == true,),);
     final invited =
         ref.watch(spaceInvitedMembersProvider(spaceId)).valueOrNull ?? [];
     final showInviteBtn = membership?.canString('CanInvite') == true;
@@ -74,6 +76,12 @@ class SpaceToolbar extends ConsumerWidget {
                 child: Text(L10n.of(context).invite),
               )
             : const SizedBox.shrink(),
+        IconButton(
+          icon: Icon(isBookmarked ? Icons.bookmark : Icons.bookmark_border),
+          onPressed: () async =>
+              await (await ref.read(spaceProvider(spaceId).future))
+                  .setBookmarked(!isBookmarked),
+        ),
         PopupMenuButton(
           icon: Icon(
             key: optionsMenu,

--- a/app/lib/features/spaces/pages/spaces_page.dart
+++ b/app/lib/features/spaces/pages/spaces_page.dart
@@ -88,7 +88,10 @@ class _SpacesPageState extends ConsumerState<SpacesPage> {
                 final space = spaces[index];
                 final roomId = space.getRoomIdStr();
                 return SpaceCard(
-                  onTap: () => context.go('/$roomId'),
+                  onTap: () => context.pushNamed(
+                    Routes.space.name,
+                    pathParameters: {'spaceId': roomId},
+                  ),
                   key: Key('space-list-item-$roomId'),
                   space: space,
                 );

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -115,6 +115,7 @@
   "@bookmark": {},
   "bookmarked": "Bookmarked",
   "@bookmarked": {},
+  "bookmarkedSpaces": "Bookmarked Spaces",
   "builtOnShouldersOfGiants": "Built on the shoulders of giants",
   "@builtOnShouldersOfGiants": {},
   "calendarEventsFromAllTheSpaces": "Calendar events from all the Spaces you are part of",

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -8157,6 +8157,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __spaceSetBookmarkedFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceSetBookmarkedFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   FfiListFfiString? __spaceActiveMembersIdsFuturePoll(
     int boxed,
     int postCobject,
@@ -22665,6 +22709,28 @@ class Api {
         int,
         int,
       )>();
+  late final _spaceIsBookmarkedPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.Int64,
+          )>>("__Space_is_bookmarked");
+
+  late final _spaceIsBookmarked = _spaceIsBookmarkedPtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _spaceSetBookmarkedPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+            ffi.Uint8,
+          )>>("__Space_set_bookmarked");
+
+  late final _spaceSetBookmarked = _spaceSetBookmarkedPtr.asFunction<
+      int Function(
+        int,
+        int,
+      )>();
   late final _spaceActiveMembersIdsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -28389,6 +28455,21 @@ class Api {
         int,
         int,
       )>();
+  late final _spaceSetBookmarkedFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _SpaceSetBookmarkedFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Space_set_bookmarked_future_poll");
+
+  late final _spaceSetBookmarkedFuturePoll =
+      _spaceSetBookmarkedFuturePollPtr.asFunction<
+          _SpaceSetBookmarkedFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _spaceActiveMembersIdsFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _SpaceActiveMembersIdsFuturePollReturn Function(
@@ -46368,6 +46449,39 @@ class Space {
     return tmp6;
   }
 
+  /// is this a bookmarked space
+  bool isBookmarked() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._spaceIsBookmarked(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// set this a bookmarked space
+  Future<bool> setBookmarked(
+    bool isBookmarked,
+  ) {
+    final tmp1 = isBookmarked;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    final tmp3 = _api._spaceSetBookmarked(
+      tmp0,
+      tmp2,
+    );
+    final tmp5 = tmp3;
+    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
+    final tmp5_1 = _Box(_api, tmp5_0, "__Space_set_bookmarked_future_drop");
+    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
+    final tmp4 = _nativeFuture(tmp5_1, _api.__spaceSetBookmarkedFuturePoll);
+    return tmp4;
+  }
+
   /// the members currently in the space
   Future<FfiListFfiString> activeMembersIds() {
     var tmp0 = 0;
@@ -58978,6 +59092,21 @@ class _SpaceSetNameFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _SpaceSetBookmarkedFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -5725,7 +5725,7 @@ class Api {
     return tmp7;
   }
 
-  bool? __convoSetFavoriteFuturePoll(
+  bool? __convoSetBookmarkedFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -5739,7 +5739,7 @@ class Api {
     tmp1 = tmp0;
     tmp3 = tmp2;
     tmp5 = tmp4;
-    final tmp6 = _convoSetFavoriteFuturePoll(
+    final tmp6 = _convoSetBookmarkedFuturePoll(
       tmp1,
       tmp3,
       tmp5,
@@ -19705,24 +19705,24 @@ class Api {
       int Function(
         int,
       )>();
-  late final _convoIsFavoritePtr = _lookup<
+  late final _convoIsBookmarkedPtr = _lookup<
       ffi.NativeFunction<
           ffi.Uint8 Function(
             ffi.Int64,
-          )>>("__Convo_is_favorite");
+          )>>("__Convo_is_bookmarked");
 
-  late final _convoIsFavorite = _convoIsFavoritePtr.asFunction<
+  late final _convoIsBookmarked = _convoIsBookmarkedPtr.asFunction<
       int Function(
         int,
       )>();
-  late final _convoSetFavoritePtr = _lookup<
+  late final _convoSetBookmarkedPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
             ffi.Int64,
             ffi.Uint8,
-          )>>("__Convo_set_favorite");
+          )>>("__Convo_set_bookmarked");
 
-  late final _convoSetFavorite = _convoSetFavoritePtr.asFunction<
+  late final _convoSetBookmarked = _convoSetBookmarkedPtr.asFunction<
       int Function(
         int,
         int,
@@ -27619,17 +27619,17 @@ class Api {
             int,
             int,
           )>();
-  late final _convoSetFavoriteFuturePollPtr = _lookup<
+  late final _convoSetBookmarkedFuturePollPtr = _lookup<
       ffi.NativeFunction<
-          _ConvoSetFavoriteFuturePollReturn Function(
+          _ConvoSetBookmarkedFuturePollReturn Function(
             ffi.Int64,
             ffi.Int64,
             ffi.Int64,
-          )>>("__Convo_set_favorite_future_poll");
+          )>>("__Convo_set_bookmarked_future_poll");
 
-  late final _convoSetFavoriteFuturePoll =
-      _convoSetFavoriteFuturePollPtr.asFunction<
-          _ConvoSetFavoriteFuturePollReturn Function(
+  late final _convoSetBookmarkedFuturePoll =
+      _convoSetBookmarkedFuturePollPtr.asFunction<
+          _ConvoSetBookmarkedFuturePollReturn Function(
             int,
             int,
             int,
@@ -41012,11 +41012,11 @@ class Convo {
     return tmp2;
   }
 
-  /// is this a favorite chat
-  bool isFavorite() {
+  /// is this a bookmarked chat
+  bool isBookmarked() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._convoIsFavorite(
+    final tmp1 = _api._convoIsBookmarked(
       tmp0,
     );
     final tmp3 = tmp1;
@@ -41024,24 +41024,24 @@ class Convo {
     return tmp2;
   }
 
-  /// set this a favorite chat
-  Future<bool> setFavorite(
-    bool isFavorite,
+  /// set this a bookmarked chat
+  Future<bool> setBookmarked(
+    bool isBookmarked,
   ) {
-    final tmp1 = isFavorite;
+    final tmp1 = isBookmarked;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1 ? 1 : 0;
-    final tmp3 = _api._convoSetFavorite(
+    final tmp3 = _api._convoSetBookmarked(
       tmp0,
       tmp2,
     );
     final tmp5 = tmp3;
     final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
-    final tmp5_1 = _Box(_api, tmp5_0, "__Convo_set_favorite_future_drop");
+    final tmp5_1 = _Box(_api, tmp5_0, "__Convo_set_bookmarked_future_drop");
     tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
-    final tmp4 = _nativeFuture(tmp5_1, _api.__convoSetFavoriteFuturePoll);
+    final tmp4 = _nativeFuture(tmp5_1, _api.__convoSetBookmarkedFuturePoll);
     return tmp4;
   }
 
@@ -58201,7 +58201,7 @@ class _ConvoMediaBinaryFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _ConvoSetFavoriteFuturePollReturn extends ffi.Struct {
+class _ConvoSetBookmarkedFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1974,6 +1974,12 @@ object Space {
     /// set name of the room
     fn set_name(name: string) -> Future<Result<EventId>>;
 
+    /// is this a bookmarked space
+    fn is_bookmarked() -> bool;
+
+    /// set this a bookmarked space
+    fn set_bookmarked(is_bookmarked: bool) -> Future<Result<bool>>;
+
     /// the members currently in the space
     fn active_members_ids() -> Future<Result<Vec<string>>>;
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1266,11 +1266,11 @@ object Convo {
     /// is this a direct message
     fn is_dm() -> bool;
 
-    /// is this a favorite chat
-    fn is_favorite() -> bool;
+    /// is this a bookmarked chat
+    fn is_bookmarked() -> bool;
 
-    /// set this a favorite chat
-    fn set_favorite(is_favorite: bool) -> Future<Result<bool>>;
+    /// set this a bookmarked chat
+    fn set_bookmarked(is_bookmarked: bool) -> Future<Result<bool>>;
 
     /// is this a low priority chat
     fn is_low_priority() -> bool;

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -240,15 +240,15 @@ impl Convo {
         self.inner.room.direct_targets_length() > 0
     }
 
-    pub fn is_favorite(&self) -> bool {
+    pub fn is_bookmarked(&self) -> bool {
         self.inner.room.is_favourite()
     }
 
-    pub async fn set_favorite(&self, is_favorite: bool) -> Result<bool> {
+    pub async fn set_bookmarked(&self, is_bookmarked: bool) -> Result<bool> {
         let room = self.inner.room.clone();
         Ok(RUNTIME
             .spawn(async move {
-                room.set_is_favourite(is_favorite, None)
+                room.set_is_favourite(is_bookmarked, None)
                     .await
                     .map(|()| true)
             })

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -561,7 +561,6 @@ impl Space {
             .await??)
     }
 
-
     pub async fn set_acter_space_states(&self) -> Result<bool> {
         if !self.inner.is_joined() {
             bail!("Unable to convert a space you didn't join");

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -546,6 +546,22 @@ impl Space {
         self.room_id().to_string()
     }
 
+    pub fn is_bookmarked(&self) -> bool {
+        self.inner.room.is_favourite()
+    }
+
+    pub async fn set_bookmarked(&self, is_bookmarked: bool) -> Result<bool> {
+        let room = self.inner.room.clone();
+        Ok(RUNTIME
+            .spawn(async move {
+                room.set_is_favourite(is_bookmarked, None)
+                    .await
+                    .map(|()| true)
+            })
+            .await??)
+    }
+
+
     pub async fn set_acter_space_states(&self) -> Result<bool> {
         if !self.inner.is_joined() {
             bail!("Unable to convert a space you didn't join");


### PR DESCRIPTION
This adds bookmarking support for spaces:

https://github.com/acterglobal/a3/assets/40496/43c0f08b-11c5-4276-9507-952528dd18eb


If you bookmarked any spaces, your space listing on the home pages will only show those. You can toggle the bookmark of any spaces on its space page and that is directly reflected.

Additionally this PR does:
 - make the "show all N spaces" to a less intrusive acter text inline button
 - renames the convo favoriting into bookmarking (first commit)
 - fixes a context.go issue on the space-listings page (which would lead to missing the `<-` button, as still visible in the video above) 