### PR TITLE
Better empties for chat and subspaces

### DIFF
--- a/.changes/1820-better-empties.md
+++ b/.changes/1820-better-empties.md
@@ -1,0 +1,1 @@
+- As a space admin you can now link subspace and space chats right from the empty screen

--- a/app/lib/features/chat/widgets/convo_list.dart
+++ b/app/lib/features/chat/widgets/convo_list.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/widgets/chat/convo_card.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -50,6 +51,18 @@ class _ConvosListConsumerState extends ConsumerState<ConvosList> {
     }
 
     if (chats.isEmpty) {
+      final hasFirstSynced =
+          ref.watch(syncStateProvider.select((x) => !x.initialSync));
+      if (!hasFirstSynced) {
+        return Center(
+          heightFactor: 1.5,
+          child: EmptyState(
+            title: L10n.of(context).noChatsStillSyncing,
+            subtitle: L10n.of(context).noChatsStillSyncingSubtitle,
+            image: 'assets/images/empty_chat.svg',
+          ),
+        );
+      }
       return Center(
         heightFactor: 1.5,
         child: EmptyState(

--- a/app/lib/features/space/pages/chats_page.dart
+++ b/app/lib/features/space/pages/chats_page.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/chat/convo_card.dart';
@@ -119,6 +120,15 @@ class SpaceChatsPage extends ConsumerWidget {
                   extra: 1,
                 ),
                 child: Text(L10n.of(context).createSpaceChat),
+              )
+            : null,
+        secondaryButton: canCreateSpace
+            ? ActerInlineTextButton(
+                onPressed: () => context.pushNamed(
+                  Routes.linkChat.name,
+                  pathParameters: {'spaceId': spaceIdOrAlias},
+                ),
+                child: Text(L10n.of(context).linkToChat),
               )
             : null,
       ),

--- a/app/lib/features/space/pages/sub_spaces_page.dart
+++ b/app/lib/features/space/pages/sub_spaces_page.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
@@ -150,6 +151,15 @@ class SubSpacesPage extends ConsumerWidget {
                   },
                 ),
                 child: Text(L10n.of(context).createNewSpace),
+              )
+            : null,
+        secondaryButton: canLinkSpace
+            ? ActerInlineTextButton(
+                onPressed: () => context.pushNamed(
+                  Routes.linkSubspace.name,
+                  pathParameters: {'spaceId': spaceIdOrAlias},
+                ),
+                child: Text(L10n.of(context).linkExistingSpace),
               )
             : null,
       ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -744,6 +744,8 @@
   "@noChatsFoundMatchingYourSearchTerm": {},
   "noChatsInThisSpaceYet": "No chats in this space yet",
   "@noChatsInThisSpaceYet": {},
+  "noChatsStillSyncing": "Synchronizing...",
+  "noChatsStillSyncingSubtitle": "We are loading your chats. On large accounts the initial loading takes a bit ...",
   "noConnectedSpaces": "No connected spaces",
   "@noConnectedSpaces": {},
   "noDisplayName": "no display name",


### PR DESCRIPTION
1. Show a better empty message for chats if we are still on first sync:
   ![syncing-chat](https://github.com/acterglobal/a3/assets/40496/beea8332-713c-4425-8371-b7261fe0007c)
2. Allow admins of a space to link chats and spaces when they are empty:

https://github.com/acterglobal/a3/assets/40496/fe608e47-4100-4025-b642-17589cf5f8c3


Fixes https://github.com/acterglobal/a3-meta/issues/276
