### PR TITLE
[Pins]: fix pin link text url overflow

### DIFF
--- a/app/lib/features/pins/widgets/pin_item.dart
+++ b/app/lib/features/pins/widgets/pin_item.dart
@@ -115,14 +115,21 @@ class _PinItemState extends ConsumerState<PinItem> {
           );
         },
         child: Card(
-          child: Container(
+          child: Padding(
             padding: const EdgeInsets.all(16),
             child: Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(Atlas.link_chain_thin, size: 18),
                 const SizedBox(width: 16),
-                Text(widget.pin.url() ?? ''),
-                const Spacer(),
+                Flexible(
+                  child: Text(
+                    widget.pin.url() ?? '',
+                    softWrap: false,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 16),
                 GestureDetector(
                   onTap: () async {
                     await openLink(widget.pin.url() ?? '', context);


### PR DESCRIPTION
As described in title, this will fix the overflow on pin link url.

### Before:

<img width="437" alt="Before" src="https://github.com/acterglobal/a3/assets/68579938/1faa6447-6b59-481f-928e-bf8de4c39621">

### After:

<img width="437" alt="After" src="https://github.com/acterglobal/a3/assets/68579938/da98cab1-1219-4fe9-8be4-5dcbd60855ff">
