### PR TITLE
Refactor memberProvider to fix the avatar loading issue

### DIFF
--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -79,35 +79,6 @@ final _accountAvatarProvider =
   return null;
 });
 
-final userAvatarInfoProvider =
-    StateProvider.family.autoDispose<AvatarInfo, Member>((ref, member) {
-  final userId = member.userId().toString();
-  final profile = member.getProfile();
-
-  final fallback =
-      AvatarInfo(uniqueId: userId, displayName: profile.getDisplayName());
-  final avatar = ref.watch(_userAvatarProvider(profile)).valueOrNull;
-  if (!profile.hasAvatar() || avatar == null) {
-    return fallback;
-  }
-  return AvatarInfo(
-    uniqueId: userId,
-    displayName: profile.getDisplayName(),
-    avatar: avatar,
-  );
-});
-
-final _userAvatarProvider = FutureProvider.autoDispose
-    .family<MemoryImage?, UserProfile>((ref, profile) async {
-  final sdk = await ref.watch(sdkProvider.future);
-  final size = sdk.api.newThumbSize(48, 48);
-  final avatar = await profile.getAvatar(size);
-  if (avatar.data() != null) {
-    return MemoryImage(avatar.data()!.asTypedList());
-  }
-  return null;
-});
-
 final notificationSettingsProvider = AsyncNotifierProvider<
     AsyncNotificationSettingsNotifier,
     NotificationSettings>(() => AsyncNotificationSettingsNotifier());

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -3,7 +3,6 @@ library;
 
 import 'package:acter/common/models/types.dart';
 import 'package:acter/common/providers/chat_providers.dart';
-import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/notifiers/room_notifiers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
@@ -337,13 +336,32 @@ final memberDisplayNameProvider =
   return ref.watch(_memberProfileProvider(query)).valueOrNull?.getDisplayName();
 });
 
+/// Caching the MemoryImage of each room
+final _memberAvatarProvider = FutureProvider.autoDispose
+    .family<MemoryImage?, MemberInfo>((ref, query) async {
+  final sdk = await ref.watch(sdkProvider.future);
+
+  final thumbsize = sdk.api.newThumbSize(48, 48);
+  final profile = await ref.watch(_memberProfileProvider(query).future);
+  // use .data() consumes the value so we keep it stored, any further call to .data()
+  // comes back empty as the data was consumed.
+  final avatar = (await profile.getAvatar(thumbsize)).data();
+  if (avatar != null) {
+    return MemoryImage(avatar.asTypedList());
+  }
+  return null;
+});
+
 final memberAvatarInfoProvider =
     Provider.autoDispose.family<AvatarInfo, MemberInfo>((ref, query) {
-  final member = ref.watch(memberProvider(query)).valueOrNull;
-  if (member != null) {
-    return ref.watch(userAvatarInfoProvider(member));
-  }
-  return AvatarInfo(uniqueId: query.userId);
+  final displayName = ref.watch(memberDisplayNameProvider(query)).valueOrNull;
+  final avatarData = ref.watch(_memberAvatarProvider(query)).valueOrNull;
+
+  return AvatarInfo(
+    uniqueId: query.userId,
+    displayName: displayName,
+    avatar: avatarData,
+  );
 });
 
 final membersIdsProvider =


### PR DESCRIPTION
unifies user* and member*Providers, reuse the pattern of smart small providers as for room and finally: do not call `.data()` twice, as the first already consumes the data.