### PR TITLE
Add changelog ci

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+name: Changelog Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for changes in .changes
+        id: changed-changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+             .changes/*.md
+      - name: Not found - add Comment
+        if: steps.changed-changes.outputs.any_changed == 'false'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Hey there :wave:,
+            and thanks for the contribution. But it seems like you forgot to 
+            - [ ] :newspaper:  Add a markdown file in `.changes/` explaining what changed
+          comment_tag: changelog_comment
+      - name: Found - delete Comment
+        if: steps.changed-changes.outputs.any_changed == 'true'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            :+1: Thanks heaps, looks like all necessary changes have been done,
+            - [x] :newspaper:  Add a markdown file in `.changes/` explaining what changed
+          comment_tag: changelog_comment
+          mode: delete


### PR DESCRIPTION
Just saw this the other day and thought it'd be useful (even for myself) and then [this](https://github.com/acterglobal/a3/pull/1867#issuecomment-2182344102) inspired me to :muscle:  just do it. Here we go, let's see if it properly detects the missing changelog.

As tested on this PR:
1. When you are missing a file in .changes, the comment is added:
![Bildschirmfoto_2024-06-21_14-58-18](https://github.com/acterglobal/a3/assets/40496/6a47784a-248d-409b-a514-444d1c03ec36)
2. When you then add it, the comment is being deleted again:
![image](https://github.com/acterglobal/a3/assets/40496/20e47304-7b15-4b4d-9b21-7c20b86bc6bf)
