### PR TITLE
Implement user bookmarks

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2290,6 +2290,9 @@ object Account {
 
     /// Remove email address from confirmed list or unconfirmed list
     fn remove_email_address(email_address: string) -> Future<Result<bool>>;
+
+    /// Get the Bookmarks manager
+    fn bookmarks() -> Future<Result<Bookmarks>>;
 }
 
 object ExternalId {
@@ -2316,6 +2319,27 @@ object ThreePidEmailTokenResponse {
 
     /// get client secret
     fn client_secret() -> string;
+}
+
+
+//  ########   #######   #######  ##    ## ##     ##    ###    ########  ##    ##  ######  
+//  ##     ## ##     ## ##     ## ##   ##  ###   ###   ## ##   ##     ## ##   ##  ##    ## 
+//  ##     ## ##     ## ##     ## ##  ##   #### ####  ##   ##  ##     ## ##  ##   ##       
+//  ########  ##     ## ##     ## #####    ## ### ## ##     ## ########  #####     ######  
+//  ##     ## ##     ## ##     ## ##  ##   ##     ## ######### ##   ##   ##  ##         ## 
+//  ##     ## ##     ## ##     ## ##   ##  ##     ## ##     ## ##    ##  ##   ##  ##    ## 
+//  ########   #######   #######  ##    ## ##     ## ##     ## ##     ## ##    ##  ######  
+
+
+object Bookmarks {
+    /// get the list of bookmarks for a specific key
+    fn entries(key: string) -> Vec<string>;
+
+    /// add the following entry to the bookmarks of key
+    fn add(key: string, entry: string) -> Future<Result<bool>>;
+
+    /// remove the following entry from the bookmarks of key
+    fn remove(key: string, entry: string) -> Future<Result<bool>>;
 }
 
 object SyncState {

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -22,6 +22,7 @@ mod account;
 mod attachments;
 mod auth;
 mod backup;
+mod bookmarks;
 mod calendar_events;
 mod client;
 mod comments;
@@ -74,6 +75,7 @@ pub use auth::{
     register_under_config, register_with_token_under_config, sanitize_user,
 };
 pub use backup::BackupManager;
+pub use bookmarks::Bookmarks;
 pub use calendar_events::{CalendarEvent, CalendarEventDraft, CalendarEventUpdateBuilder};
 pub use client::{Client, ClientStateBuilder, HistoryLoadState, SyncState};
 pub use comments::{Comment, CommentDraft, CommentsManager};

--- a/native/acter/src/api/account.rs
+++ b/native/acter/src/api/account.rs
@@ -22,7 +22,7 @@ pub use three_pid::{ExternalId, ThreePidEmailTokenResponse};
 
 #[derive(Clone, Debug)]
 pub struct Account {
-    account: SdkAccount,
+    pub(crate) account: SdkAccount,
     client: Client,
     user_id: OwnedUserId,
 }

--- a/native/acter/src/api/bookmarks.rs
+++ b/native/acter/src/api/bookmarks.rs
@@ -1,0 +1,160 @@
+use crate::RUNTIME;
+use acter_core::events::bookmarks::BookmarksEventContent;
+use anyhow::Result;
+use matrix_sdk::Account;
+use tracing::warn;
+
+pub struct Bookmarks {
+    inner: BookmarksEventContent,
+    account: Account,
+}
+
+impl Bookmarks {
+    pub fn entries(&self, key: String) -> Vec<String> {
+        let lowered = key.to_lowercase();
+        match lowered.as_str() {
+            "pins" => self.inner.pins.clone(),
+            "news" => self.inner.news.clone(),
+            "events" => self.inner.events.clone(),
+            "tasks" => self.inner.tasks.clone(),
+            "task_lists" => self.inner.task_lists.clone(),
+            _ => self.inner.other.get(&lowered).cloned().unwrap_or_default(),
+        }
+    }
+
+    pub async fn add(&self, key: String, entry: String) -> Result<bool> {
+        let mut inner = self.inner.clone();
+        let lowered = key.to_lowercase();
+        match lowered.as_str() {
+            "pins" => {
+                inner.pins.push(entry);
+                inner.pins.dedup();
+            }
+            "news" => {
+                inner.news.push(entry);
+                inner.news.dedup();
+            }
+            "events" => {
+                inner.events.push(entry);
+                inner.events.dedup();
+            }
+            "tasks" => {
+                inner.tasks.push(entry);
+                inner.tasks.dedup();
+            }
+            "task_lists" => {
+                inner.task_lists.push(entry);
+                inner.task_lists.dedup();
+            }
+            _ => {
+                inner
+                    .other
+                    .entry(lowered)
+                    .and_modify(|entries| {
+                        entries.push(entry.clone());
+                        entries.dedup();
+                    })
+                    .or_insert_with(|| vec![entry]);
+            }
+        };
+
+        self.submit(inner).await?;
+
+        Ok(true)
+    }
+
+    pub async fn remove(&self, key: String, entry: String) -> Result<bool> {
+        let mut inner = self.inner.clone();
+        let lowered = key.to_lowercase();
+        let has_updated = match lowered.as_str() {
+            "pins" => {
+                if let Some(pos) = inner.pins.iter().position(|e| e == &entry) {
+                    inner.pins.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            }
+            "news" => {
+                if let Some(pos) = inner.news.iter().position(|e| e == &entry) {
+                    inner.news.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            }
+            "events" => {
+                if let Some(pos) = inner.events.iter().position(|e| e == &entry) {
+                    inner.events.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            }
+            "tasks" => {
+                if let Some(pos) = inner.tasks.iter().position(|e| e == &entry) {
+                    inner.tasks.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            }
+            "task_lists" => {
+                if let Some(pos) = inner.task_lists.iter().position(|e| e == &entry) {
+                    inner.task_lists.remove(pos);
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => {
+                if let Some(entries) = inner.other.get_mut(&lowered) {
+                    if let Some(pos) = entries.iter().position(|e| e == &entry) {
+                        entries.remove(pos);
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+        };
+        if (has_updated) {
+            self.submit(inner).await?;
+        }
+
+        Ok(has_updated)
+    }
+
+    async fn submit(&self, content: BookmarksEventContent) -> Result<()> {
+        let account = self.account.clone();
+        let resp = RUNTIME
+            .spawn(async move { account.set_account_data(content).await })
+            .await??;
+        Ok(())
+    }
+}
+
+impl crate::Account {
+    pub async fn bookmarks(&self) -> Result<Bookmarks> {
+        let account = self.account.clone();
+        let inner = RUNTIME
+            .spawn(async move {
+                let raw = account.account_data::<BookmarksEventContent>().await?;
+
+                anyhow::Ok(if let Some(o) = raw {
+                    o.deserialize().map(Option::Some)?
+                } else {
+                    None
+                })
+            })
+            .await??
+            .unwrap_or_default();
+
+        Ok(Bookmarks {
+            inner,
+            account: self.account.clone(),
+        })
+    }
+}

--- a/native/core/src/events.rs
+++ b/native/core/src/events.rs
@@ -1,4 +1,5 @@
 pub mod attachments;
+pub mod bookmarks;
 pub mod calendar;
 pub mod comments;
 mod common;

--- a/native/core/src/events/bookmarks.rs
+++ b/native/core/src/events/bookmarks.rs
@@ -1,0 +1,24 @@
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub static BOOKMARKS_KEY: &str = "global.acter.bookmarks";
+
+#[derive(Debug, Serialize, Default, Deserialize, Clone, EventContent)]
+#[ruma_event(type = "global.acter.bookmarks", kind = GlobalAccountData)]
+pub struct BookmarksEventContent {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pins: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tasks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub task_lists: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub news: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(flatten)]
+    pub other: BTreeMap<String, Vec<String>>,
+}

--- a/native/test/src/tests.rs
+++ b/native/test/src/tests.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod bookmarks;
 mod calendar;
 mod formatted_body;
 mod invitation;

--- a/native/test/src/tests/bookmarks.rs
+++ b/native/test/src/tests/bookmarks.rs
@@ -1,0 +1,137 @@
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::random_user;
+
+#[tokio::test]
+async fn bookmarks_e2e() -> Result<()> {
+    let _ = env_logger::try_init();
+    let mut user = random_user("categories-e2e").await?;
+
+    let state_sync = user.start_sync();
+    state_sync.await_has_synced_history().await?;
+
+    let account = user.account()?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let bookmarks = account.bookmarks().await?;
+
+    assert!(bookmarks.entries("pins".to_owned()).is_empty());
+    assert!(bookmarks.entries("news".to_owned()).is_empty());
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+
+    bookmarks.add("pins".to_owned(), "AsdfG".to_owned()).await?;
+    let fetch_account = account.clone();
+    let bookmarks = Retry::spawn(retry_strategy.clone(), move || {
+        let account = fetch_account.clone();
+        async move {
+            let bookmarks = account.bookmarks().await?;
+            if bookmarks.entries("pins".to_owned()).is_empty() {
+                bail!("Bookmarks not found");
+            }
+
+            Ok(bookmarks)
+        }
+    })
+    .await?;
+
+    assert_eq!(bookmarks.entries("pins".to_owned()), vec!["AsdfG"]);
+    assert!(bookmarks.entries("news".to_owned()).is_empty());
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+
+    // adding it again, doesn't actually add it again
+    bookmarks.add("pins".to_owned(), "AsdfG".to_owned()).await?;
+    let fetch_account = account.clone();
+    let bookmarks = Retry::spawn(retry_strategy.clone(), move || {
+        let account = fetch_account.clone();
+        async move {
+            let bookmarks = account.bookmarks().await?;
+            if !bookmarks.entries("pins".to_owned()).is_empty() {
+                Ok(bookmarks)
+            } else {
+                bail!("Bookmarks not found");
+            }
+        }
+    })
+    .await?;
+
+    // add another
+    assert_eq!(bookmarks.entries("pins".to_owned()), vec!["AsdfG"]);
+    assert!(bookmarks.entries("news".to_owned()).is_empty());
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+
+    bookmarks
+        .add("pins".to_owned(), "SEcDondD".to_owned())
+        .await?;
+    let fetch_account = account.clone();
+    let bookmarks = Retry::spawn(retry_strategy.clone(), move || {
+        let account = fetch_account.clone();
+        async move {
+            let bookmarks = account.bookmarks().await?;
+            if bookmarks.entries("pins".to_owned()).len() == 2 {
+                Ok(bookmarks)
+            } else {
+                bail!("Bookmarks not found");
+            }
+        }
+    })
+    .await?;
+
+    assert_eq!(
+        bookmarks.entries("pins".to_owned()),
+        vec!["AsdfG", "SEcDondD"]
+    );
+    assert!(bookmarks.entries("news".to_owned()).is_empty());
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+
+    // add different type
+
+    bookmarks.add("news".to_owned(), "super".to_owned()).await?;
+    let fetch_account = account.clone();
+    let bookmarks = Retry::spawn(retry_strategy.clone(), move || {
+        let account = fetch_account.clone();
+        async move {
+            let bookmarks = account.bookmarks().await?;
+            if !bookmarks.entries("news".to_owned()).is_empty() {
+                Ok(bookmarks)
+            } else {
+                bail!("Bookmarks not found");
+            }
+        }
+    })
+    .await?;
+
+    assert_eq!(
+        bookmarks.entries("pins".to_owned()),
+        vec!["AsdfG", "SEcDondD"]
+    );
+    assert_eq!(bookmarks.entries("news".to_owned()), vec!["super"]);
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+
+    // test remove
+    bookmarks
+        .remove("pins".to_owned(), "AsdfG".to_owned())
+        .await?;
+    let fetch_account = account.clone();
+    let bookmarks = Retry::spawn(retry_strategy.clone(), move || {
+        let account = fetch_account.clone();
+        async move {
+            let bookmarks = account.bookmarks().await?;
+            if bookmarks.entries("pins".to_owned()).len() == 1 {
+                Ok(bookmarks)
+            } else {
+                bail!("Bookmarks not found");
+            }
+        }
+    })
+    .await?;
+
+    assert_eq!(bookmarks.entries("pins".to_owned()), vec!["SEcDondD"]);
+    assert_eq!(bookmarks.entries("news".to_owned()), vec!["super"]);
+    assert!(bookmarks.entries("events".to_owned()).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Rust SDK Api to manage bookmarks - list or eventIds per type - as a global user config, synced across devices. Simple toggle per item through `add('pins', eventId)` and `remove('pins', eventId)`. Double adding is not possible, keys are de-duplicated before submitting. Items are added to the end, so essentially it is a "newest last" list of bookmarks (might make sense to reverse this for displaying them to the user).

To stay up to date, `client.subscribeStream('global.acter.bookmarks')`: this will trigger after any update is received.

Contains e2ee tests, of course.