### PR TITLE
Keep avatar binary in flutters resident memory

### DIFF
--- a/.changes/1949-avatar-binary.md
+++ b/.changes/1949-avatar-binary.md
@@ -1,0 +1,2 @@
+- Fix: Avatars some time showed up weird, were broken or didn't show at all
+- Fix: Several instances in which the App failed or froze because of broken Avatars

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -75,8 +75,9 @@ final _accountAvatarProvider =
   final account = ref.watch(accountProvider);
   final thumbSize = sdk.api.newThumbSize(48, 48);
   final avatar = await account.avatar(thumbSize);
-  if (avatar.data() != null) {
-    return MemoryImage(Uint8List.fromList(avatar.data()!.asTypedList()));
+  final avatarData = avatar.data();
+  if (avatarData != null) {
+    return MemoryImage(Uint8List.fromList(avatarData.asTypedList()));
   }
   return null;
 });

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -75,6 +75,8 @@ final _accountAvatarProvider =
   final account = ref.watch(accountProvider);
   final thumbSize = sdk.api.newThumbSize(48, 48);
   final avatar = await account.avatar(thumbSize);
+  // Only call data() once as it will consume the value and any subsequent
+  // call will come back with `null`.
   final avatarData = avatar.data();
   if (avatarData != null) {
     return MemoryImage(Uint8List.fromList(avatarData.asTypedList()));

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:acter/common/providers/notifiers/notification_settings_notifier.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -74,7 +76,7 @@ final _accountAvatarProvider =
   final thumbSize = sdk.api.newThumbSize(48, 48);
   final avatar = await account.avatar(thumbSize);
   if (avatar.data() != null) {
-    return MemoryImage(avatar.data()!.asTypedList());
+    return MemoryImage(Uint8List.fromList(avatar.data()!.asTypedList()));
   }
   return null;
 });

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -1,6 +1,8 @@
 /// Get the relations of the given SpaceId.  Throws
 library;
 
+import 'dart:typed_data';
+
 import 'package:acter/common/models/types.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/notifiers/room_notifiers.dart';
@@ -174,7 +176,7 @@ final roomAvatarProvider =
 
   final avatar = (await room.avatar(thumbsize)).data();
   if (avatar != null) {
-    return MemoryImage(avatar.asTypedList());
+    return MemoryImage(Uint8List.fromList(avatar.asTypedList()));
   }
   return null;
 });
