### PR TITLE
Activities screen shows unconfirmed Emails

### DIFF
--- a/.changes/1861-show-unconfirmed-emails.md
+++ b/.changes/1861-show-unconfirmed-emails.md
@@ -1,0 +1,1 @@
+- Now shows unconfirmed emails on Activities screen to nudge you to confirm them

--- a/app/integration_test/support/login.dart
+++ b/app/integration_test/support/login.dart
@@ -116,6 +116,7 @@ extension ActerLogin on ConvenientTest {
     await find.byKey(Keys.mainNav).should(findsOneWidget);
     await navigateTo([
       MainNavKeys.quickJump,
+      MainNavKeys.quickJump,
       QuickJumpKeys.settings,
       SettingsMenu.logoutAccount,
       LogoutDialogKeys.confirm,

--- a/app/integration_test/tests/auth.dart
+++ b/app/integration_test/tests/auth.dart
@@ -96,12 +96,34 @@ void authTests() {
     final userId = await t.freshAccount();
     final emailAddr = '$userId@example.org';
 
+    // we have the activities widget shown
+    await find.byKey(Keys.mainNav).should(findsOneWidget);
+    await t.navigateTo([
+      MainNavKeys.activities,
+    ]);
+
+    final emailAddrUnconfirmed = find.byKey(ActivitiesPage.unconfirmedEmails);
+    await t.tester.ensureVisible(emailAddrUnconfirmed);
+    await emailAddrUnconfirmed.should(findsOneWidget);
+
+    // Actually confirm
     await t.clickLinkInLatestEmail(
       emailAddr,
       contains: 'Validate your email',
     );
 
+    // Confirm on the App side, too
+
     await t.confirmEmailAdd(emailAddr, t.passwordFor(userId));
+
+    // the widget is gone on the activities page
+    await find.byKey(Keys.mainNav).should(findsOneWidget);
+    await t.navigateTo([
+      MainNavKeys.activities,
+    ]);
+
+    await emailAddrUnconfirmed.should(findsNothing);
+
     await t.logout();
 
     await t.navigateTo([

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -28,6 +28,18 @@ Future<ProfileData> getProfileData(Account account) async {
   return ProfileData(displayName.text(), avatar.data());
 }
 
+final genericUpdatesStream =
+    StreamProvider.family<int, String>((ref, key) async* {
+  final client = ref.watch(alwaysClientProvider);
+  int counter = 0; // to ensure the value updates
+
+  // ignore: unused_local_variable
+  await for (final value in client.subscribeStream(key)) {
+    yield counter;
+    counter += 1;
+  }
+});
+
 final myUserIdStrProvider = StateProvider(
   (ref) => ref.watch(
     alwaysClientProvider.select((client) => client.userId().toString()),
@@ -67,6 +79,8 @@ class EmailAddresses {
 
 final emailAddressesProvider = FutureProvider((ref) async {
   final client = ref.watch(alwaysClientProvider);
+  // ensure we are updated if the upgrade comes down the wire.
+  ref.watch(genericUpdatesStream('global.acter.dev.three_pid'));
   final threePidManager = client.threePidManager();
   final confirmed =
       asDartStringList(await threePidManager.confirmedEmailAddresses());

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -188,7 +188,6 @@ class ActivitiesPage extends ConsumerWidget {
       }
     }
     final hasUnconfirmedEmails = ref.watch(hasUnconfirmedEmailAddresses);
-    print('has unconfirmed addrs: $hasUnconfirmedEmails');
     if (hasUnconfirmedEmails) {
       children.add(renderUnconfirmedEmailAddrs(context));
     }

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -25,6 +25,7 @@ class ActivitiesPage extends ConsumerWidget {
       Key('activities-one-unverified-session');
   static const Key unverifiedSessionsCard =
       Key('activities-unverified-sessions');
+  static const Key unconfirmedEmails = Key('activities-has-unconfirmed-emails');
   const ActivitiesPage({super.key});
 
   Widget? renderSyncingState(BuildContext context, WidgetRef ref) {
@@ -153,35 +154,51 @@ class ActivitiesPage extends ConsumerWidget {
     return const SliverToBoxAdapter(child: BackupStateWidget());
   }
 
+  Widget renderUnconfirmedEmailAddrs(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Card(
+        key: unconfirmedEmails,
+        margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 15),
+        child: ListTile(
+          onTap: () => context.goNamed(Routes.emailAddresses.name),
+          leading: const Icon(Atlas.envelope_minus_thin),
+          title: Text(L10n.of(context).unconfirmedEmailsActivityTitle),
+          subtitle: Text(L10n.of(context).unconfirmedEmailsActivitySubtitle),
+          trailing: const Icon(
+            Icons.keyboard_arrow_right_outlined,
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // update the inner provider...
     // ignore: unused_local_variable
     final allDone = ref.watch(hasActivitiesProvider) == UrgencyBadge.none;
     final children = [];
-    bool renderEmptyState = true;
 
-    final syncState = renderSyncingState(context, ref);
-    if (syncState != null) {
-      // if all we have is this item, we still want to render the empty State...
-      children.add(syncState);
-    }
+    final syncStateWidget = renderSyncingState(context, ref);
 
     if (ref.watch(featuresProvider).isActive(LabsFeature.encryptionBackup)) {
       final backups = renderBackupSection(context, ref);
       if (backups != null) {
-        renderEmptyState = false;
         children.add(backups);
       }
     }
+    final hasUnconfirmedEmails = ref.watch(hasUnconfirmedEmailAddresses);
+    print('has unconfirmed addrs: $hasUnconfirmedEmails');
+    if (hasUnconfirmedEmails) {
+      children.add(renderUnconfirmedEmailAddrs(context));
+    }
+
     final sessions = renderSessions(context, ref);
     if (sessions != null) {
-      renderEmptyState = false;
       children.add(sessions);
     }
     final invitations = renderInvitations(context, ref);
     if (invitations != null && invitations.isNotEmpty) {
-      renderEmptyState = false;
       children.addAll(invitations);
     }
 
@@ -200,8 +217,9 @@ class ActivitiesPage extends ConsumerWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
-          ...children,
-          if (renderEmptyState)
+          if (syncStateWidget != null) syncStateWidget,
+          if (children.isNotEmpty) ...children,
+          if (children.isEmpty)
             SliverToBoxAdapter(
               child: Center(
                 heightFactor: 1.5,

--- a/app/lib/features/activities/providers/activities_providers.dart
+++ b/app/lib/features/activities/providers/activities_providers.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/models/types.dart';
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/features/activities/providers/invitations_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:riverpod/riverpod.dart';
@@ -12,5 +13,14 @@ final hasActivitiesProvider = StateProvider((ref) {
   if (syncStatus.errorMsg != null) {
     return UrgencyBadge.important;
   }
+  if (ref.watch(hasUnconfirmedEmailAddresses)) {
+    return UrgencyBadge.important;
+  }
   return UrgencyBadge.none;
 });
+
+final hasUnconfirmedEmailAddresses = StateProvider(
+  (ref) =>
+      ref.watch(emailAddressesProvider).valueOrNull?.unconfirmed.isNotEmpty ==
+      true,
+);

--- a/app/lib/features/onboarding/pages/link_email_page.dart
+++ b/app/lib/features/onboarding/pages/link_email_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/validation_utils.dart';
@@ -105,6 +106,7 @@ class LinkEmailPage extends ConsumerWidget {
     EasyLoading.show(status: L10n.of(context).linkingEmailAddress);
     try {
       await manager.requestTokenViaEmail(emailController.text.trim());
+      ref.invalidate(emailAddressesProvider);
       if (!context.mounted) return;
       EasyLoading.showSuccess(L10n.of(context).pleaseCheckYourInbox);
       isLinked.value = true;

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -884,7 +884,7 @@
   "@play": {},
   "playbackSpeed": "Playback speed",
   "@playbackSpeed": {},
-  "pleaseCheckYourInbox": "Please check your inbox for the validation email",
+  "pleaseCheckYourInbox": "Please check your inbox for the validation email and click the link before it expires",
   "@pleaseCheckYourInbox": {},
   "pleaseEnterAName": "Please enter a name",
   "@pleaseEnterAName": {},
@@ -2231,5 +2231,7 @@
   "deleteTaskList": "Delete Task List",
   "deleteTaskItem": "Delete Task Item",
   "reportTaskList": "Report Task List",
-  "reportTaskItem": "Report Task Item"
+  "reportTaskItem": "Report Task Item",
+  "unconfirmedEmailsActivityTitle": "You have unconfirmed E-Mail Addresses",
+  "unconfirmedEmailsActivitySubtitle": "Please follow the link we've sent you in the email and then confirm them here"
 }


### PR DESCRIPTION
Fixes #1861 through two measures:
1. A more forceful message upon the registration
2. An additional widget on the Activities screen to nudge users to confirm their email addresses

The latter is proven with a test as well:

https://github.com/acterglobal/a3/assets/40496/eb83711b-8a34-4855-b0f3-00a50ee1728c

