### PR TITLE
fix chat list ordering

### DIFF
--- a/.changes/fix-chat-list-order.md
+++ b/.changes/fix-chat-list-order.md
@@ -1,0 +1,1 @@
+- Fixed the chat rooms list ordering based on latest message timestamp.

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -26,7 +26,7 @@ final _convosProvider =
 
 /// Provider that sorts up list based on latest timestamp from [_convosProvider].
 final chatsProvider = StateProvider<List<Convo>>((ref) {
-  final convos = ref.watch(_convosProvider);
+  final convos = List.of(ref.watch(_convosProvider));
   convos.sort((a, b) => b.latestMessageTs().compareTo(a.latestMessageTs()));
   return convos;
 });
@@ -43,9 +43,10 @@ final chatProvider =
 
 final relatedChatsProvider =
     FutureProvider.family<List<Convo>, String>((ref, spaceId) async {
-  final chats =
-      (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
-          .knownChats;
+  final chats = List.of(
+    (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
+        .knownChats,
+  );
   chats.sort((a, b) => b.latestMessageTs().compareTo(a.latestMessageTs()));
   return chats;
 });

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -4,7 +4,6 @@ import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:riverpod/riverpod.dart';
 
-/// Provider the profile data of a the given space, keeps up to date with underlying client
 final convoProvider =
     AsyncNotifierProvider.family<AsyncConvoNotifier, Convo?, Convo>(
   () => AsyncConvoNotifier(),
@@ -18,11 +17,18 @@ final latestMessageProvider =
   return LatestMsgNotifier(ref, convo);
 });
 
-/// Provider the profile data of a the given space, keeps up to date with underlying client
-final chatsProvider =
+/// Provider for fetching rooms list. This'll always bring up unsorted list.
+final _convosProvider =
     StateNotifierProvider<ChatRoomsListNotifier, List<Convo>>((ref) {
   final client = ref.watch(alwaysClientProvider);
   return ChatRoomsListNotifier(ref: ref, client: client);
+});
+
+/// Provider that sorts up list based on latest timestamp from [_convosProvider].
+final chatsProvider = StateProvider<List<Convo>>((ref) {
+  final convos = ref.watch(_convosProvider);
+  convos.sort((a, b) => b.latestMessageTs().compareTo(a.latestMessageTs()));
+  return convos;
 });
 
 final chatProvider =
@@ -37,8 +43,11 @@ final chatProvider =
 
 final relatedChatsProvider =
     FutureProvider.family<List<Convo>, String>((ref, spaceId) async {
-  return (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
-      .knownChats;
+  final chats =
+      (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
+          .knownChats;
+  chats.sort((a, b) => b.latestMessageTs().compareTo(a.latestMessageTs()));
+  return chats;
 });
 
 final selectedChatIdProvider =

--- a/app/lib/common/providers/notifiers/chat_notifiers.dart
+++ b/app/lib/common/providers/notifiers/chat_notifiers.dart
@@ -86,12 +86,17 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
 
   List<Convo> listCopy() => List.from(state, growable: true);
 
+  void _sortList(List<Convo> list) {
+    list.sort((a, b) => b.latestMessageTs().compareTo(b.latestMessageTs()));
+  }
+
   void _handleDiff(ConvoDiff diff) {
     switch (diff.action()) {
       case 'Append':
         final newList = listCopy();
         List<Convo> items = diff.values()!.toList();
         newList.addAll(items);
+        _sortList(newList);
         state = newList;
         break;
       case 'Insert':
@@ -99,6 +104,7 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
         final index = diff.index()!;
         final newList = listCopy();
         newList.insert(index, m);
+        _sortList(newList);
         state = newList;
         break;
       case 'Set':
@@ -106,34 +112,40 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
         final index = diff.index()!;
         final newList = listCopy();
         newList[index] = m;
+        _sortList(newList);
         state = newList;
         break;
       case 'Remove':
         final index = diff.index()!;
         final newList = listCopy();
         newList.removeAt(index);
+        _sortList(newList);
         state = newList;
         break;
       case 'PushBack':
         Convo m = diff.value()!;
         final newList = listCopy();
         newList.add(m);
+        _sortList(newList);
         state = newList;
         break;
       case 'PushFront':
         Convo m = diff.value()!;
         final newList = listCopy();
         newList.insert(0, m);
+        _sortList(newList);
         state = newList;
         break;
       case 'PopBack':
         final newList = listCopy();
         newList.removeLast();
+        _sortList(newList);
         state = newList;
         break;
       case 'PopFront':
         final newList = listCopy();
         newList.removeAt(0);
+        _sortList(newList);
         state = newList;
         break;
       case 'Clear':
@@ -145,6 +157,7 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
       case 'Truncate':
         final length = diff.index()!;
         final newList = listCopy();
+        _sortList(newList);
         state = newList.take(length).toList();
         break;
       default:

--- a/app/lib/common/providers/notifiers/chat_notifiers.dart
+++ b/app/lib/common/providers/notifiers/chat_notifiers.dart
@@ -86,17 +86,12 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
 
   List<Convo> listCopy() => List.from(state, growable: true);
 
-  void _sortList(List<Convo> list) {
-    list.sort((a, b) => b.latestMessageTs().compareTo(b.latestMessageTs()));
-  }
-
   void _handleDiff(ConvoDiff diff) {
     switch (diff.action()) {
       case 'Append':
         final newList = listCopy();
         List<Convo> items = diff.values()!.toList();
         newList.addAll(items);
-        _sortList(newList);
         state = newList;
         break;
       case 'Insert':
@@ -104,7 +99,6 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
         final index = diff.index()!;
         final newList = listCopy();
         newList.insert(index, m);
-        _sortList(newList);
         state = newList;
         break;
       case 'Set':
@@ -112,40 +106,34 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
         final index = diff.index()!;
         final newList = listCopy();
         newList[index] = m;
-        _sortList(newList);
         state = newList;
         break;
       case 'Remove':
         final index = diff.index()!;
         final newList = listCopy();
         newList.removeAt(index);
-        _sortList(newList);
         state = newList;
         break;
       case 'PushBack':
         Convo m = diff.value()!;
         final newList = listCopy();
         newList.add(m);
-        _sortList(newList);
         state = newList;
         break;
       case 'PushFront':
         Convo m = diff.value()!;
         final newList = listCopy();
         newList.insert(0, m);
-        _sortList(newList);
         state = newList;
         break;
       case 'PopBack':
         final newList = listCopy();
         newList.removeLast();
-        _sortList(newList);
         state = newList;
         break;
       case 'PopFront':
         final newList = listCopy();
         newList.removeAt(0);
-        _sortList(newList);
         state = newList;
         break;
       case 'Clear':
@@ -157,7 +145,6 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
       case 'Truncate':
         final length = diff.index()!;
         final newList = listCopy();
-        _sortList(newList);
         state = newList.take(length).toList();
         break;
       default:


### PR DESCRIPTION
This checks up the sorting on ```ConvoDiff``` and re-arranges based on timestamp both for chats and space related chats.

### Before:

<img width="418" alt="Screenshot 2024-07-09 at 11 54 20 AM" src="https://github.com/acterglobal/a3/assets/68579938/10966c80-6cf2-4858-883f-f9af901a8e3a">

### After:

<img width="418" alt="Screenshot 2024-07-09 at 12 07 24 PM" src="https://github.com/acterglobal/a3/assets/68579938/1830db2e-8c2e-4284-b61c-c6c3034c03ab">