@@ -309,7 +311,7 @@ final _memberAvatarProvider = FutureProvider.autoDispose
     // comes back empty as the data was consumed.
     final avatar = (await profile.getAvatar(thumbsize)).data();
     if (avatar != null) {
-      return MemoryImage(avatar.asTypedList());
+      return MemoryImage(Uint8List.fromList(avatar.asTypedList()));
     }
     return null;
   } on RoomNotFound {

--- a/app/lib/common/widgets/user_builder.dart
+++ b/app/lib/common/widgets/user_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 
@@ -19,7 +21,7 @@ final userAvatarProvider =
     try {
       final data = (await user.getAvatar(null)).data();
       if (data != null) {
-        return MemoryImage(data.asTypedList());
+        return MemoryImage(Uint8List.fromList(data.asTypedList()));
       }
     } catch (e, s) {
       _log.severe('failure fetching avatar', e, s);

--- a/app/lib/features/activities/providers/invitations_providers.dart
+++ b/app/lib/features/activities/providers/invitations_providers.dart
@@ -21,11 +21,12 @@ final invitationUserProfileProvider = FutureProvider.autoDispose
   final displayName = user.getDisplayName();
   final fallback = AvatarInfo(uniqueId: userId, displayName: displayName);
   final avatar = await user.getAvatar(null);
+  final avatarData = avatar.data();
 
-  if (!user.hasAvatar() || avatar.data() == null) {
+  if (!user.hasAvatar() || avatarData == null) {
     return fallback;
   }
-  final data = MemoryImage(Uint8List.fromList(avatar.data()!.asTypedList()));
+  final data = MemoryImage(Uint8List.fromList(avatarData.asTypedList()));
 
   return AvatarInfo(
     uniqueId: userId,

--- a/app/lib/features/activities/providers/invitations_providers.dart
+++ b/app/lib/features/activities/providers/invitations_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:acter/features/activities/providers/notifiers/invitation_list_notifier.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -23,7 +25,7 @@ final invitationUserProfileProvider = FutureProvider.autoDispose
   if (!user.hasAvatar() || avatar.data() == null) {
     return fallback;
   }
-  final data = MemoryImage(avatar.data()!.asTypedList());
+  final data = MemoryImage(Uint8List.fromList(avatar.data()!.asTypedList()));
 
   return AvatarInfo(
     uniqueId: userId,

--- a/app/lib/features/invite_members/providers/invite_providers.dart
+++ b/app/lib/features/invite_members/providers/invite_providers.dart
@@ -67,7 +67,7 @@ final suggestedUsersProvider = FutureProvider.family<List<FoundUser>, String>(
       if (user.hasAvatar()) {
         try {
           avatar = await user.getAvatar(null).then((val) =>
-              MemoryImage(Uint8List.fromList(val.data()!.asTypedList())));
+              MemoryImage(Uint8List.fromList(val.data()!.asTypedList())),);
         } catch (e, s) {
           _log.severe('failure fetching avatar', e, s);
         }

--- a/app/lib/features/invite_members/providers/invite_providers.dart
+++ b/app/lib/features/invite_members/providers/invite_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
@@ -64,9 +66,8 @@ final suggestedUsersProvider = FutureProvider.family<List<FoundUser>, String>(
       MemoryImage? avatar;
       if (user.hasAvatar()) {
         try {
-          avatar = await user
-              .getAvatar(null)
-              .then((val) => MemoryImage(val.data()!.asTypedList()));
+          avatar = await user.getAvatar(null).then((val) =>
+              MemoryImage(Uint8List.fromList(val.data()!.asTypedList())));
         } catch (e, s) {
           _log.severe('failure fetching avatar', e, s);
         }

--- a/app/lib/features/public_room_search/providers/public_space_info_provider.dart
+++ b/app/lib/features/public_room_search/providers/public_space_info_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +14,8 @@ final searchItemProfileData = FutureProvider.autoDispose
   return AvatarInfo(
     uniqueId: publicSpace.roomIdStr(),
     displayName: publicSpace.name(),
-    avatar: avatar != null ? MemoryImage(avatar.asTypedList()) : null,
+    avatar: avatar != null
+        ? MemoryImage(Uint8List.fromList(avatar.asTypedList()))
+        : null,
   );
 });


### PR DESCRIPTION
While working on the android crash problem I noticed the following in remark in the generated ffi for `FfiBufferUint8`
```dart
  /// Returns a typed view of this buffer.
  /// Note: The lifetime of this view is tied to the lifetime of this FfiBufferUint8. This Uint8List must not live longer than the creating FfiBufferUint8
  Uint8List asTypedList() {
    final buffer = _box.borrow();
    final addressRaw = _api._ffiBufferAddress(buffer);
    final size = _api._ffiBufferSize(buffer) ~/ 1;
    return ffi.Pointer<ffi.Uint8>.fromAddress(addressRaw).asTypedList(size);
  }
```

Which means that if we ever where to discard the surrounding `FfiBufferUint8` the underlying memory space we have a view on might not be reused for other things on the rust side. This would explain very well the issues we have been seeing in #1937 and the freezes of freezes when going to any page that has an avatar on it (e.g. chat or updates).

And as it turns out we are usually doing the following to fetch an avatar:

```rust
  final avatar = await account.avatar(thumbSize);
  final avatarData  = avatar.data();
  if (avatarData != null) {
    return MemoryImage(avatarData.asTypedList());
  }
```

As we are pulling the `FfiBufferUint8` by calling `data()` and discard it before even returning the function. As a result the view we have handed to `MemoryImage` might or might actually still be valid. Sometimes it works, often times it does not. 

The fix is rather simple: make a copy of the binary in the flutter side to keep the data in resident memory there regardless of what rust does via `Uint8List.fromList(`. (Until we have uniffi-dart where we have a better memory management model). And that is the fix this PR does. And one fix where we called `.data()` more than once (last commit).

Fixes #1937, https://github.com/acterglobal/a3-meta/issues/368


