### PR TITLE
Expose canRedact api about some models

### DIFF
--- a/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/app/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -3202,6 +3202,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __calendarEventCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _calendarEventCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   CommentsManager? __calendarEventCommentsFuturePoll(
     int boxed,
     int postCobject,
@@ -6429,6 +6473,50 @@ class Api {
     return tmp7;
   }
 
+  bool? __commentCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _commentCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
+    return tmp7;
+  }
+
   FfiListComment? __commentsManagerCommentsFuturePoll(
     int boxed,
     int postCobject,
@@ -6662,6 +6750,50 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_OptionString");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = OptionString._(this, tmp13_1);
+    return tmp7;
+  }
+
+  bool? __attachmentCanRedactFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _attachmentCanRedactFuturePoll(
+      tmp1,
+      tmp3,
+      tmp5,
+    );
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 =
+          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -17306,6 +17438,16 @@ class Api {
           int Function(
             int,
           )>();
+  late final _calendarEventCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__CalendarEvent_can_redact");
+
+  late final _calendarEventCanRedact = _calendarEventCanRedactPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _calendarEventCommentsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -20118,6 +20260,16 @@ class Api {
       int Function(
         int,
       )>();
+  late final _commentCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Comment_can_redact");
+
+  late final _commentCanRedact = _commentCanRedactPtr.asFunction<
+      int Function(
+        int,
+      )>();
   late final _commentsManagerCommentsPtr = _lookup<
       ffi.NativeFunction<
           ffi.Int64 Function(
@@ -20295,6 +20447,16 @@ class Api {
   late final _attachmentMediaPath = _attachmentMediaPathPtr.asFunction<
       int Function(
         int,
+        int,
+      )>();
+  late final _attachmentCanRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int64 Function(
+            ffi.Int64,
+          )>>("__Attachment_can_redact");
+
+  late final _attachmentCanRedact = _attachmentCanRedactPtr.asFunction<
+      int Function(
         int,
       )>();
   late final _attachmentsManagerRoomIdStrPtr = _lookup<
@@ -26881,6 +27043,21 @@ class Api {
             int,
             int,
           )>();
+  late final _calendarEventCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _CalendarEventCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__CalendarEvent_can_redact_future_poll");
+
+  late final _calendarEventCanRedactFuturePoll =
+      _calendarEventCanRedactFuturePollPtr.asFunction<
+          _CalendarEventCanRedactFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _calendarEventCommentsFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _CalendarEventCommentsFuturePollReturn Function(
@@ -27908,6 +28085,21 @@ class Api {
             int,
             int,
           )>();
+  late final _commentCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _CommentCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Comment_can_redact_future_poll");
+
+  late final _commentCanRedactFuturePoll =
+      _commentCanRedactFuturePollPtr.asFunction<
+          _CommentCanRedactFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
   late final _commentsManagerCommentsFuturePollPtr = _lookup<
       ffi.NativeFunction<
           _CommentsManagerCommentsFuturePollReturn Function(
@@ -27979,6 +28171,21 @@ class Api {
   late final _attachmentMediaPathFuturePoll =
       _attachmentMediaPathFuturePollPtr.asFunction<
           _AttachmentMediaPathFuturePollReturn Function(
+            int,
+            int,
+            int,
+          )>();
+  late final _attachmentCanRedactFuturePollPtr = _lookup<
+      ffi.NativeFunction<
+          _AttachmentCanRedactFuturePollReturn Function(
+            ffi.Int64,
+            ffi.Int64,
+            ffi.Int64,
+          )>>("__Attachment_can_redact_future_poll");
+
+  late final _attachmentCanRedactFuturePoll =
+      _attachmentCanRedactFuturePollPtr.asFunction<
+          _AttachmentCanRedactFuturePollReturn Function(
             int,
             int,
             int,
@@ -35769,6 +35976,21 @@ class CalendarEvent {
     return tmp2;
   }
 
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._calendarEventCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__CalendarEvent_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__calendarEventCanRedactFuturePoll);
+    return tmp2;
+  }
+
   /// get the comments manager
   Future<CommentsManager> comments() {
     var tmp0 = 0;
@@ -41818,6 +42040,21 @@ class Comment {
     return tmp2;
   }
 
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._commentCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Comment_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__commentCanRedactFuturePoll);
+    return tmp2;
+  }
+
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
     _box.drop();
@@ -42205,6 +42442,21 @@ class Attachment {
     tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
     final tmp4 = _nativeFuture(tmp5_1, _api.__attachmentMediaPathFuturePoll);
     return tmp4;
+  }
+
+  /// whether or not this user can redact this item
+  Future<bool> canRedact() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._attachmentCanRedact(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "__Attachment_can_redact_future_drop");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp2 = _nativeFuture(tmp3_1, _api.__attachmentCanRedactFuturePoll);
+    return tmp2;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
@@ -57506,6 +57758,21 @@ class _CalendarEventParticipantsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _CalendarEventCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _CalendarEventCommentsFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -58549,6 +58816,21 @@ class _CommentDraftSendFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _CommentCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
+  external int arg5;
+}
+
 class _CommentsManagerCommentsFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -58621,6 +58903,21 @@ class _AttachmentMediaPathFuturePollReturn extends ffi.Struct {
   @ffi.Uint64()
   external int arg4;
   @ffi.Int64()
+  external int arg5;
+}
+
+class _AttachmentCanRedactFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.Int64()
+  external int arg2;
+  @ffi.Uint64()
+  external int arg3;
+  @ffi.Uint64()
+  external int arg4;
+  @ffi.Uint8()
   external int arg5;
 }
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -593,6 +593,9 @@ object CalendarEvent {
     /// get the user id list who have responded with `Yes` on this event
     fn participants() -> Future<Result<Vec<string>>>;
 
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
+
     /// get the comments manager
     fn comments() -> Future<Result<CommentsManager>>;
 
@@ -1358,6 +1361,9 @@ object Comment {
     fn msg_content() -> MsgContent;
     /// create a draft builder to reply to this comment
     fn reply_builder() -> CommentDraft;
+
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 }
 
 /// Reference to the comments section of a particular item
@@ -1424,6 +1430,9 @@ object Attachment {
     /// get the path that media (image/audio/video/file) was saved
     /// return None when never downloaded
     fn media_path(is_thumb: bool) -> Future<Result<OptionString>>;
+
+    /// whether or not this user can redact this item
+    fn can_redact() -> Future<Result<bool>>;
 }
 
 /// Reference to the attachments section of a particular item


### PR DESCRIPTION
`can_redact()` was missed about `CalendarEvent`, `Comment`, and `Attachment`, so the following code couldn't find `canRedact()` method about those class instances.

```dart
final canRedactProvider = FutureProvider.autoDispose.family<bool, dynamic>(
  ((ref, arg) async {
    try {
      return await arg.canRedact();
    } catch (error) {
      _log.severe('Fetching canRedact failed for $arg', error);
      return false;
    }
  }),
);
```

This is error log.

```
flutter: SEVERE: 2024-06-14 01:25:19.006676: Fetching canRedact failed for Instance of 'CalendarEvent'
[2024-06-14][01:25:19.011491][a3::common::providers][ERROR] Fetching canRedact failed for Instance of 'CalendarEvent' NoSuchMethodError: Class 'CalendarEvent' has no instance method 'canRedact'.
Receiver: Instance of 'CalendarEvent'
Tried calling: canRedact() null null
flutter: ══╡ EXCEPTION CAUGHT BY A3::COMMON::PROVIDERS ╞═════════════════════════════════════════════════════
flutter: The following _Exception was thrown Fetching canRedact failed for Instance of 'CalendarEvent':
flutter: Exception: NoSuchMethodError: Class 'CalendarEvent' has no instance method 'canRedact'.
flutter: Receiver: Instance of 'CalendarEvent'
flutter: Tried calling: canRedact()
flutter: ════════════════════════════════════════════════════════════════════════════════════════════════════
```

Will expose api to fix this issue.