### PR TITLE
Fixing Subchat listing

### DIFF
--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/notifiers/chat_notifiers.dart';
-import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:riverpod/riverpod.dart';
@@ -39,16 +38,6 @@ final chatProvider =
     roomIdOrAlias,
     120,
   ); // retrying for up to 30seconds before failing
-});
-
-final relatedChatsProvider =
-    FutureProvider.family<List<Convo>, String>((ref, spaceId) async {
-  final chats = List.of(
-    (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
-        .knownChats,
-  );
-  chats.sort((a, b) => b.latestMessageTs().compareTo(a.latestMessageTs()));
-  return chats;
 });
 
 final selectedChatIdProvider =

--- a/app/lib/common/providers/notifiers/relations_notifier.dart
+++ b/app/lib/common/providers/notifiers/relations_notifier.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HasSubSpacesNotifier extends FamilyAsyncNotifier<bool, String> {
+  late ProviderSubscription<AsyncValue<List<SpaceHierarchyRoomInfo>>> listener;
   @override
   FutureOr<bool> build(String arg) async {
     final spaceId = arg;
@@ -12,9 +14,10 @@ class HasSubSpacesNotifier extends FamilyAsyncNotifier<bool, String> {
     if (relatedSpaces.knownSubspaces.isNotEmpty) {
       return true; // we have subspaces and know it
     }
-    if (relatedSpaces.hasMoreSubspaces) {
+    if (relatedSpaces.hasMore) {
       // there might be some, but we need to confirm remotely. We do that without blocking
-      ref.listen(remoteSubspaceRelationsProvider(spaceId), (previous, next) {
+      listener = ref.listen(remoteSubspaceRelationsProvider(spaceId),
+          (previous, next) {
         state = next.whenData((data) => data.isNotEmpty);
       });
     }
@@ -23,6 +26,7 @@ class HasSubSpacesNotifier extends FamilyAsyncNotifier<bool, String> {
 }
 
 class HasSubChatsNotifier extends FamilyAsyncNotifier<bool, String> {
+  late ProviderSubscription<AsyncValue<List<SpaceHierarchyRoomInfo>>> listener;
   @override
   FutureOr<bool> build(String arg) async {
     final spaceId = arg;
@@ -31,9 +35,10 @@ class HasSubChatsNotifier extends FamilyAsyncNotifier<bool, String> {
     if (relatedSpaces.knownChats.isNotEmpty) {
       return true; // we have subspaces and know it
     }
-    if (relatedSpaces.hasMoreChats) {
+    if (relatedSpaces.hasMore) {
       // there might be some, but we need to confirm remotely. We do that without blocking
-      ref.listen(remoteChatRelationsProvider(spaceId), (previous, next) {
+      listener =
+          ref.listen(remoteChatRelationsProvider(spaceId), (previous, next) {
         state = next.whenData((data) => data.isNotEmpty);
       });
     }

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -218,15 +218,6 @@ final joinRulesAllowedRoomsProvider = FutureProvider.autoDispose
   return room.restrictedRoomIdsStr().map((e) => e.toDartString()).toList();
 });
 
-/// Get the List of related of the spaces for the space. Errors if the space or any
-/// related space isn't found. Stays up  to date with underlying client data if
-/// a space was found.
-final relatedSpacesProvider =
-    FutureProvider.family<List<Space>, String>((ref, spaceId) async {
-  return (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
-      .knownSubspaces;
-});
-
 /// The list of suggested RoomIDs
 final suggestedRelationsIdsProvider =
     FutureProvider.family<List<String>, String>((ref, spaceId) async {

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/notifiers/relations_notifier.dart';
 import 'package:acter/common/providers/notifiers/space_notifiers.dart';
 import 'package:acter/common/providers/room_providers.dart';
@@ -108,11 +107,10 @@ class SpaceItem {
 }
 
 class SpaceRelationsOverview {
-  bool hasMoreSubspaces;
-  bool hasMoreChats;
+  bool hasMore;
   SpaceRelations rel;
-  List<Space> knownSubspaces;
-  List<Convo> knownChats;
+  List<String> knownSubspaces;
+  List<String> knownChats;
   List<String> suggestedIds;
   Space? mainParent;
   List<Space> parents;
@@ -126,8 +124,7 @@ class SpaceRelationsOverview {
     required this.mainParent,
     required this.parents,
     required this.otherRelations,
-    required this.hasMoreSubspaces,
-    required this.hasMoreChats,
+    required this.hasMore,
   });
 }
 
@@ -231,37 +228,27 @@ final spaceRelationsOverviewProvider =
   if (relatedSpaces == null) {
     throw SpaceNotFound;
   }
-  bool hasMoreSubspaces = false;
-  bool hasMoreChats = false;
-  final List<Space> knownSubspaces = [];
-  final List<Convo> knownChats = [];
+  bool hasMore = false;
+  final List<String> knownSubspaces = [];
+  final List<String> knownChats = [];
   final List<String> suggested = [];
   List<Space> otherRelated = [];
-  for (final related in relatedSpaces.children()) {
+  final children = relatedSpaces.children();
+  for (final related in children) {
     String targetType = related.targetType();
     final roomId = related.roomId().toString();
     if (related.suggested()) {
       suggested.add(roomId);
     }
-    if (targetType == 'ChatRoom') {
-      try {
-        final chat = await ref.watch(chatProvider(roomId).future);
-        knownChats.add(chat);
-      } catch (e) {
-        hasMoreChats = true;
-      }
+    if (targetType == 'Unknown') {
+      // this one is not found locally
+      hasMore = true;
+    } else if (targetType == 'ChatRoom') {
+      // we know this as a chat room
+      knownChats.add(roomId);
     } else {
-      try {
-        final space = await ref.watch(spaceProvider(roomId).future);
-        final isChildSpaceOf = await space.isChildSpaceOf(spaceId);
-        if (isChildSpaceOf) {
-          knownSubspaces.add(space);
-        } else {
-          otherRelated.add(space);
-        }
-      } catch (e) {
-        hasMoreSubspaces = true;
-      }
+      // this must be some space.
+      knownSubspaces.add(roomId);
     }
   }
   List<Space> parents = [];
@@ -304,8 +291,7 @@ final spaceRelationsOverviewProvider =
     knownSubspaces: knownSubspaces,
     otherRelations: otherRelated,
     mainParent: mainParent,
-    hasMoreSubspaces: hasMoreSubspaces,
-    hasMoreChats: hasMoreChats,
+    hasMore: hasMore,
     suggestedIds: suggested,
   );
 });
@@ -336,8 +322,7 @@ final remoteChatRelationsProvider =
   try {
     final relatedSpaces =
         await ref.watch(spaceRelationsOverviewProvider(spaceId).future);
-    final toIgnore =
-        relatedSpaces.knownChats.map((e) => e.getRoomIdStr()).toList();
+    final toIgnore = relatedSpaces.knownChats.toList();
     final roomHierarchy =
         await ref.watch(_spaceRemoteRelationsProvider(spaceId).future);
     // filter out the known rooms
@@ -355,8 +340,7 @@ final remoteSubspaceRelationsProvider =
   try {
     final relatedSpaces =
         await ref.watch(spaceRelationsOverviewProvider(spaceId).future);
-    final toIgnore =
-        relatedSpaces.knownSubspaces.map((e) => e.getRoomIdStr()).toList();
+    final toIgnore = List.of(relatedSpaces.knownSubspaces);
     toIgnore.addAll(relatedSpaces.parents.map((e) => e.getRoomIdStr()));
     if (relatedSpaces.mainParent != null) {
       toIgnore.add(relatedSpaces.mainParent!.getRoomIdStr());

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -111,7 +111,6 @@ class SpaceRelationsOverview {
   bool hasMoreSubspaces;
   bool hasMoreChats;
   SpaceRelations rel;
-  Member? membership;
   List<Space> knownSubspaces;
   List<Convo> knownChats;
   List<String> suggestedIds;
@@ -121,7 +120,6 @@ class SpaceRelationsOverview {
 
   SpaceRelationsOverview({
     required this.rel,
-    required this.membership,
     required this.knownSubspaces,
     required this.knownChats,
     required this.suggestedIds,
@@ -196,7 +194,7 @@ final searchedSpacesProvider =
   return foundSpaces;
 });
 
-/// Get the SpaceItem of the given sapceId filled in brief form
+/// Get the SpaceItem of the given spaceId filled in brief form
 /// (only spaceProfileData, no activeMembers). Stays up to date with underlying
 /// client info
 final briefSpaceItemProvider =
@@ -233,7 +231,6 @@ final spaceRelationsOverviewProvider =
   if (relatedSpaces == null) {
     throw SpaceNotFound;
   }
-  final membership = await ref.watch(roomMembershipProvider(spaceId).future);
   bool hasMoreSubspaces = false;
   bool hasMoreChats = false;
   final List<Space> knownSubspaces = [];
@@ -302,7 +299,6 @@ final spaceRelationsOverviewProvider =
   }
   return SpaceRelationsOverview(
     rel: relatedSpaces,
-    membership: membership,
     parents: parents,
     knownChats: knownChats,
     knownSubspaces: knownSubspaces,

--- a/app/lib/common/widgets/chat/convo_with_avatar_card.dart
+++ b/app/lib/common/widgets/chat/convo_with_avatar_card.dart
@@ -1,12 +1,10 @@
 import 'package:acter/common/providers/chat_providers.dart';
-import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/room_avatar.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:skeletonizer/skeletonizer.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 class ConvoWithAvatarInfoCard extends ConsumerWidget {
@@ -70,7 +68,14 @@ class ConvoWithAvatarInfoCard extends ConsumerWidget {
                 onFocusChange: onFocusChange,
                 onLongPress: onLongPress,
                 leading: avatarWithIndicator(context, ref),
-                title: buildDisplayName(context, ref),
+                title: Text(
+                  avatarInfo.displayName ?? roomId,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium!
+                      .copyWith(fontWeight: FontWeight.w700),
+                  overflow: TextOverflow.ellipsis,
+                ),
                 subtitle: buildSubtitle(context, constraints),
                 trailing: constraints.maxWidth < 300 ? null : trailing,
               ),
@@ -103,33 +108,6 @@ class ConvoWithAvatarInfoCard extends ConsumerWidget {
       L10n.of(context).suggested,
       style: Theme.of(context).textTheme.labelSmall,
     );
-  }
-
-  Widget buildDisplayName(BuildContext context, WidgetRef ref) {
-    return ref.watch(roomDisplayNameProvider(roomId)).when(
-          data: (dpl) => Text(
-            dpl ?? roomId,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(fontWeight: FontWeight.w700),
-            overflow: TextOverflow.ellipsis,
-          ),
-          error: (error, stackTrace) => Text(
-            roomId,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(fontWeight: FontWeight.w700),
-            overflow: TextOverflow.ellipsis,
-          ),
-          loading: () => Skeletonizer(
-            child: Text(
-              roomId,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        );
   }
 
   Widget avatarWithIndicator(BuildContext context, WidgetRef ref) {

--- a/app/lib/common/widgets/chat/loading_convo_card.dart
+++ b/app/lib/common/widgets/chat/loading_convo_card.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 class LoadingConvoCard extends ConsumerWidget {
   final String roomId;
@@ -65,15 +66,21 @@ class LoadingConvoCard extends ConsumerWidget {
                 onFocusChange: onFocusChange,
                 onLongPress: onLongPress,
                 leading: avatar,
-                title: Text(
-                  '',
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .copyWith(fontWeight: FontWeight.w700),
-                  overflow: TextOverflow.ellipsis,
+                title: Skeletonizer(
+                  child: Text(
+                    roomId,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium!
+                        .copyWith(fontWeight: FontWeight.w700),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-                subtitle: constraints.maxWidth < 300 ? null : subtitle,
+                subtitle: constraints.maxWidth < 300
+                    ? null
+                    : subtitle != null
+                        ? Skeletonizer(child: subtitle!)
+                        : null,
                 trailing: constraints.maxWidth < 300 ? null : trailing,
               ),
             ),

--- a/app/lib/common/widgets/spaces/space_card.dart
+++ b/app/lib/common/widgets/spaces/space_card.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 typedef SubtitleFn = Widget? Function(Space);
 
 class SpaceCard extends ConsumerWidget {
-  final Space space;
+  final String roomId;
   final SubtitleFn? subtitleFn;
   final double avatarSize;
 
@@ -85,7 +85,7 @@ class SpaceCard extends ConsumerWidget {
 
   const SpaceCard({
     super.key,
-    required this.space,
+    required this.roomId,
     this.subtitleFn,
     this.onTap,
     this.onLongPress,
@@ -105,7 +105,7 @@ class SpaceCard extends ConsumerWidget {
 
   const SpaceCard.small({
     super.key,
-    required this.space,
+    required this.roomId,
     this.subtitleFn,
     this.onTap,
     this.onLongPress,
@@ -125,9 +125,7 @@ class SpaceCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final roomId = space.getRoomIdStr();
     final avatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
-    final subtitle = subtitleFn != null ? subtitleFn!(space) : null;
     final parents = ref.watch(parentAvatarInfosProvider(roomId)).valueOrNull;
 
     return SpaceWithAvatarInfoCard(
@@ -135,7 +133,6 @@ class SpaceCard extends ConsumerWidget {
       roomId: roomId,
       avatarInfo: avatarInfo,
       parents: parents,
-      subtitle: subtitle,
       onTap: onTap,
       onFocusChange: onFocusChange,
       onLongPress: onLongPress,

--- a/app/lib/common/widgets/spaces/space_hierarchy_card.dart
+++ b/app/lib/common/widgets/spaces/space_hierarchy_card.dart
@@ -139,7 +139,7 @@ class SpaceHierarchyCard extends ConsumerWidget {
                 viaServerName: roomInfo.viaServerName(),
                 forward: (spaceId) {
                   goToSpace(context, spaceId);
-                  ref.invalidate(relatedSpacesProvider(parentId));
+                  ref.invalidate(spaceRelationsProvider(parentId));
                 },
               ),
               RoomHierarchyOptionsMenu(

--- a/app/lib/features/home/widgets/my_spaces_section.dart
+++ b/app/lib/features/home/widgets/my_spaces_section.dart
@@ -100,7 +100,7 @@ class _RenderSpacesSection extends ConsumerWidget {
           physics: const NeverScrollableScrollPhysics(),
           itemBuilder: (context, index) {
             return SpaceCard(
-              space: spaces[index],
+              roomId: spaces[index].getRoomIdStr(),
               margin: const EdgeInsets.only(bottom: 14),
             );
           },

--- a/app/lib/features/public_room_search/widgets/maybe_direct_room_action_widget.dart
+++ b/app/lib/features/public_room_search/widgets/maybe_direct_room_action_widget.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/room/actions/join_room.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -165,16 +164,12 @@ class MaybeDirectRoomActionWidget extends ConsumerWidget {
     void Function()? onTap,
     Widget? trailing,
   }) {
-    final space = ref.watch(spaceProvider(roomId)).valueOrNull;
-    if (space != null) {
-      return SpaceCard(
-        space: space,
-        showParents: true,
-        onTap: onTap,
-        trailing: trailing,
-      );
-    }
-    return loadingCard();
+    return SpaceCard(
+      roomId: roomId,
+      showParents: true,
+      onTap: onTap,
+      trailing: trailing,
+    );
   }
 
   Widget renderConvoCard(

--- a/app/lib/features/space/pages/sub_spaces_page.dart
+++ b/app/lib/features/space/pages/sub_spaces_page.dart
@@ -83,6 +83,9 @@ class SubSpacesPage extends ConsumerWidget {
     final crossAxisCount = max(1, min(widthCount, minCount));
     final spaceName =
         ref.watch(roomDisplayNameProvider(spaceIdOrAlias)).valueOrNull;
+    final membership = ref.watch(roomMembershipProvider(spaceIdOrAlias));
+    bool canLinkSpace =
+        membership.valueOrNull?.canString('CanLinkSpaces') == true;
     // get platform of context.
     return Scaffold(
       appBar: AppBar(
@@ -108,7 +111,7 @@ class SubSpacesPage extends ConsumerWidget {
           ),
           spaces.when(
             data: (spaces) {
-              if (spaces.membership?.canString('CanLinkSpaces') ?? false) {
+              if (canLinkSpace) {
                 return _renderTools(context);
               } else {
                 return const SizedBox.shrink();
@@ -135,7 +138,7 @@ class SubSpacesPage extends ConsumerWidget {
                     ) ??
                     renderFallback(
                       context,
-                      spaces.membership?.canString('CanLinkSpaces') ?? false,
+                      canLinkSpace,
                     );
               },
               error: (error, stack) => Center(

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -73,11 +73,11 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
     childRoomsIds.clear();
     if (widget.childRoomType == ChildRoomType.chat) {
       for (int i = 0; i < space.knownChats.length; i++) {
-        childRoomsIds.add(space.knownChats[i].getRoomIdStr());
+        childRoomsIds.add(space.knownChats[i]);
       }
     } else {
       for (int i = 0; i < space.knownSubspaces.length; i++) {
-        childRoomsIds.add(space.knownSubspaces[i].getRoomIdStr());
+        childRoomsIds.add(space.knownSubspaces[i]);
       }
       //Add recommended child spaces ids
       recommendedChildSpaceIds.clear();

--- a/app/lib/features/space/widgets/related_spaces/helpers.dart
+++ b/app/lib/features/space/widgets/related_spaces/helpers.dart
@@ -32,12 +32,11 @@ List<Widget>? _renderKnownSubspaces(
       ),
       shrinkWrap: true,
       itemBuilder: (context, index) {
-        final space = spaces.knownSubspaces[index];
-        final roomId = space.getRoomIdStr();
+        final roomId = spaces.knownSubspaces[index];
         final isSuggested = spaces.suggestedIds.contains(roomId);
         return SpaceCard(
           key: Key('subspace-list-item-$roomId'),
-          space: space,
+          roomId: roomId,
           showParents: false,
           showSuggestedMark: isSuggested,
           trailing: RoomHierarchyOptionsMenu(
@@ -134,7 +133,7 @@ Widget? renderSubSpaces(
     // crossAxisCount: crossAxisCount,
   );
 
-  final moreSubspaces = spaces.hasMoreSubspaces
+  final moreSubspaces = spaces.hasMore
       ? renderMoreSubspaces(
           context,
           ref,

--- a/app/lib/features/space/widgets/related_spaces/helpers.dart
+++ b/app/lib/features/space/widgets/related_spaces/helpers.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/widgets/room/room_hierarchy_options_menu.dart';
 import 'package:acter/common/widgets/spaces/space_card.dart';
@@ -119,7 +120,11 @@ Widget? renderSubSpaces(
   int crossAxisCount = 1,
   Widget? Function()? titleBuilder,
 }) {
-  final canLinkSpace = spaces.membership?.canString('CanLinkSpaces') ?? false;
+  final canLinkSpace = ref
+          .watch(roomMembershipProvider(spaceIdOrAlias))
+          .valueOrNull
+          ?.canString('CanLinkSpaces') ??
+      false;
 
   final knownSubspaces = _renderKnownSubspaces(
     context,

--- a/app/lib/features/space/widgets/space_sections/chats_section.dart
+++ b/app/lib/features/space/widgets/space_sections/chats_section.dart
@@ -1,10 +1,11 @@
+import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/chat/convo_card.dart';
 import 'package:acter/common/widgets/chat/convo_hierarchy_card.dart';
+import 'package:acter/common/widgets/chat/loading_convo_card.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
 import 'package:acter/router/utils.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -29,7 +30,6 @@ class ChatsSection extends ConsumerWidget {
         context,
         ref,
         spaceRelationsOverview.knownChats,
-        spaceRelationsOverview.hasMoreChats,
       ),
       error: (error, stack) =>
           Center(child: Text(L10n.of(context).loadingFailed(error))),
@@ -44,12 +44,34 @@ class ChatsSection extends ConsumerWidget {
   Widget buildChatsSectionUI(
     BuildContext context,
     WidgetRef ref,
-    List<Convo> chats,
-    bool hasMore,
+    List<String> chats,
   ) {
-    int chatsLimit = (chats.length > limit) ? limit : chats.length;
-    int moreCount = limit > chats.length ? limit - chats.length : 0;
-    bool isShowSeeAllButton = (chats.length > chatsLimit) || hasMore;
+    int chatsLimit;
+    bool isShowSeeAllButton = false;
+    bool renderRemote = false;
+    int moreCount;
+    if (chats.length > limit) {
+      chatsLimit = limit;
+      isShowSeeAllButton = true;
+      moreCount = 0;
+    } else {
+      chatsLimit = chats.length;
+      moreCount = limit - chats.length;
+      if (moreCount > 0) {
+        final remoteCount =
+            (ref.watch(remoteChatRelationsProvider(spaceId)).valueOrNull ?? [])
+                .length;
+        if (remoteCount > 0) {
+          renderRemote = true;
+          if (remoteCount < moreCount) {
+            moreCount = remoteCount;
+          }
+          if (remoteCount > moreCount) {
+            isShowSeeAllButton = true;
+          }
+        }
+      }
+    }
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -62,25 +84,33 @@ class ChatsSection extends ConsumerWidget {
             pathParameters: {'spaceId': spaceId},
           ),
         ),
-        chatsListUI(chats, chatsLimit),
-        if (moreCount > 0 && hasMore) renderFurther(context, ref, moreCount),
+        chatsListUI(ref, chats, chatsLimit),
+        if (renderRemote) renderFurther(context, ref, moreCount),
       ],
     );
   }
 
-  Widget chatsListUI(List<Convo> chats, int chatsLimit) {
+  Widget chatsListUI(WidgetRef ref, List<String> chats, int chatsLimit) {
     return ListView.builder(
       shrinkWrap: true,
       itemCount: chatsLimit,
       padding: EdgeInsets.zero,
       physics: const NeverScrollableScrollPhysics(),
       itemBuilder: (context, index) {
-        return ConvoCard(
-          room: chats[index],
-          showParents: false,
-          showSelectedIndication: false,
-          onTap: () => goToChat(context, chats[index].getRoomIdStr()),
-        );
+        final roomId = chats[index];
+        return ref.watch(chatProvider(roomId)).when(
+              data: (room) => ConvoCard(
+                room: room,
+                showParents: false,
+                showSelectedIndication: false,
+                onTap: () => goToChat(context, roomId),
+              ),
+              error: (error, stack) => ListTile(
+                title: Text(roomId),
+                subtitle: Text(L10n.of(context).loadingFailed(error)),
+              ),
+              loading: () => LoadingConvoCard(roomId: roomId),
+            );
       },
     );
   }

--- a/app/lib/features/spaces/pages/spaces_page.dart
+++ b/app/lib/features/spaces/pages/spaces_page.dart
@@ -81,7 +81,7 @@ class _SpacesPageState extends ConsumerState<SpacesPage> {
                   pathParameters: {'spaceId': roomId},
                 ),
                 key: Key('space-list-item-$roomId'),
-                space: space,
+                roomId: roomId,
               );
             },
           ),

--- a/app/lib/features/super_invites/widgets/to_join_room.dart
+++ b/app/lib/features/super_invites/widgets/to_join_room.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/widgets/chat/convo_card.dart';
 import 'package:acter/common/widgets/spaces/space_card.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -24,15 +23,11 @@ class RoomToInviteTo extends ConsumerWidget {
     String subtitle = L10n.of(context).unknownRoom;
     if (room != null) {
       if (room.isSpace()) {
-        final space = ref.watch(spaceProvider(roomId)).valueOrNull;
-        if (space != null) {
-          return SpaceCard(
-            space: space,
-            showParents: true,
-            trailing: removeWidget(),
-          );
-        }
-        subtitle = L10n.of(context).loadingRoom;
+        return SpaceCard(
+          roomId: roomId,
+          showParents: true,
+          trailing: removeWidget(),
+        );
       } else {
         final chat = ref.watch(chatProvider(roomId)).valueOrNull;
         if (chat != null) {


### PR DESCRIPTION
This fixes missing the chats-section when you were not in any of the subchats, as well as several errors in trying to list them up. It also improves the performance by dropping several unnecessary fetching of entire objects where roomIds only will do.

See that it works in the previously broken demo space:

https://github.com/user-attachments/assets/deea3a3a-f4a7-4066-ad3b-4ff2f17b47e2

There are several fixes in this coming together. I'll explain them with comments on the PR review to make it easier to understand why the changes were made the way they were. 