### PR TITLE
Switch to a secret store that works for linux.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -843,12 +843,13 @@ packages:
     source: hosted
     version: "9.2.2"
   flutter_secure_storage_linux:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_secure_storage_linux
-      sha256: "4d91bfc23047422cbcd73ac684bc169859ee766482517c22172c86596bf1464b"
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_secure_storage_linux
+      ref: ben-fix-linux-secret-store-problem
+      resolved-ref: cfe44e6c58bd3410969b0ef08358371111fa0a28
+      url: "https://github.com/gnunicorn/flutter_secure_storage/"
+    source: git
     version: "1.2.1"
   flutter_secure_storage_macos:
     dependency: transitive

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -158,6 +158,13 @@ dev_dependencies:
   uuid: ^4.0.0
   enough_mail: ^2.1.6
 
+dependency_overrides:
+  flutter_secure_storage_linux:
+    git:
+      url: https://github.com/gnunicorn/flutter_secure_storage/
+      ref: ben-fix-linux-secret-store-problem
+      path: flutter_secure_storage_linux
+
 icons_launcher:
   image_path: "assets/icon/logo.png"
   platforms:


### PR DESCRIPTION
See https://github.com/mogol/flutter_secure_storage/pull/756 for details. This only pulls in that external fix.

fixes #1825