### PR TITLE
Generalised avatar view and change flow

### DIFF
--- a/.changes/1940-generic-avatar-flow.md
+++ b/.changes/1940-generic-avatar-flow.md
@@ -1,0 +1,3 @@
+[Improvement] : Now you can view space and group chat avatar in full screen
+[Improvement] : If you have permission than you can have inline avatar change option instead of go to any detail screen
+[New] : You can zoom in and out avatar view for better visualisation

--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -32,6 +32,9 @@ enum Routes {
   // --- search
   searchPublicDirectory('/search/public'),
 
+  // --- Full Screen Avatar
+  fullScreenAvatar('/fullScreenAvatar'),
+
   // --- chat
   chat('/chat'),
   // show as dialog

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -192,9 +192,9 @@ Future<void> openAvatar(
   WidgetRef ref,
   String roomId,
 ) async {
-  final membership = await ref.watch(roomMembershipProvider(roomId).future);
+  final membership = await ref.read(roomMembershipProvider(roomId).future);
   final canUpdateAvatar = membership?.canString('CanUpdateAvatar') == true;
-  final avatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
+  final avatarInfo = ref.read(roomAvatarInfoProvider(roomId));
 
   if (avatarInfo.avatar != null && context.mounted) {
     //Open avatar in full screen if avatar data available
@@ -202,9 +202,7 @@ Future<void> openAvatar(
       Routes.fullScreenAvatar.name,
       queryParameters: {'roomId': roomId},
     );
-  } else if (avatarInfo.avatar == null &&
-      canUpdateAvatar &&
-      context.mounted) {
+  } else if (avatarInfo.avatar == null && canUpdateAvatar && context.mounted) {
     //Change avatar if avatar is null and have relevant permission
     uploadAvatar(ref, context, roomId);
   }
@@ -230,7 +228,12 @@ Future<void> uploadAvatar(
     EasyLoading.dismiss();
   } catch (e, st) {
     _log.severe('Failed to upload avatar', e, st);
-    EasyLoading.dismiss();
+    if (context.mounted) {
+      EasyLoading.showError(
+        L10n.of(context).failedToUploadAvatar(e),
+        duration: const Duration(seconds: 3),
+      );
+    }
   }
 }
 

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -3,8 +3,11 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/routes.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -182,6 +185,53 @@ String randomString() {
   final random = Random.secure();
   final values = List<int>.generate(16, (i) => random.nextInt(255));
   return base64UrlEncode(values);
+}
+
+Future<void> openAvatar(
+  BuildContext context,
+  WidgetRef ref,
+  String roomId,
+) async {
+  final membership = await ref.watch(roomMembershipProvider(roomId).future);
+  final canUpdateAvatar = membership?.canString('CanUpdateAvatar') == true;
+  final avatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
+
+  if (avatarInfo.avatar != null && context.mounted) {
+    //Open avatar in full screen if avatar data available
+    context.pushNamed(
+      Routes.fullScreenAvatar.name,
+      queryParameters: {'roomId': roomId},
+    );
+  } else if (avatarInfo.avatar == null &&
+      canUpdateAvatar &&
+      context.mounted) {
+    //Change avatar if avatar is null and have relevant permission
+    uploadAvatar(ref, context, roomId);
+  }
+}
+
+Future<void> uploadAvatar(
+  WidgetRef ref,
+  BuildContext context,
+  String roomId,
+) async {
+  final room = await ref.read(maybeRoomProvider(roomId).future);
+  if (room == null || !context.mounted) return;
+  FilePickerResult? result = await FilePicker.platform.pickFiles(
+    type: FileType.image,
+  );
+  if (result == null || result.files.isEmpty) return;
+  try {
+    if (!context.mounted) return;
+    EasyLoading.show(status: L10n.of(context).avatarUploading);
+    final file = result.files.first;
+    if (file.path != null) await room.uploadAvatar(file.path!);
+    // close loading
+    EasyLoading.dismiss();
+  } catch (e, st) {
+    _log.severe('Failed to upload avatar', e, st);
+    EasyLoading.dismiss();
+  }
 }
 
 T getRandomElement<T>(List<T> list) {

--- a/app/lib/common/widgets/avatar/full_screen_avatar_page.dart
+++ b/app/lib/common/widgets/avatar/full_screen_avatar_page.dart
@@ -19,7 +19,7 @@ class FullScreenAvatarPage extends ConsumerWidget {
   }
 
   AppBar _buildAppBar(BuildContext context, WidgetRef ref) {
-    final membership = ref.watch(roomMembershipProvider(roomId)).requireValue;
+    final membership = ref.watch(roomMembershipProvider(roomId)).valueOrNull;
     return AppBar(
       leading: IconButton(
         onPressed: context.pop,
@@ -29,7 +29,7 @@ class FullScreenAvatarPage extends ConsumerWidget {
         if (membership?.canString('CanUpdateAvatar') == true)
           IconButton(
             onPressed: () => uploadAvatar(ref, context, roomId),
-            icon: const Icon(Icons.edit_outlined),
+            icon: const Icon(Icons.upload),
           ),
       ],
     );

--- a/app/lib/common/widgets/avatar/full_screen_avatar_page.dart
+++ b/app/lib/common/widgets/avatar/full_screen_avatar_page.dart
@@ -1,0 +1,61 @@
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zoom_hover_pinch_image/zoom_hover_pinch_image.dart';
+
+class FullScreenAvatarPage extends ConsumerWidget {
+  final String roomId;
+
+  const FullScreenAvatarPage({super.key, required this.roomId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: _buildAppBar(context, ref),
+      body: _buildBody(context, ref),
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context, WidgetRef ref) {
+    final membership = ref.watch(roomMembershipProvider(roomId)).requireValue;
+    return AppBar(
+      leading: IconButton(
+        onPressed: context.pop,
+        icon: const Icon(Icons.close),
+      ),
+      actions: [
+        if (membership?.canString('CanUpdateAvatar') == true)
+          IconButton(
+            onPressed: () => uploadAvatar(ref, context, roomId),
+            icon: const Icon(Icons.edit_outlined),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBody(BuildContext context, WidgetRef ref) {
+    final size = MediaQuery.of(context).size;
+    final profileData = ref.watch(roomAvatarInfoProvider(roomId));
+
+    if (profileData.avatar == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Center(
+      child: Zoom(
+        width: size.width,
+        height: size.height,
+        child: Container(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              fit: BoxFit.fitWidth,
+              image: profileData.avatar!,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/space/widgets/space_header_profile.dart
+++ b/app/lib/features/space/widgets/space_header_profile.dart
@@ -1,8 +1,8 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/spaces/space_info.dart';
-import 'package:acter/router/utils.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -37,7 +37,7 @@ class SpaceHeaderProfile extends ConsumerWidget {
                 uniqueId: spaceId,
                 displayName: spaceAvatarInfo.displayName,
                 avatar: spaceAvatarInfo.avatar,
-                onAvatarTap: () => goToSpace(context, spaceId),
+                onAvatarTap: () => openAvatar(context, ref, spaceId),
               ),
               parentBadges: parentBadges,
               size: 70,

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2243,5 +2243,6 @@
   "addPin": "Add Pin",
   "addEvent": "Add Event",
   "linkChat": "Link Chat",
-  "linkSpace": "Link Space"
+  "linkSpace": "Link Space",
+  "failedToUploadAvatar": "Failed to upload avatar: {error}"
 }

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/pages/fatal_fail.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
+import 'package:acter/common/widgets/avatar/full_screen_avatar_page.dart';
 import 'package:acter/common/widgets/dialog_page.dart';
 import 'package:acter/common/widgets/side_sheet_page.dart';
 import 'package:acter/features/bug_report/pages/bug_report_page.dart';
@@ -329,6 +330,19 @@ List<RouteBase> makeGeneralRoutes() {
                   initialPage: state.extra as int?,
                 ),
               );
+      },
+    ),
+    GoRoute(
+      parentNavigatorKey: rootNavKey,
+      name: Routes.fullScreenAvatar.name,
+      path: Routes.fullScreenAvatar.route,
+      pageBuilder: (context, state) {
+        return NoTransitionPage(
+          key: state.pageKey,
+          child: FullScreenAvatarPage(
+            roomId: state.uri.queryParameters['roomId']!,
+          ),
+        );
       },
     ),
     GoRoute(


### PR DESCRIPTION
Make avatar view and change flow generic and cover different use-case as below.

### 1) Avatar Empty - With Change Permission - Direct change options:

https://github.com/user-attachments/assets/ffb1f842-eafb-4489-8746-1e5526269753

### 2) Avatar Available - With Change Permission - Full View + Change:

https://github.com/user-attachments/assets/65046f1d-490e-427b-847b-417f3f73e7d0

### 3) Avatar Available - No Permission - Full View Only:

https://github.com/user-attachments/assets/980847c1-1c2a-48c1-be81-c639d5769948

### 4) Avatar Empty - No Permission - No Full screen View:

https://github.com/user-attachments/assets/a88a1b09-92f2-4de3-a751-27719cb95e5f

### 5) Zoom option:

https://github.com/user-attachments/assets/16ef586f-0d38-41c0-aa04-06f42191e53f


Side-note:
- 
Full screen avatar is still not support for DM and Group as it need to manage with different scenario.