### PR TITLE
Reducing the re-rendering of the chat input

### DIFF
--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -279,8 +279,7 @@ final relatedSpacesProvider = FutureProvider.autoDispose
 
 /// Get the user's membership for a specific space based off the spaceId
 /// will throw if the client doesn't kow the space
-final roomMembershipProvider =
-    FutureProvider.autoDispose.family<Member?, String>(
+final roomMembershipProvider = FutureProvider.family<Member?, String>(
   (ref, roomId) async {
     final room = await ref.watch(maybeRoomProvider(roomId).future);
     if (room == null || !room.isJoined()) {

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -211,23 +211,31 @@ final _roomProfileProvider =
 /// Caching the name of each Room
 final roomDisplayNameProvider =
     FutureProvider.family<String?, String>((ref, roomId) async {
-  return (await (await ref.watch(_roomProfileProvider(roomId).future))
-          .getDisplayName())
-      .text();
+  try {
+    final profile = await ref.watch(_roomProfileProvider(roomId).future);
+    return (await profile.getDisplayName()).text();
+  } on RoomNotFound {
+    return null;
+  }
 });
 
 /// Caching the MemoryImage of each room
 final _roomAvatarProvider =
     FutureProvider.family<MemoryImage?, String>((ref, roomId) async {
-  final sdk = await ref.watch(sdkProvider.future);
-  final thumbsize = sdk.api.newThumbSize(48, 48);
-  final avatar = (await (await ref.watch(_roomProfileProvider(roomId).future))
-          .getAvatar(thumbsize))
-      .data();
-  if (avatar != null) {
-    return MemoryImage(avatar.asTypedList());
+  try {
+    final sdk = await ref.watch(sdkProvider.future);
+    final thumbsize = sdk.api.newThumbSize(48, 48);
+
+    final avatar = (await (await ref.watch(_roomProfileProvider(roomId).future))
+            .getAvatar(thumbsize))
+        .data();
+    if (avatar != null) {
+      return MemoryImage(avatar.asTypedList());
+    }
+    return null;
+  } on RoomNotFound {
+    return null;
   }
-  return null;
 });
 
 /// Provide the AvatarInfo for each room. Update internally accordingly

--- a/app/lib/common/widgets/chat/convo_with_avatar_card.dart
+++ b/app/lib/common/widgets/chat/convo_with_avatar_card.dart
@@ -1,12 +1,16 @@
 import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/room_avatar.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class ConvoWithAvatarInfoCard extends ConsumerWidget {
+  final String? title;
   final String roomId;
   final AvatarInfo avatarInfo;
   final Widget? subtitle;
@@ -41,10 +45,12 @@ class ConvoWithAvatarInfoCard extends ConsumerWidget {
     this.subtitle,
     this.trailing,
     this.showParents = true,
+    this.title,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final displayName = ref.watch(roomDisplayNameProvider(roomId));
     return LayoutBuilder(
       builder: (context, constraints) {
         return Column(
@@ -60,13 +66,29 @@ class ConvoWithAvatarInfoCard extends ConsumerWidget {
                 onFocusChange: onFocusChange,
                 onLongPress: onLongPress,
                 leading: avatarWithIndicator(context, ref),
-                title: Text(
-                  avatarInfo.displayName ?? roomId,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .copyWith(fontWeight: FontWeight.w700),
-                  overflow: TextOverflow.ellipsis,
+                title: displayName.when(
+                  data: (dpl) => Text(
+                    dpl ?? roomId,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium!
+                        .copyWith(fontWeight: FontWeight.w700),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  error: (error, stackTrace) => Text(
+                    roomId,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium!
+                        .copyWith(fontWeight: FontWeight.w700),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  loading: () => Skeletonizer(
+                    child: Text(
+                      roomId,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
                 ),
                 subtitle: constraints.maxWidth < 300 ? null : subtitle,
                 trailing: constraints.maxWidth < 300 ? null : trailing,

--- a/app/lib/common/widgets/chat/convo_with_avatar_card.dart
+++ b/app/lib/common/widgets/chat/convo_with_avatar_card.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/room_avatar.dart';

--- a/app/lib/common/widgets/chat/convo_with_avatar_card.dart
+++ b/app/lib/common/widgets/chat/convo_with_avatar_card.dart
@@ -10,7 +10,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class ConvoWithAvatarInfoCard extends ConsumerWidget {
-  final String? title;
   final String roomId;
   final AvatarInfo avatarInfo;
   final Widget? subtitle;
@@ -45,7 +44,6 @@ class ConvoWithAvatarInfoCard extends ConsumerWidget {
     this.subtitle,
     this.trailing,
     this.showParents = true,
-    this.title,
   });
 
   @override

--- a/app/lib/features/chat/widgets/room_avatar.dart
+++ b/app/lib/features/chat/widgets/room_avatar.dart
@@ -6,6 +6,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class RoomAvatar extends ConsumerWidget {
   final String roomId;
@@ -28,8 +29,8 @@ class RoomAvatar extends ConsumerWidget {
       child: ref.watch(chatProvider(roomId)).when(
             data: (convo) => chatAvatarUI(convo, ref, context),
             error: (e, s) =>
-                Center(child: Text(L10n.of(context).loadingRoomFailed(e))),
-            loading: () => Center(child: Text(L10n.of(context).loading)),
+                errorAvatar(context, L10n.of(context).loadingRoomFailed(e)),
+            loading: () => loadingAvatar(context),
           ),
     );
   }
@@ -43,6 +44,29 @@ class RoomAvatar extends ConsumerWidget {
       data: (avatarInfos) => avatarInfos,
       error: (e, s) => [],
       loading: () => [],
+    );
+  }
+
+  Widget errorAvatar(BuildContext context, String error) {
+    return ActerAvatar(
+      options: AvatarOptions(
+        AvatarInfo(
+          uniqueId: 'error',
+          displayName: error,
+        ),
+        size: avatarSize,
+        badgesSize: avatarSize / 2,
+      ),
+    );
+  }
+
+  Widget loadingAvatar(BuildContext context, {String? error}) {
+    return Skeletonizer(
+      child: Container(
+        color: Colors.white,
+        width: avatarSize,
+        height: avatarSize,
+      ),
     );
   }
 


### PR DESCRIPTION
We were still re-rendering that way to often. This refactors this so that we rarely re-render the chat input box while we are in the chat screen. We only rerender it now for when we are a) loading in the first place or b) the permissions have changed and disallow us to send messages now. Additionally this improves the loading animation of chat rooms in the list and the room itself by some smarter using of our providers:


https://github.com/acterglobal/a3/assets/40496/19341588-7b48-45c2-a8da-9147d52d3283


Fixes #1679 , and probably also fixes https://github.com/acterglobal/a3-meta/issues/246 .