### PR TITLE
Hardening the setup procedures to continue on errors with a fresh session

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -34,7 +34,7 @@ const defaultServerName = String.fromEnvironment(
 );
 
 final defaultLogSetting = Platform.environment.containsKey(rustLogKey)
-    ? Platform.environment[rustLogKey]
+    ? Platform.environment[rustLogKey] as String
     : const String.fromEnvironment(
         rustLogKey,
         defaultValue: 'acter=debug,a3::sdk=info,a3=warn,warn',


### PR DESCRIPTION
We are seeing some failure to deserialize the session string or the specific token and thus the release build just stops with a black screen (see #1728 ). This "fixes" with a try-catch around both the `json.decode` and the `loginWithToken` and write a log (and print) entry for when that happens, but then continues. Which in effect should mean that it continues to go forward, you are just not being logged in. We need to observe whether that happens often or is just a f*cked-up setup on one machine.