### PR TITLE
Desktop Settings-Routing fixes

### DIFF
--- a/.changes/1906-fixed-routing.md
+++ b/.changes/1906-fixed-routing.md
@@ -1,0 +1,1 @@
+- Fix in routing if you resized the app window while in setting screens.

--- a/app/lib/common/dialogs/attachment_selection.dart
+++ b/app/lib/common/dialogs/attachment_selection.dart
@@ -15,7 +15,7 @@ void showAttachmentSelection(
   BuildContext context,
   AttachmentsManager manager,
 ) async {
-  isLargeScreen(context)
+  context.isLargeScreen
       ? await showAdaptiveDialog(
           context: context,
           builder: (context) => Dialog(

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -70,8 +70,9 @@ extension RefDebounceExtension on Ref {
 
 const largeScreenBreakPoint = 770;
 
-bool isLargeScreen(BuildContext context) {
-  return MediaQuery.of(context).size.width >= largeScreenBreakPoint;
+extension ActerContextUtils on BuildContext {
+  bool get isLargeScreen =>
+      MediaQuery.of(this).size.width >= largeScreenBreakPoint;
 }
 
 DateTime kFirstDay = DateTime.utc(2010, 10, 16);

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -17,6 +17,7 @@ import 'package:intl/intl.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 final _log = Logger('a3::common::util');
@@ -73,6 +74,15 @@ const largeScreenBreakPoint = 770;
 extension ActerContextUtils on BuildContext {
   bool get isLargeScreen =>
       MediaQuery.of(this).size.width >= largeScreenBreakPoint;
+
+  Future<void> closeDialog<T>([T? result]) async {
+    try {
+      Navigator.of(this).pop(result);
+    } catch (error, stackTrace) {
+      _log.severe('Routing failed', error, stackTrace);
+      await Sentry.captureException(error, stackTrace: stackTrace);
+    }
+  }
 }
 
 DateTime kFirstDay = DateTime.utc(2010, 10, 16);

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -75,13 +75,22 @@ extension ActerContextUtils on BuildContext {
   bool get isLargeScreen =>
       MediaQuery.of(this).size.width >= largeScreenBreakPoint;
 
-  Future<void> closeDialog<T>([T? result]) async {
+  NavigatorState closeDialog({Routes? orGo, bool ignorePopFailure = false}) {
+    final navigator = Navigator.of(this);
     try {
-      Navigator.of(this).pop(result);
+      if (orGo != null && !navigator.canPop()) {
+        navigator.pushReplacementNamed(orGo.name);
+      } else {
+        navigator.pop();
+      }
     } catch (error, stackTrace) {
-      _log.severe('Routing failed', error, stackTrace);
-      await Sentry.captureException(error, stackTrace: stackTrace);
+      if (!ignorePopFailure) {
+        // track if we failed to pop so we can fix that.
+        _log.severe('Routing failed', error, stackTrace);
+        Sentry.captureException(error, stackTrace: stackTrace);
+      }
     }
+    return navigator;
   }
 }
 

--- a/app/lib/common/widgets/chat/edit_room_description_sheet.dart
+++ b/app/lib/common/widgets/chat/edit_room_description_sheet.dart
@@ -1,10 +1,10 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::chat::room_description_edit_sheet');
@@ -76,7 +76,7 @@ class _EditRoomDescriptionSheetState
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 OutlinedButton(
-                  onPressed: () => context.pop(),
+                  onPressed: () => context.closeDialog(),
                   child: Text(L10n.of(context).cancel),
                 ),
                 const SizedBox(width: 20),
@@ -95,7 +95,7 @@ class _EditRoomDescriptionSheetState
   Future<void> _editDescription(BuildContext context, WidgetRef ref) async {
     final newDesc = _descriptionController.text.trim();
     if (newDesc == widget.description.trim()) {
-      context.pop();
+      context.closeDialog();
       return; // no changes to submit
     }
 
@@ -105,7 +105,7 @@ class _EditRoomDescriptionSheetState
       await convo.setTopic(_descriptionController.text.trim());
       EasyLoading.dismiss();
       if (!context.mounted) return;
-      context.pop();
+      context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to edit chat description', e, st);
       if (!context.mounted) {

--- a/app/lib/common/widgets/edit_html_description_sheet.dart
+++ b/app/lib/common/widgets/edit_html_description_sheet.dart
@@ -1,11 +1,11 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 
 void showEditHtmlDescriptionBottomSheet({
   required BuildContext context,
@@ -93,7 +93,7 @@ class _EditHtmlDescriptionSheetState
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.pop(),
+                onPressed: () => context.closeDialog(),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -104,7 +104,7 @@ class _EditHtmlDescriptionSheetState
                   final plainDescription = textEditorState.intoMarkdown();
                   if (htmlBodyDescription == widget.descriptionHtmlValue ||
                       plainDescription == widget.descriptionMarkdownValue) {
-                    context.pop();
+                    context.closeDialog();
                     return;
                   }
                   widget.onSave(htmlBodyDescription, plainDescription);

--- a/app/lib/common/widgets/edit_link_sheet.dart
+++ b/app/lib/common/widgets/edit_link_sheet.dart
@@ -1,9 +1,9 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 
 void showEditLinkBottomSheet({
   required BuildContext context,
@@ -81,7 +81,7 @@ class _EditTitleSheetState extends ConsumerState<EditLinkSheet> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.pop(),
+                onPressed: () => context.closeDialog(),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -89,7 +89,7 @@ class _EditTitleSheetState extends ConsumerState<EditLinkSheet> {
                 onPressed: () {
                   // no changes to submit
                   if (_linkController.text.trim() == widget.linkValue.trim()) {
-                    context.pop();
+                    context.closeDialog();
                     return;
                   }
 

--- a/app/lib/common/widgets/edit_plain_description_sheet.dart
+++ b/app/lib/common/widgets/edit_plain_description_sheet.dart
@@ -1,7 +1,7 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 
 void showEditPlainDescriptionBottomSheet({
   required BuildContext context,
@@ -71,7 +71,7 @@ class _EditPlainDescriptionSheetState extends State<EditPlainDescriptionSheet> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 OutlinedButton(
-                  onPressed: () => context.pop(),
+                  onPressed: () => context.closeDialog(),
                   child: Text(L10n.of(context).cancel),
                 ),
                 const SizedBox(width: 20),
@@ -80,7 +80,7 @@ class _EditPlainDescriptionSheetState extends State<EditPlainDescriptionSheet> {
                     final newDescription = _descriptionController.text.trim();
                     // No need to change
                     if (newDescription == widget.descriptionValue.trim()) {
-                      context.pop();
+                      context.closeDialog();
                       return;
                     }
 

--- a/app/lib/common/widgets/edit_title_sheet.dart
+++ b/app/lib/common/widgets/edit_title_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 
 void showEditTitleBottomSheet({
   required BuildContext context,
@@ -79,7 +79,7 @@ class _EditTitleSheetState extends ConsumerState<EditTitleSheet> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.pop(),
+                onPressed: () => context.closeDialog(),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -88,7 +88,7 @@ class _EditTitleSheetState extends ConsumerState<EditTitleSheet> {
                   // no changes to submit
                   if (_titleController.text.trim() ==
                       widget.titleValue.trim()) {
-                    context.pop();
+                    context.closeDialog();
                     return;
                   }
 

--- a/app/lib/common/widgets/with_sidebar.dart
+++ b/app/lib/common/widgets/with_sidebar.dart
@@ -12,7 +12,7 @@ class WithSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isLarge = isLargeScreen(context);
+    final isLarge = context.isLargeScreen;
     if (isLarge) {
       return Row(
         mainAxisSize: MainAxisSize.min,

--- a/app/lib/common/widgets/with_sidebar.dart
+++ b/app/lib/common/widgets/with_sidebar.dart
@@ -1,33 +1,28 @@
-import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 
 class WithSidebar extends StatelessWidget {
   final Widget child;
   final Widget sidebar;
-  final bool preferSidebar;
   const WithSidebar({
     super.key,
     required this.child,
     required this.sidebar,
-    this.preferSidebar = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constrains) {
-        if (constrains.maxWidth > 770 && isDesktop) {
-          return Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              Flexible(flex: 1, child: sidebar),
-              Flexible(flex: 2, child: child),
-            ],
-          );
-        }
-        return preferSidebar ? sidebar : child;
-      },
-    );
+    final isLarge = isLargeScreen(context);
+    if (isLarge) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Flexible(flex: 1, child: sidebar),
+          Flexible(flex: 2, child: child),
+        ],
+      );
+    }
+    return child;
   }
 }

--- a/app/lib/features/auth/pages/register_page.dart
+++ b/app/lib/features/auth/pages/register_page.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/no_internet.dart';
 import 'package:acter/features/auth/providers/auth_providers.dart';
 import 'package:acter/features/super_invites/providers/super_invites_providers.dart';
@@ -335,7 +336,7 @@ class _RegisterPageState extends ConsumerState<RegisterPage> {
                     ),
                     IconButton(
                       onPressed: () async {
-                        context.pop(); // close the drawer
+                        context.closeDialog(); // close the drawer
                         EasyLoading.showToast(
                           L10n.of(context).inviteCopiedToClipboard,
                           toastPosition: EasyLoadingToastPosition.bottom,

--- a/app/lib/features/bug_report/pages/bug_report_page.dart
+++ b/app/lib/features/bug_report/pages/bug_report_page.dart
@@ -241,7 +241,7 @@ class _BugReportState extends ConsumerState<BugReportPage> {
                           if (!await reportBug(context)) return;
                           if (!context.mounted) return;
                           if (context.canPop()) {
-                            context.pop();
+                            context.closeDialog();
                           }
                         },
                         child: Text(L10n.of(context).submit),

--- a/app/lib/features/chat/config.dart
+++ b/app/lib/features/chat/config.dart
@@ -1,1 +1,0 @@
-const sidebarMinWidth = 750;

--- a/app/lib/features/chat/dialogs/encryption_info_drawer.dart
+++ b/app/lib/features/chat/dialogs/encryption_info_drawer.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:go_router/go_router.dart';
@@ -35,7 +36,7 @@ class EncryptionInfoSheet extends StatelessWidget {
               ),
               if (context.canPop())
                 TextButton(
-                  onPressed: () => context.pop(),
+                  onPressed: () => context.closeDialog(),
                   child: Text(
                     L10n.of(context).close,
                   ),
@@ -49,7 +50,7 @@ class EncryptionInfoSheet extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           OutlinedButton(
-            onPressed: () => context.pop(),
+            onPressed: () => context.closeDialog(),
             child: Text(L10n.of(context).close),
           ),
         ],

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -46,7 +46,7 @@ class RoomPage extends ConsumerWidget {
     final activeMembers = ref.watch(membersIdsProvider(roomId));
     return AppBar(
       elevation: 0,
-      automaticallyImplyLeading: !isLargeScreen(context),
+      automaticallyImplyLeading: !context.isLargeScreen,
       centerTitle: true,
       toolbarHeight: 70,
       flexibleSpace: FrostEffect(

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/acter_theme.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/frost_effect.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/avatar_builder.dart';
@@ -34,11 +35,9 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 class RoomPage extends ConsumerWidget {
   static const roomPageKey = Key('chat-room-page');
   final String roomId;
-  final bool inSidebar;
 
   const RoomPage({
     required this.roomId,
-    required this.inSidebar,
     super.key = roomPageKey,
   });
 
@@ -47,7 +46,7 @@ class RoomPage extends ConsumerWidget {
     final activeMembers = ref.watch(membersIdsProvider(roomId));
     return AppBar(
       elevation: 0,
-      automaticallyImplyLeading: inSidebar ? false : true,
+      automaticallyImplyLeading: !isLargeScreen(context),
       centerTitle: true,
       toolbarHeight: 70,
       flexibleSpace: FrostEffect(
@@ -114,7 +113,7 @@ class RoomPage extends ConsumerWidget {
           children: [
             appBar(context, ref),
             ref.watch(chatProvider(roomId)).when(
-                  data: (convo) => ChatRoom(convo: convo, inSidebar: inSidebar),
+                  data: (convo) => ChatRoom(convo: convo),
                   error: (e, s) => Center(
                     child: Text(L10n.of(context).loadingRoomFailed(e)),
                   ),
@@ -148,11 +147,9 @@ class RoomPage extends ConsumerWidget {
 
 class ChatRoom extends ConsumerStatefulWidget {
   final Convo convo;
-  final bool inSidebar;
 
   const ChatRoom({
     required this.convo,
-    required this.inSidebar,
     super.key,
   });
 

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -97,7 +97,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
       automaticallyImplyLeading: !context.isLargeScreen,
       leading: context.isLargeScreen
           ? IconButton(
-              onPressed: () => context.pop(),
+              onPressed: () => context.closeDialog(),
               icon: const Icon(Atlas.xmark_circle_thin),
             )
           : null,
@@ -191,7 +191,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
       await convo.setName(newName.trim());
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.pop();
+      context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to edit chat name', e, st);
       EasyLoading.dismiss();
@@ -532,7 +532,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
           await convo?.setTopic(newDescription);
           EasyLoading.dismiss();
           if (!context.mounted) return;
-          context.pop();
+          context.closeDialog();
         } catch (e) {
           EasyLoading.dismiss();
           if (!context.mounted) return;

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -29,11 +28,9 @@ final _log = Logger('a3::chat::room_profile_page');
 
 class RoomProfilePage extends ConsumerStatefulWidget {
   final String roomId;
-  final bool inSidebar;
 
   const RoomProfilePage({
     required this.roomId,
-    required this.inSidebar,
     super.key,
   });
 
@@ -97,7 +94,8 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
 
     return AppBar(
       // custom x-circle when we are in widescreen mode;
-      leading: widget.inSidebar
+      automaticallyImplyLeading: !isLargeScreen(context),
+      leading: isLargeScreen(context)
           ? IconButton(
               onPressed: () => context.pop(),
               icon: const Icon(Atlas.xmark_circle_thin),
@@ -338,7 +336,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   }
 
   Widget _optionsBody(BuildContext context) {
-    final size = MediaQuery.of(context).size;
+    final isLarge = isLargeScreen(context);
     return Column(
       children: [
         // Notification section
@@ -365,17 +363,10 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
                     title: Text(L10n.of(context).accessAndVisibility),
                     description: VisibilityChip(roomId: widget.roomId),
                     leading: const Icon(Atlas.lab_appliance_thin),
-                    onPressed: (context) {
-                      isDesktop || size.width > 770
-                          ? context.goNamed(
-                              Routes.chatSettingsVisibility.name,
-                              pathParameters: {'roomId': widget.roomId},
-                            )
-                          : context.pushNamed(
-                              Routes.chatSettingsVisibility.name,
-                              pathParameters: {'roomId': widget.roomId},
-                            );
-                    },
+                    onPressed: (context) => context.pushNamed(
+                      Routes.chatSettingsVisibility.name,
+                      pathParameters: {'roomId': widget.roomId},
+                    ),
                   ),
                 ],
               ),

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -94,8 +94,8 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
 
     return AppBar(
       // custom x-circle when we are in widescreen mode;
-      automaticallyImplyLeading: !isLargeScreen(context),
-      leading: isLargeScreen(context)
+      automaticallyImplyLeading: !context.isLargeScreen,
+      leading: context.isLargeScreen
           ? IconButton(
               onPressed: () => context.pop(),
               icon: const Icon(Atlas.xmark_circle_thin),
@@ -336,7 +336,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   }
 
   Widget _optionsBody(BuildContext context) {
-    final isLarge = isLargeScreen(context);
+    final isLarge = context.isLargeScreen;
     return Column(
       children: [
         // Notification section

--- a/app/lib/features/chat/widgets/chat_layout_builder.dart
+++ b/app/lib/features/chat/widgets/chat_layout_builder.dart
@@ -1,75 +1,77 @@
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/features/chat/config.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/pages/chat_select_page.dart';
 import 'package:acter/features/chat/widgets/rooms_list.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 class ChatLayoutBuilder extends StatelessWidget {
-  // (bool inSideBar) -> Widget
-  final Widget Function(bool)? centerBuilder;
-  // (bool inSideBar) -> Widget
-  final Widget Function(bool)? expandedBuilder;
+  final Widget? centerChild;
+  final Widget? expandedChild;
   const ChatLayoutBuilder({
-    this.centerBuilder,
-    this.expandedBuilder,
+    this.centerChild,
+    this.expandedChild,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < sidebarMinWidth) {
-          // we only have space to show the deepest child:
-          if (expandedBuilder != null) {
-            return expandedBuilder!(false);
-          } else if (centerBuilder != null) {
-            return centerBuilder!(false);
-          } else {
-            // no children, show the room list
-            return RoomsListWidget(
-              onSelected: (String roomId) => context.pushNamed(
-                Routes.chatroom.name,
-                pathParameters: {'roomId': roomId},
-              ),
-            );
-          }
-        }
-
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Flexible(
-              child: RoomsListWidget(
-                onSelected: (String roomId) => context.goNamed(
-                  // we switch without "push"
-                  Routes.chatroom.name,
-                  pathParameters: {'roomId': roomId},
-                ),
-              ),
-            ),
-            // we have a room selected
-            if (centerBuilder != null)
-              Flexible(
-                flex: 3,
-                child: centerBuilder!(true),
-              ),
-            // we have an expanded as well
-            if (expandedBuilder != null)
-              Flexible(
-                flex: 2,
-                child: expandedBuilder!(true),
-              ),
-            // Fallback if neither is in our route
-            if (centerBuilder == null && expandedBuilder == null)
-              const Flexible(
-                flex: 2,
-                child: ChatSelectPage(),
-              ),
-          ],
+    if (!isLargeScreen(context)) {
+      // we only have space to show the deepest child:
+      if (expandedChild != null) {
+        return expandedChild!;
+      } else if (centerChild != null) {
+        return centerChild!;
+      } else {
+        // no children, show the room list
+        return RoomsListWidget(
+          onSelected: (String roomId) => context.pushNamed(
+            Routes.chatroom.name,
+            pathParameters: {'roomId': roomId},
+          ),
         );
-      },
+      }
+    }
+
+    final pushReplacementRouting = centerChild != null;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Flexible(
+          child: RoomsListWidget(
+            onSelected: (String roomId) => pushReplacementRouting
+                ? context.pushReplacementNamed(
+                    // we switch without "push"
+                    Routes.chatroom.name,
+                    pathParameters: {'roomId': roomId},
+                  )
+                : context.pushNamed(
+                    // we switch without "push"
+                    Routes.chatroom.name,
+                    pathParameters: {'roomId': roomId},
+                  ),
+          ),
+        ),
+        // we have a room selected
+        if (centerChild != null)
+          Flexible(
+            flex: 3,
+            child: centerChild!,
+          ),
+        // we have an expanded as well
+        if (expandedChild != null)
+          Flexible(
+            flex: 2,
+            child: expandedChild!,
+          ),
+        // Fallback if neither is in our route
+        if (centerChild == null && expandedChild == null)
+          const Flexible(
+            flex: 2,
+            child: ChatSelectPage(),
+          ),
+      ],
     );
   }
 }

--- a/app/lib/features/chat/widgets/chat_layout_builder.dart
+++ b/app/lib/features/chat/widgets/chat_layout_builder.dart
@@ -16,7 +16,7 @@ class ChatLayoutBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!isLargeScreen(context)) {
+    if (!context.isLargeScreen) {
       // we only have space to show the deepest child:
       if (expandedChild != null) {
         return expandedChild!;

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -73,7 +73,7 @@ class _CreateChatWidgetState extends ConsumerState<CreateChatPage> {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
-    return isLargeScreen(context)
+    return context.isLargeScreen
         ? Container(
             width: size.width * 0.5,
             decoration: BoxDecoration(

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -508,7 +508,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
   ) {
     final size = MediaQuery.of(context).size;
     if (selectedFiles != null && selectedFiles.isNotEmpty) {
-      isLargeScreen(context)
+      context.isLargeScreen
           ? showAdaptiveDialog(
               context: context,
               builder: (context) => Dialog(

--- a/app/lib/features/events/pages/create_edit_event_page.dart
+++ b/app/lib/features/events/pages/create_edit_event_page.dart
@@ -487,7 +487,7 @@ class CreateEditEventPageConsumerState
       ref.invalidate(spaceEventsProvider(spaceId)); // events page in space
 
       if (mounted) {
-        context.pop();
+        context.closeDialog();
         context.pushNamed(
           Routes.calendarEvent.name,
           pathParameters: {'calendarId': eventId.toString()},
@@ -544,7 +544,7 @@ class CreateEditEventPageConsumerState
       final spaceId = calendarEvent.roomIdStr();
       ref.invalidate(spaceEventsProvider(spaceId)); // events page in space
 
-      if (mounted) context.pop();
+      if (mounted) context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to update calendar event', e, st);
       if (!mounted) {

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -312,7 +312,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
 
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.pop();
+      context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to edit event name', e, st);
       EasyLoading.dismiss();
@@ -667,7 +667,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       updateBuilder.descriptionHtml(plainDescription, htmlBodyDescription);
       await updateBuilder.send();
       EasyLoading.dismiss();
-      if (mounted) context.pop();
+      if (mounted) context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();

--- a/app/lib/features/events/widgets/participants_list.dart
+++ b/app/lib/features/events/widgets/participants_list.dart
@@ -1,8 +1,8 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/member/widgets/member_list_entry.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class ParticipantsList extends ConsumerWidget {
   final String roomId;
@@ -27,7 +27,7 @@ class ParticipantsList extends ConsumerWidget {
                 child: Text(L10n.of(context).eventParticipants),
               ),
               TextButton(
-                onPressed: () => context.pop(),
+                onPressed: () => context.closeDialog(),
                 child: Text(L10n.of(context).close),
               ),
             ],

--- a/app/lib/features/home/widgets/sidebar_widget.dart
+++ b/app/lib/features/home/widgets/sidebar_widget.dart
@@ -26,7 +26,7 @@ class _MyUserAvatar extends ConsumerWidget {
       key: Keys.avatar,
       margin: const EdgeInsets.only(top: 8),
       child: InkWell(
-        onTap: () => context.goNamed(Routes.settings.name),
+        onTap: () => context.pushNamed(Routes.settings.name),
         child: const UserAvatarWidget(size: 20),
       ),
     );

--- a/app/lib/features/invite_members/pages/share_invite_code.dart
+++ b/app/lib/features/invite_members/pages/share_invite_code.dart
@@ -8,7 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
 
 class ShareInviteCode extends ConsumerWidget {
@@ -194,7 +193,7 @@ class ShareInviteCode extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
       child: ActerPrimaryActionButton(
-        onPressed: () => context.pop(),
+        onPressed: () => context.closeDialog(),
         child: Text(L10n.of(context).done),
       ),
     );

--- a/app/lib/features/member/widgets/member_info_drawer.dart
+++ b/app/lib/features/member/widgets/member_info_drawer.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/toolkit/menu_item_widget.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/room/room_avatar_builder.dart';
 import 'package:acter/features/member/dialogs/show_block_user_dialog.dart';
 import 'package:acter/features/member/dialogs/show_change_power_level_dialog.dart';
@@ -17,7 +18,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class _MemberInfoDrawerInner extends ConsumerWidget {
@@ -177,7 +177,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                   () async {
                     await changePowerLevel(context, ref);
                     if (context.mounted) {
-                      context.pop();
+                      context.closeDialog();
                     }
                   },
                 ),
@@ -195,7 +195,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                   onTap: () async {
                     await showKickUserDialog(context, member);
                     if (context.mounted) {
-                      context.pop();
+                      context.closeDialog();
                     }
                   },
                 ),
@@ -210,7 +210,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                     onTap: () async {
                       await showKickAndBanUserDialog(context, member);
                       if (context.mounted) {
-                        context.pop();
+                        context.closeDialog();
                       }
                     },
                   ),
@@ -279,7 +279,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
   Widget _buildUserName(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        context.pop(); // close the drawer
+        context.closeDialog(); // close the drawer
         Clipboard.setData(ClipboardData(text: memberId));
         EasyLoading.showToast(L10n.of(context).usernameCopiedToClipboard);
       },

--- a/app/lib/features/member/widgets/message_user_button.dart
+++ b/app/lib/features/member/widgets/message_user_button.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/providers/create_chat_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/router/utils.dart';
@@ -6,7 +7,6 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class MessageUserButton extends ConsumerWidget {
   final Member member;
@@ -21,7 +21,7 @@ class MessageUserButton extends ConsumerWidget {
         child: OutlinedButton.icon(
           icon: const Icon(Atlas.chats_thin),
           onPressed: () async {
-            context.pop();
+            context.closeDialog();
             goToChat(context, dmId);
           },
           label: const Text('Message'),
@@ -36,10 +36,9 @@ class MessageUserButton extends ConsumerWidget {
             ref.read(createChatSelectedUsersProvider.notifier).state = [
               profile,
             ];
-            context.pop();
-            context.pushNamed(
-              Routes.createChat.name,
-            );
+            context.closeDialog().pushNamed(
+                  Routes.createChat.name,
+                );
           },
           label: const Text('Start DM'),
         ),

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -461,7 +461,8 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
       ref.invalidate(newsStateProvider);
       // Navigate back to update screen.
       Navigator.of(context).pop();
-      context.goNamed(Routes.main.name); // go to the home / main updates
+      context.pushReplacementNamed(
+          Routes.main.name,); // go to the home / main updates
     } catch (err) {
       if (!context.mounted) {
         EasyLoading.dismiss();

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -4,6 +4,7 @@ import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
@@ -99,7 +100,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
         onPressed: () {
           // Hide Keyboard
           SystemChannels.textInput.invokeMethod('TextInput.hide');
-          context.pop();
+          context.closeDialog();
         },
         icon: const Icon(Atlas.xmark_circle),
       ),
@@ -462,7 +463,8 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
       // Navigate back to update screen.
       Navigator.of(context).pop();
       context.pushReplacementNamed(
-          Routes.main.name,); // go to the home / main updates
+        Routes.main.name,
+      ); // go to the home / main updates
     } catch (err) {
       if (!context.mounted) {
         EasyLoading.dismiss();

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,6 +1,8 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
 import 'package:acter/common/widgets/like_button.dart';
 import 'package:acter/common/widgets/redact_content.dart';
@@ -13,7 +15,6 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -181,7 +182,7 @@ class ActionBox extends ConsumerWidget {
               title: L10n.of(context).removeThisPost,
               eventId: news.eventId().toString(),
               onSuccess: () {
-                if (context.canPop()) context.pop();
+                context.closeDialog(orGo: Routes.main);
                 ref.invalidate(newsListProvider);
               },
               senderId: senderId,

--- a/app/lib/features/pins/Utils/pins_utils.dart
+++ b/app/lib/features/pins/Utils/pins_utils.dart
@@ -1,15 +1,14 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
-
 
 Future<void> savePinTitle(
-    BuildContext context,
-    ActerPin pin,
-    String newTitle,
-    ) async {
+  BuildContext context,
+  ActerPin pin,
+  String newTitle,
+) async {
   try {
     EasyLoading.show(status: L10n.of(context).updateName);
     final updateBuilder = pin.updateBuilder();
@@ -17,7 +16,7 @@ Future<void> savePinTitle(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.pop();
+    context.closeDialog();
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;
@@ -26,10 +25,10 @@ Future<void> savePinTitle(
 }
 
 Future<void> savePinLink(
-    BuildContext context,
-    ActerPin pin,
-    String newLink,
-    ) async {
+  BuildContext context,
+  ActerPin pin,
+  String newLink,
+) async {
   try {
     EasyLoading.show(status: L10n.of(context).updatingLinking);
     final updateBuilder = pin.updateBuilder();
@@ -37,7 +36,7 @@ Future<void> savePinLink(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.pop();
+    context.closeDialog();
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;
@@ -59,7 +58,7 @@ Future<void> saveDescription(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.pop();
+    context.closeDialog();
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;

--- a/app/lib/features/search/widgets/quick_actions_builder.dart
+++ b/app/lib/features/search/widgets/quick_actions_builder.dart
@@ -141,9 +141,7 @@ class QuickActionsBuilder extends ConsumerWidget {
               style: Theme.of(context).textTheme.labelMedium,
             ),
             onPressed: () async {
-              if (context.canPop()) {
-                context.pop();
-              }
+              context.closeDialog();
               await openBugReport(context);
             },
           ),

--- a/app/lib/features/search/widgets/quick_jump.dart
+++ b/app/lib/features/search/widgets/quick_jump.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/icons/tasks_icon.dart';
 import 'package:acter/features/public_room_search/widgets/maybe_direct_room_action_widget.dart';
 import 'package:acter/features/search/model/keys.dart';
@@ -10,7 +11,6 @@ import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 
 class QuickJump extends ConsumerStatefulWidget {
   final bool expand;
@@ -146,8 +146,7 @@ class _QuickJumpState extends ConsumerState<QuickJump> {
   }
 
   void routeTo(Routes route) {
-    if (context.canPop()) context.pop();
-    context.pushNamed(route.name);
+    context.closeDialog(ignorePopFailure: true).pushNamed(route.name);
   }
 
   @override

--- a/app/lib/features/search/widgets/spaces_builder.dart
+++ b/app/lib/features/search/widgets/spaces_builder.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/search/providers/search.dart';
 import 'package:acter/features/search/providers/spaces.dart';
 import 'package:acter/router/utils.dart';
@@ -78,7 +79,7 @@ class SpacesBuilder extends ConsumerWidget {
                     ),
                   ),
                   onTap: () {
-                    if (context.canPop()) context.pop();
+                    context.closeDialog(ignorePopFailure: true);
                     goToSpace(context, e.navigationTargetId);
                   },
                 ),

--- a/app/lib/features/settings/pages/backup_page.dart
+++ b/app/lib/features/settings/pages/backup_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/backups/widgets/backup_state_widget.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
@@ -14,8 +15,7 @@ class BackupPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
-          elevation: 0.0,
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(L10n.of(context).encryptionBackupKeyBackup),
           centerTitle: true,
         ),

--- a/app/lib/features/settings/pages/backup_page.dart
+++ b/app/lib/features/settings/pages/backup_page.dart
@@ -15,7 +15,7 @@ class BackupPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(L10n.of(context).encryptionBackupKeyBackup),
           centerTitle: true,
         ),

--- a/app/lib/features/settings/pages/blocked_users.dart
+++ b/app/lib/features/settings/pages/blocked_users.dart
@@ -74,7 +74,7 @@ class BlockedUsersPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(L10n.of(context).blockedUsers),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/blocked_users.dart
+++ b/app/lib/features/settings/pages/blocked_users.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
@@ -73,8 +74,7 @@ class BlockedUsersPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
-          elevation: 0.0,
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(L10n.of(context).blockedUsers),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/change_password.dart
+++ b/app/lib/features/settings/pages/change_password.dart
@@ -42,7 +42,7 @@ class _ChangePasswordPageState extends ConsumerState<ChangePasswordPage> {
 
   AppBar _buildAppbar() {
     return AppBar(
-      automaticallyImplyLeading: !isLargeScreen(context),
+      automaticallyImplyLeading: !context.isLargeScreen,
       title: Text(L10n.of(context).changePassword),
       centerTitle: true,
     );

--- a/app/lib/features/settings/pages/change_password.dart
+++ b/app/lib/features/settings/pages/change_password.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
@@ -41,8 +42,7 @@ class _ChangePasswordPageState extends ConsumerState<ChangePasswordPage> {
 
   AppBar _buildAppbar() {
     return AppBar(
-      backgroundColor: const AppBarTheme().backgroundColor,
-      elevation: 0.0,
+      automaticallyImplyLeading: !isLargeScreen(context),
       title: Text(L10n.of(context).changePassword),
       centerTitle: true,
     );

--- a/app/lib/features/settings/pages/chat_settings_page.dart
+++ b/app/lib/features/settings/pages/chat_settings_page.dart
@@ -124,7 +124,7 @@ class ChatSettingsPage extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(
           title: Text(L10n.of(context).chat),
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
         ),
         body: SettingsList(
           sections: [

--- a/app/lib/features/settings/pages/chat_settings_page.dart
+++ b/app/lib/features/settings/pages/chat_settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/app_settings_provider.dart';
@@ -121,7 +122,10 @@ class ChatSettingsPage extends ConsumerWidget {
     return WithSidebar(
       sidebar: const SettingsPage(),
       child: Scaffold(
-        appBar: AppBar(title: Text(L10n.of(context).chat)),
+        appBar: AppBar(
+          title: Text(L10n.of(context).chat),
+          automaticallyImplyLeading: !isLargeScreen(context),
+        ),
         body: SettingsList(
           sections: [
             SettingsSection(

--- a/app/lib/features/settings/pages/email_addresses.dart
+++ b/app/lib/features/settings/pages/email_addresses.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/widgets/email_address_card.dart';
@@ -79,8 +80,7 @@ class EmailAddressesPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
-          elevation: 0.0,
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(L10n.of(context).emailAddresses),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/email_addresses.dart
+++ b/app/lib/features/settings/pages/email_addresses.dart
@@ -80,7 +80,7 @@ class EmailAddressesPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(L10n.of(context).emailAddresses),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -6,6 +6,7 @@ import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/main.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/bug_report/const.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -48,6 +49,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(
             '${L10n.of(context).acterApp} ${L10n.of(context).info}',
             style: Theme.of(context).textTheme.titleLarge,

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -49,7 +49,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(
             '${L10n.of(context).acterApp} ${L10n.of(context).info}',
             style: Theme.of(context).textTheme.titleLarge,

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -21,7 +21,7 @@ class SettingsLabsPage extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(
           title: Text(L10n.of(context).labs),
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
         ),
         body: SettingsList(
           sections: [

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -19,7 +19,10 @@ class SettingsLabsPage extends ConsumerWidget {
     return WithSidebar(
       sidebar: const SettingsPage(),
       child: Scaffold(
-        appBar: AppBar(title: Text(L10n.of(context).labs)),
+        appBar: AppBar(
+          title: Text(L10n.of(context).labs),
+          automaticallyImplyLeading: !isLargeScreen(context),
+        ),
         body: SettingsList(
           sections: [
             SettingsSection(

--- a/app/lib/features/settings/pages/language_select_page.dart
+++ b/app/lib/features/settings/pages/language_select_page.dart
@@ -24,7 +24,7 @@ class LanguageSelectPage extends ConsumerWidget {
 
   AppBar _buildAppbar(BuildContext context) {
     return AppBar(
-      automaticallyImplyLeading: !isLargeScreen(context),
+      automaticallyImplyLeading: !context.isLargeScreen,
       title: Text(L10n.of(context).selectLanguage),
       centerTitle: true,
     );

--- a/app/lib/features/settings/pages/language_select_page.dart
+++ b/app/lib/features/settings/pages/language_select_page.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/utils/language.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/model/language_model.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
@@ -23,8 +24,7 @@ class LanguageSelectPage extends ConsumerWidget {
 
   AppBar _buildAppbar(BuildContext context) {
     return AppBar(
-      backgroundColor: const AppBarTheme().backgroundColor,
-      elevation: 0.0,
+      automaticallyImplyLeading: !isLargeScreen(context),
       title: Text(L10n.of(context).selectLanguage),
       centerTitle: true,
     );

--- a/app/lib/features/settings/pages/notifications_page.dart
+++ b/app/lib/features/settings/pages/notifications_page.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/notifications/notifications.dart';
 import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
 
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/room/widgets/notifications_settings_tile.dart';
@@ -83,8 +84,7 @@ class NotificationsSettingsPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
-          elevation: 0.0,
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(L10n.of(context).notifications),
         ),
         body: SettingsList(

--- a/app/lib/features/settings/pages/notifications_page.dart
+++ b/app/lib/features/settings/pages/notifications_page.dart
@@ -84,7 +84,7 @@ class NotificationsSettingsPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(L10n.of(context).notifications),
         ),
         body: SettingsList(

--- a/app/lib/features/settings/pages/sessions_page.dart
+++ b/app/lib/features/settings/pages/sessions_page.dart
@@ -19,7 +19,7 @@ class SessionsPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
           title: Text(L10n.of(context).sessions),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/sessions_page.dart
+++ b/app/lib/features/settings/pages/sessions_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/session_providers.dart';
@@ -18,8 +19,7 @@ class SessionsPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
-          elevation: 0.0,
+          automaticallyImplyLeading: !isLargeScreen(context),
           title: Text(L10n.of(context).sessions),
           centerTitle: true,
           actions: [

--- a/app/lib/features/settings/pages/settings_page.dart
+++ b/app/lib/features/settings/pages/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
@@ -9,7 +10,8 @@ import 'package:go_router/go_router.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class SettingsPage extends ConsumerWidget {
-  const SettingsPage({super.key});
+  final bool isFullPage;
+  const SettingsPage({this.isFullPage = false, super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -23,7 +25,7 @@ class SettingsPage extends ConsumerWidget {
 
   AppBar _buildAppbar(BuildContext context) {
     return AppBar(
-      backgroundColor: Colors.transparent,
+      automaticallyImplyLeading: !isLargeScreen(context),
       title: Text(L10n.of(context).settings),
     );
   }
@@ -33,7 +35,7 @@ class SettingsPage extends ConsumerWidget {
       child: Column(
         children: [
           _userProfileUI(context, ref),
-          const SettingsMenu(),
+          SettingsMenu(isFullPage: isFullPage),
         ],
       ),
     );
@@ -42,8 +44,7 @@ class SettingsPage extends ConsumerWidget {
   Widget _userProfileUI(BuildContext context, WidgetRef ref) {
     final account = ref.watch(accountProvider);
     final accountInfo = ref.watch(accountAvatarInfoProvider);
-    final size = MediaQuery.of(context).size;
-    final shouldGoNotNamed = size.width > 770;
+    final shouldGoReplacement = isLargeScreen(context);
     final userId = account.userId().toString();
     return Card(
       shape: RoundedRectangleBorder(
@@ -52,8 +53,8 @@ class SettingsPage extends ConsumerWidget {
       child: Column(
         children: [
           ListTile(
-            onTap: () => shouldGoNotNamed
-                ? context.goNamed(Routes.myProfile.name)
+            onTap: () => shouldGoReplacement
+                ? context.pushReplacementNamed(Routes.myProfile.name)
                 : context.pushNamed(Routes.myProfile.name),
             leading: ActerAvatar(
               options: AvatarOptions.DM(accountInfo),

--- a/app/lib/features/settings/pages/settings_page.dart
+++ b/app/lib/features/settings/pages/settings_page.dart
@@ -25,7 +25,7 @@ class SettingsPage extends ConsumerWidget {
 
   AppBar _buildAppbar(BuildContext context) {
     return AppBar(
-      automaticallyImplyLeading: !isLargeScreen(context),
+      automaticallyImplyLeading: !context.isLargeScreen,
       title: Text(L10n.of(context).settings),
     );
   }
@@ -44,7 +44,7 @@ class SettingsPage extends ConsumerWidget {
   Widget _userProfileUI(BuildContext context, WidgetRef ref) {
     final account = ref.watch(accountProvider);
     final accountInfo = ref.watch(accountAvatarInfoProvider);
-    final shouldGoReplacement = isLargeScreen(context);
+    final shouldGoReplacement = context.isLargeScreen;
     final userId = account.userId().toString();
     return Card(
       shape: RoundedRectangleBorder(

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -185,7 +185,7 @@ class SettingsMenu extends ConsumerWidget {
               onTap: isSuperInviteEnable
                   ? () => replacementRouting
                       ? context.pushReplacementNamed(
-                          Routes.settingsSuperInvites.name)
+                          Routes.settingsSuperInvites.name,)
                       : context.pushNamed(Routes.settingsSuperInvites.name)
                   : null,
             ),

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -43,7 +43,7 @@ class SettingsMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final replacementRouting = !isFullPage && isLargeScreen(context);
+    final replacementRouting = !isFullPage && context.isLargeScreen;
 
     final isSuperInviteEnable =
         ref.watch(hasSuperTokensAccess).valueOrNull == true;
@@ -185,7 +185,8 @@ class SettingsMenu extends ConsumerWidget {
               onTap: isSuperInviteEnable
                   ? () => replacementRouting
                       ? context.pushReplacementNamed(
-                          Routes.settingsSuperInvites.name,)
+                          Routes.settingsSuperInvites.name,
+                        )
                       : context.pushNamed(Routes.settingsSuperInvites.name)
                   : null,
             ),

--- a/app/lib/features/settings/widgets/settings_menu.dart
+++ b/app/lib/features/settings/widgets/settings_menu.dart
@@ -21,8 +21,12 @@ class SettingsMenu extends ConsumerWidget {
   static Key emailAddresses = const Key('settings-email-addresses');
   static Key chat = const Key('settings-chat');
   static Key labs = const Key('settings-labs');
+  final bool isFullPage;
 
-  const SettingsMenu({super.key = defaultSettingsMenuKey});
+  const SettingsMenu({
+    this.isFullPage = false,
+    super.key = defaultSettingsMenuKey,
+  });
 
   Color? routedColor(
     BuildContext context,
@@ -39,9 +43,7 @@ class SettingsMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final size = MediaQuery.of(context).size;
-
-    final shouldGoNotNamed = size.width > 770;
+    final replacementRouting = !isFullPage && isLargeScreen(context);
 
     final isSuperInviteEnable =
         ref.watch(hasSuperTokensAccess).valueOrNull == true;
@@ -65,8 +67,9 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.settingNotifications,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.settingNotifications.name)
+              onTap: () => replacementRouting
+                  ? context
+                      .pushReplacementNamed(Routes.settingNotifications.name)
                   : context.pushNamed(Routes.settingNotifications.name),
             ),
             MenuItemWidget(
@@ -82,8 +85,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.emailAddresses,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.emailAddresses.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.emailAddresses.name)
                   : context.pushNamed(Routes.emailAddresses.name),
             ),
           ],
@@ -104,8 +107,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.settingSessions,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.settingSessions.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.settingSessions.name)
                   : context.pushNamed(Routes.settingSessions.name),
             ),
             if (ref
@@ -123,8 +126,8 @@ class SettingsMenu extends ConsumerWidget {
                     Routes.settingBackup,
                   ),
                 ),
-                onTap: () => shouldGoNotNamed
-                    ? context.goNamed(Routes.settingBackup.name)
+                onTap: () => replacementRouting
+                    ? context.pushReplacementNamed(Routes.settingBackup.name)
                     : context.pushNamed(Routes.settingBackup.name),
               ),
             MenuItemWidget(
@@ -139,8 +142,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.blockedUsers,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.blockedUsers.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.blockedUsers.name)
                   : context.pushNamed(Routes.blockedUsers.name),
             ),
             MenuItemWidget(
@@ -155,8 +158,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.changePassword,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.changePassword.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.changePassword.name)
                   : context.pushNamed(Routes.changePassword.name),
             ),
           ],
@@ -180,8 +183,9 @@ class SettingsMenu extends ConsumerWidget {
                 ),
               ),
               onTap: isSuperInviteEnable
-                  ? () => shouldGoNotNamed
-                      ? context.goNamed(Routes.settingsSuperInvites.name)
+                  ? () => replacementRouting
+                      ? context.pushReplacementNamed(
+                          Routes.settingsSuperInvites.name)
                       : context.pushNamed(Routes.settingsSuperInvites.name)
                   : null,
             ),
@@ -204,8 +208,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.settingsChat,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.settingsChat.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.settingsChat.name)
                   : context.pushNamed(Routes.settingsChat.name),
             ),
             MenuItemWidget(
@@ -220,8 +224,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.settingLanguage,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.settingLanguage.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.settingLanguage.name)
                   : context.pushNamed(Routes.settingLanguage.name),
             ),
             MenuItemWidget(
@@ -237,8 +241,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.settingsLabs,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.settingsLabs.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.settingsLabs.name)
                   : context.pushNamed(Routes.settingsLabs.name),
             ),
             MenuItemWidget(
@@ -252,8 +256,8 @@ class SettingsMenu extends ConsumerWidget {
                   Routes.info,
                 ),
               ),
-              onTap: () => shouldGoNotNamed
-                  ? context.goNamed(Routes.info.name)
+              onTap: () => replacementRouting
+                  ? context.pushReplacementNamed(Routes.info.name)
                   : context.pushNamed(Routes.info.name),
             ),
           ],

--- a/app/lib/features/space/actions/set_space_title.dart
+++ b/app/lib/features/space/actions/set_space_title.dart
@@ -1,11 +1,11 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::space::set_space_title');
@@ -29,7 +29,7 @@ void showEditSpaceNameBottomSheet({
         await space.setName(newName);
         EasyLoading.dismiss();
         if (!context.mounted) return;
-        context.pop();
+        context.closeDialog();
       } catch (e, st) {
         _log.severe('Failed to edit space name', e, st);
         EasyLoading.dismiss();

--- a/app/lib/features/space/actions/set_space_topic.dart
+++ b/app/lib/features/space/actions/set_space_topic.dart
@@ -1,10 +1,10 @@
 import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_plain_description_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 void showEditDescriptionBottomSheet({
   required BuildContext context,
@@ -22,7 +22,7 @@ void showEditDescriptionBottomSheet({
         await space.setTopic(newDescription);
         EasyLoading.dismiss();
         if (!context.mounted) return;
-        context.pop();
+        context.closeDialog();
       } catch (e) {
         EasyLoading.dismiss();
         if (!context.mounted) return;

--- a/app/lib/features/space/settings/pages/apps_settings_page.dart
+++ b/app/lib/features/space/settings/pages/apps_settings_page.dart
@@ -274,7 +274,7 @@ class SpaceAppsSettingsPage extends ConsumerWidget {
           return Scaffold(
             appBar: AppBar(
               title: const Text('Apps Settings'),
-              automaticallyImplyLeading: !isLargeScreen(context),
+              automaticallyImplyLeading: !context.isLargeScreen,
             ),
             body: SettingsList(
               sections: [

--- a/app/lib/features/space/settings/pages/apps_settings_page.dart
+++ b/app/lib/features/space/settings/pages/apps_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/space/settings/widgets/space_settings_menu.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -271,7 +272,10 @@ class SpaceAppsSettingsPage extends ConsumerWidget {
           }
 
           return Scaffold(
-            appBar: AppBar(title: const Text('Apps Settings')),
+            appBar: AppBar(
+              title: const Text('Apps Settings'),
+              automaticallyImplyLeading: !isLargeScreen(context),
+            ),
             body: SettingsList(
               sections: [
                 SettingsSection(

--- a/app/lib/features/space/settings/pages/index_page.dart
+++ b/app/lib/features/space/settings/pages/index_page.dart
@@ -9,6 +9,7 @@ class SpaceSettingsMenuIndexPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return SpaceSettingsMenu(
       spaceId: spaceId,
+      isFullPage: true,
     );
   }
 }

--- a/app/lib/features/space/settings/pages/notification_configuration_page.dart
+++ b/app/lib/features/space/settings/pages/notification_configuration_page.dart
@@ -21,7 +21,7 @@ class SpaceNotificationConfigurationPage extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(
           title: Text(L10n.of(context).spaceNotifications),
-          automaticallyImplyLeading: !isLargeScreen(context),
+          automaticallyImplyLeading: !context.isLargeScreen,
         ),
         body: SettingsList(
           sections: [

--- a/app/lib/features/space/settings/pages/notification_configuration_page.dart
+++ b/app/lib/features/space/settings/pages/notification_configuration_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/room/widgets/notifications_settings_tile.dart';
 import 'package:acter/features/space/settings/widgets/space_settings_menu.dart';
@@ -18,7 +19,10 @@ class SpaceNotificationConfigurationPage extends ConsumerWidget {
         spaceId: spaceId,
       ),
       child: Scaffold(
-        appBar: AppBar(title: Text(L10n.of(context).spaceNotifications)),
+        appBar: AppBar(
+          title: Text(L10n.of(context).spaceNotifications),
+          automaticallyImplyLeading: !isLargeScreen(context),
+        ),
         body: SettingsList(
           sections: [
             SettingsSection(

--- a/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
+++ b/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
@@ -5,8 +5,6 @@ import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/spaces/has_space_permission.dart';
 import 'package:acter/common/widgets/visibility/room_visibilty_type.dart';
 import 'package:acter/common/widgets/spaces/space_selector_drawer.dart';
-import 'package:acter/common/widgets/with_sidebar.dart';
-import 'package:acter/features/space/settings/widgets/space_settings_menu.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
@@ -21,12 +19,12 @@ final _log = Logger('a3::space::settings::visibility_accessibility_settings');
 
 class VisibilityAccessibilityPage extends ConsumerStatefulWidget {
   final String roomId;
-  final bool showCloseX;
+  final bool impliedClose;
 
   const VisibilityAccessibilityPage({
     super.key,
     required this.roomId,
-    this.showCloseX = false,
+    this.impliedClose = false,
   });
 
   @override
@@ -38,14 +36,9 @@ class _VisibilityAccessibilityPageState
     extends ConsumerState<VisibilityAccessibilityPage> {
   @override
   Widget build(BuildContext context) {
-    return WithSidebar(
-      sidebar: SpaceSettingsMenu(
-        spaceId: widget.roomId,
-      ),
-      child: Scaffold(
-        appBar: _buildAppbar(),
-        body: _buildBody(),
-      ),
+    return Scaffold(
+      appBar: _buildAppbar(),
+      body: _buildBody(),
     );
   }
 
@@ -54,6 +47,12 @@ class _VisibilityAccessibilityPageState
       title: Text(L10n.of(context).visibilityAndAccessibility),
       centerTitle: true,
       automaticallyImplyLeading: !isLargeScreen(context),
+      leading: widget.impliedClose
+          ? IconButton(
+              onPressed: () => context.pop(),
+              icon: const Icon(Atlas.xmark_circle_thin),
+            )
+          : null,
     );
   }
 

--- a/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
+++ b/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
@@ -5,6 +5,8 @@ import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/spaces/has_space_permission.dart';
 import 'package:acter/common/widgets/visibility/room_visibilty_type.dart';
 import 'package:acter/common/widgets/spaces/space_selector_drawer.dart';
+import 'package:acter/common/widgets/with_sidebar.dart';
+import 'package:acter/features/space/settings/widgets/space_settings_menu.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
@@ -36,9 +38,14 @@ class _VisibilityAccessibilityPageState
     extends ConsumerState<VisibilityAccessibilityPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: _buildAppbar(),
-      body: _buildBody(),
+    return WithSidebar(
+      sidebar: SpaceSettingsMenu(
+        spaceId: widget.roomId,
+      ),
+      child: Scaffold(
+        appBar: _buildAppbar(),
+        body: _buildBody(),
+      ),
     );
   }
 
@@ -46,13 +53,7 @@ class _VisibilityAccessibilityPageState
     return AppBar(
       title: Text(L10n.of(context).visibilityAndAccessibility),
       centerTitle: true,
-      // custom x-circle when we are in widescreen mode;
-      leading: widget.showCloseX
-          ? IconButton(
-              onPressed: () => context.pop(),
-              icon: const Icon(Atlas.xmark_circle_thin),
-            )
-          : null,
+      automaticallyImplyLeading: !isLargeScreen(context),
     );
   }
 

--- a/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
+++ b/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
@@ -46,7 +46,7 @@ class _VisibilityAccessibilityPageState
     return AppBar(
       title: Text(L10n.of(context).visibilityAndAccessibility),
       centerTitle: true,
-      automaticallyImplyLeading: !isLargeScreen(context),
+      automaticallyImplyLeading: !context.isLargeScreen,
       leading: widget.impliedClose
           ? IconButton(
               onPressed: () => context.pop(),

--- a/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
+++ b/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
@@ -11,7 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -49,7 +48,7 @@ class _VisibilityAccessibilityPageState
       automaticallyImplyLeading: !context.isLargeScreen,
       leading: widget.impliedClose
           ? IconButton(
-              onPressed: () => context.pop(),
+              onPressed: () => context.closeDialog(),
               icon: const Icon(Atlas.xmark_circle_thin),
             )
           : null,

--- a/app/lib/features/space/settings/widgets/space_settings_menu.dart
+++ b/app/lib/features/space/settings/widgets/space_settings_menu.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,16 +14,17 @@ const defaultSpaceSettingsMenuKey = Key('space-settings-menu');
 
 class SpaceSettingsMenu extends ConsumerWidget {
   static const appsMenu = Key('space-settings-apps');
+  final bool isFullPage;
   final String spaceId;
 
   const SpaceSettingsMenu({
     required this.spaceId,
+    this.isFullPage = false,
     super.key = defaultSpaceSettingsMenuKey,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final size = MediaQuery.of(context).size;
     final spaceAvatarInfo = ref.watch(roomAvatarInfoProvider(spaceId));
     final parentBadges =
         ref.watch(parentAvatarInfosProvider(spaceId)).valueOrNull;
@@ -30,9 +32,13 @@ class SpaceSettingsMenu extends ConsumerWidget {
     final notificationStatus =
         ref.watch(roomNotificationStatusProvider(spaceId));
     final curNotifStatus = notificationStatus.valueOrNull;
+    final replaceRoute = !isFullPage && isLargeScreen(context);
+
+    final spaceName = spaceAvatarInfo.displayName ?? spaceId;
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: isFullPage,
         title: FittedBox(
           fit: BoxFit.fitWidth,
           child: Row(
@@ -49,13 +55,17 @@ class SpaceSettingsMenu extends ConsumerWidget {
                   badgesSize: 18,
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.only(left: 15),
-                child: Text(spaceAvatarInfo.displayName ?? spaceId),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: 15),
-                child: Text(L10n.of(context).settings),
+              const SizedBox(width: 10),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(L10n.of(context).settings),
+                  Text(
+                    '($spaceName)',
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                ],
               ),
             ],
           ),
@@ -79,8 +89,8 @@ class SpaceSettingsMenu extends ConsumerWidget {
                         ? const Icon(Atlas.bell_dash_bold, size: 18)
                         : const Icon(Atlas.bell_thin, size: 18),
                     onPressed: (context) {
-                      isDesktop || size.width > 770
-                          ? context.goNamed(
+                      replaceRoute
+                          ? context.pushReplacementNamed(
                               Routes.spaceSettingsNotifications.name,
                               pathParameters: {'spaceId': spaceId},
                             )
@@ -102,8 +112,8 @@ class SpaceSettingsMenu extends ConsumerWidget {
                     ),
                     leading: const Icon(Atlas.lab_appliance_thin),
                     onPressed: (context) {
-                      isDesktop || size.width > 770
-                          ? context.goNamed(
+                      replaceRoute
+                          ? context.pushReplacementNamed(
                               Routes.spaceSettingsVisibility.name,
                               pathParameters: {'spaceId': spaceId},
                             )
@@ -121,8 +131,8 @@ class SpaceSettingsMenu extends ConsumerWidget {
                     ),
                     leading: const Icon(Atlas.info_circle_thin),
                     onPressed: (context) {
-                      isDesktop || size.width > 770
-                          ? context.goNamed(
+                      replaceRoute
+                          ? context.pushReplacementNamed(
                               Routes.spaceSettingsApps.name,
                               pathParameters: {'spaceId': spaceId},
                             )

--- a/app/lib/features/space/settings/widgets/space_settings_menu.dart
+++ b/app/lib/features/space/settings/widgets/space_settings_menu.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter_avatar/acter_avatar.dart';

--- a/app/lib/features/space/settings/widgets/space_settings_menu.dart
+++ b/app/lib/features/space/settings/widgets/space_settings_menu.dart
@@ -31,7 +31,7 @@ class SpaceSettingsMenu extends ConsumerWidget {
     final notificationStatus =
         ref.watch(roomNotificationStatusProvider(spaceId));
     final curNotifStatus = notificationStatus.valueOrNull;
-    final replaceRoute = !isFullPage && isLargeScreen(context);
+    final replaceRoute = !isFullPage && context.isLargeScreen;
 
     final spaceName = spaceAvatarInfo.displayName ?? spaceId;
 

--- a/app/lib/features/spaces/pages/create_space_page.dart
+++ b/app/lib/features/spaces/pages/create_space_page.dart
@@ -298,7 +298,7 @@ class _CreateSpacePageConsumerState extends ConsumerState<CreateSpacePage> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         OutlinedButton(
-          onPressed: () => context.pop(),
+          onPressed: () => context.closeDialog(),
           child: Text(L10n.of(context).cancel),
         ),
         const SizedBox(width: 20),

--- a/app/lib/features/super_invites/pages/create.dart
+++ b/app/lib/features/super_invites/pages/create.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/chat/chat_selector_drawer.dart';
 import 'package:acter/common/widgets/checkbox_form_field.dart';
 import 'package:acter/common/widgets/input_text_field.dart';
@@ -193,9 +194,7 @@ class _CreateSuperInviteTokenPageConsumerState
                 ButtonBar(
                   children: [
                     OutlinedButton(
-                      onPressed: () => context.canPop()
-                          ? context.pop()
-                          : context.goNamed(Routes.main.name),
+                      onPressed: () => context.closeDialog(orGo: Routes.main),
                       child: Text(
                         L10n.of(context).cancel,
                       ),

--- a/app/lib/features/super_invites/pages/super_invites.dart
+++ b/app/lib/features/super_invites/pages/super_invites.dart
@@ -21,7 +21,6 @@ class SuperInvitesPage extends ConsumerWidget {
       sidebar: const SettingsPage(),
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: const AppBarTheme().backgroundColor,
           elevation: 0.0,
           title: Text(L10n.of(context).superInvites),
           centerTitle: true,

--- a/app/lib/features/tasks/pages/task_item_detail_page.dart
+++ b/app/lib/features/tasks/pages/task_item_detail_page.dart
@@ -20,7 +20,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::tasks::task_item_details_page');
@@ -277,7 +276,7 @@ class TaskItemDetailPage extends ConsumerWidget {
       updater.descriptionHtml(plainDescription, htmlBodyDescription);
       await updater.send();
       EasyLoading.dismiss();
-      if (context.mounted) context.pop();
+      if (context.mounted) context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();
@@ -483,7 +482,7 @@ class TaskItemDetailPage extends ConsumerWidget {
       ref.invalidate(taskListProvider);
       EasyLoading.dismiss();
       if (!context.mounted) return;
-      context.pop();
+      context.closeDialog();
     } catch (e) {
       EasyLoading.dismiss();
       if (!context.mounted) return;

--- a/app/lib/features/tasks/pages/task_list_details_page.dart
+++ b/app/lib/features/tasks/pages/task_list_details_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/redact_content.dart';
@@ -12,7 +13,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::tasks::task_list_details_page');
@@ -207,7 +207,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
       updater.descriptionHtml(plainDescription, htmlBodyDescription);
       await updater.send();
       EasyLoading.dismiss();
-      if (mounted) context.pop();
+      if (mounted) context.closeDialog();
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();
@@ -293,7 +293,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
           ref.invalidate(taskListProvider);
           EasyLoading.dismiss();
           if (!context.mounted) return;
-          context.pop();
+          context.closeDialog();
         } catch (e) {
           EasyLoading.dismiss();
           if (!context.mounted) return;

--- a/app/lib/features/tasks/sheets/create_update_task_item.dart
+++ b/app/lib/features/tasks/sheets/create_update_task_item.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 import 'package:acter/features/tasks/widgets/due_picker.dart';
 
 void showCreateUpdateTaskItemBottomSheet(
@@ -260,7 +259,7 @@ class _CreateUpdateItemListConsumerState
       EasyLoading.dismiss();
       if (!mounted) return;
       if (widget.cancel != null) widget.cancel!();
-      context.pop();
+      context.closeDialog();
       ref.invalidate(taskListProvider);
     } catch (e) {
       EasyLoading.dismiss();
@@ -291,7 +290,7 @@ class _CreateUpdateItemListConsumerState
       await updater.send();
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.pop();
+      context.closeDialog();
       ref.invalidate(taskListProvider);
     } catch (e) {
       EasyLoading.dismiss();

--- a/app/lib/features/tasks/sheets/create_update_task_list.dart
+++ b/app/lib/features/tasks/sheets/create_update_task_list.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:acter/common/widgets/spaces/select_space_form_field.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
@@ -8,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 void showCreateUpdateTaskListBottomSheet(
   BuildContext context, {
@@ -202,7 +202,7 @@ class _CreateUpdateTaskListConsumerState
 
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.pop();
+      context.closeDialog();
       ref.invalidate(taskListProvider);
     } catch (e) {
       if (!mounted) {

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -122,7 +122,7 @@ List<RouteBase> makeGeneralRoutes() {
       name: Routes.actionAddPin.name,
       path: Routes.actionAddPin.route,
       pageBuilder: (context, state) {
-        return isLargeScreen(context)
+        return context.isLargeScreen
             ? SideSheetPage(
                 key: state.pageKey,
                 transitionsBuilder:
@@ -280,7 +280,7 @@ List<RouteBase> makeGeneralRoutes() {
       name: Routes.createChat.name,
       path: Routes.createChat.route,
       pageBuilder: (context, state) {
-        return isLargeScreen(context)
+        return context.isLargeScreen
             ? DialogPage(
                 barrierDismissible: false,
                 builder: (context) => CreateChatPage(

--- a/app/lib/router/shell_routers/chat_shell_router.dart
+++ b/app/lib/router/shell_routers/chat_shell_router.dart
@@ -33,9 +33,8 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            centerBuilder: (inSidebar) => RoomPage(
+            centerChild: RoomPage(
               roomId: roomId,
-              inSidebar: inSidebar,
             ),
           ),
         );
@@ -51,13 +50,11 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            centerBuilder: (inSidebar) => RoomPage(
+            centerChild: RoomPage(
               roomId: roomId,
-              inSidebar: inSidebar,
             ),
-            expandedBuilder: (inSidebar) => RoomProfilePage(
+            expandedChild: RoomProfilePage(
               roomId: roomId,
-              inSidebar: inSidebar,
             ),
           ),
         );
@@ -75,13 +72,12 @@ List<RouteBase> makeChatShellRoutes(ref) {
         return NoTransitionPage(
           key: state.pageKey,
           child: ChatLayoutBuilder(
-            centerBuilder: (inSidebar) => RoomPage(
+            centerChild: RoomPage(
               roomId: roomId,
-              inSidebar: inSidebar,
             ),
-            expandedBuilder: (inSidebar) => VisibilityAccessibilityPage(
+            expandedChild: VisibilityAccessibilityPage(
               roomId: roomId,
-              showCloseX: inSidebar,
+              impliedClose: true,
             ),
           ),
         );

--- a/app/lib/router/shell_routers/home_shell_router.dart
+++ b/app/lib/router/shell_routers/home_shell_router.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/features/invite_members/pages/invite_indicidual_users.dart';
 import 'package:acter/features/invite_members/pages/invite_page.dart';
 import 'package:acter/features/events/pages/create_edit_event_page.dart';
@@ -25,6 +26,7 @@ import 'package:acter/features/settings/pages/notifications_page.dart';
 import 'package:acter/features/settings/pages/sessions_page.dart';
 import 'package:acter/features/space/pages/space_details_page.dart';
 import 'package:acter/features/space/settings/pages/visibility_accessibility_page.dart';
+import 'package:acter/features/space/settings/widgets/space_settings_menu.dart';
 import 'package:acter/features/super_invites/pages/super_invites.dart';
 import 'package:acter/features/space/pages/chats_page.dart';
 import 'package:acter/features/space/pages/events_page.dart';
@@ -358,10 +360,16 @@ List<RouteBase> makeHomeShellRoutes() {
       path: Routes.spaceSettingsVisibility.route,
       redirect: authGuardRedirect,
       pageBuilder: (context, state) {
+        final roomId = state.pathParameters['spaceId']!;
         return NoTransitionPage(
           key: state.pageKey,
-          child: VisibilityAccessibilityPage(
-            roomId: state.pathParameters['spaceId']!,
+          child: WithSidebar(
+            sidebar: SpaceSettingsMenu(
+              spaceId: roomId,
+            ),
+            child: VisibilityAccessibilityPage(
+              roomId: roomId,
+            ),
           ),
         );
       },

--- a/app/lib/router/shell_routers/home_shell_router.dart
+++ b/app/lib/router/shell_routers/home_shell_router.dart
@@ -64,7 +64,7 @@ List<RouteBase> makeHomeShellRoutes() {
       pageBuilder: (context, state) {
         return NoTransitionPage(
           key: state.pageKey,
-          child: const SettingsPage(),
+          child: const SettingsPage(isFullPage: true),
         );
       },
     ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -989,10 +989,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: cdae1b9c8bd7efadcef6112e81c903662ef2ce105cbd220a04bbb7c3425b5554
+      sha256: "39dd52168d6c59984454183148dc3a5776960c61083adfc708cc79a7b3ce1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.0"
+    version: "14.2.1"
   google_identity_services_web:
     dependency: transitive
     description:


### PR DESCRIPTION
Remove several context.go and make them use `pushReplacement` to switch between settings screens. Cleaning up a lot of `isDesktop` and using proper isLeadingImplied for AppBar to make the routing smooth across breakpoints (imagine someone rotating their iPad). Did some more code cleaning around the routing on the way, like replacing local size-checks with the `isLargeScreen` helper to unify the behavior and simplify the chat-columns-routing.

Fixed for Settings, Space Settings:

https://github.com/user-attachments/assets/1aeb7390-9328-477a-bddf-a809bf669325

Fixed for the partly weird Chat settings, too:

https://github.com/user-attachments/assets/10d3219b-9aa7-44f4-bbec-4ee4c7bd32bc


In an attempt to fix `GoError: There is nothing to pop`, this also refactors `context.pop` into a new `context.closeDialog` helper and uses that everywhere. If nothing else, it should give us a bit more context where we are when doing things wrong.


Fixes #1906 .