### PR TITLE
Manual refresh for manually loaded data: sessions, super_invites

### DIFF
--- a/app/lib/features/settings/pages/sessions_page.dart
+++ b/app/lib/features/settings/pages/sessions_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/session_providers.dart';
@@ -22,6 +23,19 @@ class SessionsPage extends ConsumerWidget {
           elevation: 0.0,
           title: Text(L10n.of(context).sessions),
           centerTitle: true,
+          actions: [
+            IconButton(
+              icon: Icon(
+                Atlas.arrows_rotating_right_thin,
+                color: Theme.of(context).colorScheme.neutral5,
+              ),
+              iconSize: 28,
+              color: Theme.of(context).colorScheme.surface,
+              onPressed: () async {
+                ref.invalidate(allSessionsProvider);
+              },
+            ),
+          ],
         ),
         body: allSessions.when(
           data: (sessions) => buildSessions(context, sessions),

--- a/app/lib/features/super_invites/pages/super_invites.dart
+++ b/app/lib/features/super_invites/pages/super_invites.dart
@@ -28,6 +28,17 @@ class SuperInvitesPage extends ConsumerWidget {
           centerTitle: true,
           actions: [
             IconButton(
+              icon: Icon(
+                Atlas.arrows_rotating_right_thin,
+                color: Theme.of(context).colorScheme.neutral5,
+              ),
+              iconSize: 28,
+              color: Theme.of(context).colorScheme.surface,
+              onPressed: () async {
+                ref.invalidate(superInvitesTokensProvider);
+              },
+            ),
+            IconButton(
               key: createNewToken,
               icon: Icon(
                 Atlas.plus_circle_thin,


### PR DESCRIPTION
Just adding two refresh icons for data we are manually pulling so the user can make them reload.