### PR TITLE
Additional Router Fixes

### DIFF
--- a/app/lib/common/actions/report_content.dart
+++ b/app/lib/common/actions/report_content.dart
@@ -14,8 +14,31 @@ final _log = Logger('a3::common::report');
 
 final _ignoreUserProvider = StateProvider.autoDispose<bool>((ref) => false);
 
+Future<bool> openReportContentDialog(
+  BuildContext context, {
+  required String title,
+  required String description,
+  required final String eventId,
+  required final String roomId,
+  required final String senderId,
+  final bool? isSpace,
+}) async {
+  return await showAdaptiveDialog(
+    context: context,
+    useRootNavigator: false,
+    builder: (context) => _ReportContentWidget(
+      title: title,
+      description: description,
+      eventId: eventId,
+      senderId: senderId,
+      roomId: roomId,
+      isSpace: isSpace ?? false,
+    ),
+  );
+}
+
 /// Reusable reporting acter content widget.
-class ReportContentWidget extends ConsumerWidget {
+class _ReportContentWidget extends ConsumerWidget {
   final String title;
   final String description;
   final String eventId;
@@ -23,7 +46,7 @@ class ReportContentWidget extends ConsumerWidget {
   final String roomId;
   final bool isSpace;
 
-  const ReportContentWidget({
+  const _ReportContentWidget({
     super.key,
     required this.title,
     required this.description,

--- a/app/lib/common/actions/report_content.dart
+++ b/app/lib/common/actions/report_content.dart
@@ -47,7 +47,6 @@ class _ReportContentWidget extends ConsumerWidget {
   final bool isSpace;
 
   const _ReportContentWidget({
-    super.key,
     required this.title,
     required this.description,
     required this.eventId,

--- a/app/lib/common/dialogs/attachment_confirmation.dart
+++ b/app/lib/common/dialogs/attachment_confirmation.dart
@@ -6,15 +6,15 @@ import 'package:flutter/material.dart';
 
 // reusable attachment confirmation dialog
 void attachmentConfirmationDialog(
-  BuildContext ctx,
+  BuildContext context,
   AttachmentsManager manager,
   List<AttachmentInfo>? selectedAttachments,
 ) {
-  final size = MediaQuery.of(ctx).size;
+  final size = MediaQuery.of(context).size;
   if (selectedAttachments != null && selectedAttachments.isNotEmpty) {
     showAdaptiveDialog(
-      context: ctx,
-      builder: (ctx) => Dialog(
+      context: context,
+      builder: (context) => Dialog(
         insetPadding: const EdgeInsets.all(8),
         child: ConstrainedBox(
           constraints: BoxConstraints(

--- a/app/lib/common/dialogs/attachment_selection.dart
+++ b/app/lib/common/dialogs/attachment_selection.dart
@@ -47,7 +47,7 @@ void _onTapCameraSelection(
     File file = File(imageFile.path);
 
     if (context.mounted) {
-      Navigator.of(context).pop();
+      Navigator.pop(context);
       attachmentConfirmationDialog(
         context,
         manager,
@@ -68,7 +68,7 @@ void _onTapVideoSelection(
     newAttachments.add((type: AttachmentType.video, file: file));
   }
   if (context.mounted) {
-    Navigator.of(context).pop();
+    Navigator.pop(context);
     attachmentConfirmationDialog(
       context,
       manager,
@@ -90,7 +90,7 @@ void _onTapImageSelection(
   }
 
   if (context.mounted) {
-    Navigator.of(context).pop();
+    Navigator.pop(context);
     attachmentConfirmationDialog(
       context,
       manager,
@@ -117,7 +117,7 @@ void _onTapFileSelection(
     }).toList();
 
     if (context.mounted) {
-      Navigator.of(context).pop();
+      Navigator.pop(context);
       attachmentConfirmationDialog(
         context,
         manager,

--- a/app/lib/common/dialogs/deactivation_confirmation.dart
+++ b/app/lib/common/dialogs/deactivation_confirmation.dart
@@ -19,7 +19,7 @@ void deactivationConfirmationDialog(BuildContext context, WidgetRef ref) {
   final theme = Theme.of(context).colorScheme;
   showDialog(
     context: context,
-    builder: (BuildContext ctx) {
+    builder: (BuildContext context) {
       return AlertDialog(
         backgroundColor: Theme.of(context).colorScheme.surface,
         title: Text(
@@ -83,7 +83,7 @@ void deactivationConfirmationDialog(BuildContext context, WidgetRef ref) {
         actions: <Widget>[
           OutlinedButton(
             key: deactivateCancelBtn,
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).cancel),
           ),
           ActerDangerActionButton(

--- a/app/lib/common/dialogs/logout_confirmation.dart
+++ b/app/lib/common/dialogs/logout_confirmation.dart
@@ -12,7 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 void logoutConfirmationDialog(BuildContext context, WidgetRef ref) {
   showDialog(
     context: context,
-    builder: (BuildContext ctx) {
+    builder: (BuildContext context) {
       return AlertDialog(
         backgroundColor: Theme.of(context).colorScheme.surface,
         title: Column(
@@ -46,7 +46,7 @@ void logoutConfirmationDialog(BuildContext context, WidgetRef ref) {
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(
               L10n.of(context).no,
               key: LogoutDialogKeys.cancel,
@@ -54,7 +54,7 @@ void logoutConfirmationDialog(BuildContext context, WidgetRef ref) {
           ),
           ActerDangerActionButton(
             onPressed: () async {
-              await ref.read(authStateProvider.notifier).logout(ctx);
+              await ref.read(authStateProvider.notifier).logout(context);
             },
             child: Text(
               L10n.of(context).yes,

--- a/app/lib/common/dialogs/nuke_confirmation.dart
+++ b/app/lib/common/dialogs/nuke_confirmation.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
+import 'package:acter/common/utils/routes.dart';
 
 import 'package:acter/features/auth/providers/auth_providers.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -11,7 +12,7 @@ import 'package:go_router/go_router.dart';
 void nukeConfirmationDialog(BuildContext context, WidgetRef ref) {
   showAdaptiveDialog(
     context: context,
-    builder: (BuildContext ctx) {
+    builder: (BuildContext context) {
       return AlertDialog(
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -43,14 +44,18 @@ void nukeConfirmationDialog(BuildContext context, WidgetRef ref) {
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => ctx.pop(),
+            onPressed: () => Navigator.pop(context),
             child: const Text(
               'No',
             ),
           ),
           ActerDangerActionButton(
             onPressed: () async {
-              await ref.read(authStateProvider.notifier).nuke(ctx);
+              await ref.read(authStateProvider.notifier).nuke();
+
+              if (context.mounted) {
+                context.goNamed(Routes.main.name);
+              }
             },
             child: const Text(
               'Yihaaaa',

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -17,7 +17,6 @@ import 'package:intl/intl.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 final _log = Logger('a3::common::util');
@@ -74,24 +73,6 @@ const largeScreenBreakPoint = 770;
 extension ActerContextUtils on BuildContext {
   bool get isLargeScreen =>
       MediaQuery.of(this).size.width >= largeScreenBreakPoint;
-
-  NavigatorState closeDialog({Routes? orGo, bool ignorePopFailure = false}) {
-    final navigator = Navigator.of(this);
-    try {
-      if (orGo != null && !navigator.canPop()) {
-        navigator.pushReplacementNamed(orGo.name);
-      } else {
-        navigator.pop();
-      }
-    } catch (error, stackTrace) {
-      if (!ignorePopFailure) {
-        // track if we failed to pop so we can fix that.
-        _log.severe('Routing failed', error, stackTrace);
-        Sentry.captureException(error, stackTrace: stackTrace);
-      }
-    }
-    return navigator;
-  }
 }
 
 DateTime kFirstDay = DateTime.utc(2010, 10, 16);

--- a/app/lib/common/widgets/chat/edit_room_description_sheet.dart
+++ b/app/lib/common/widgets/chat/edit_room_description_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -76,7 +75,7 @@ class _EditRoomDescriptionSheetState
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 OutlinedButton(
-                  onPressed: () => context.closeDialog(),
+                  onPressed: () => Navigator.pop(context),
                   child: Text(L10n.of(context).cancel),
                 ),
                 const SizedBox(width: 20),
@@ -95,7 +94,7 @@ class _EditRoomDescriptionSheetState
   Future<void> _editDescription(BuildContext context, WidgetRef ref) async {
     final newDesc = _descriptionController.text.trim();
     if (newDesc == widget.description.trim()) {
-      context.closeDialog();
+      Navigator.pop(context);
       return; // no changes to submit
     }
 
@@ -105,7 +104,7 @@ class _EditRoomDescriptionSheetState
       await convo.setTopic(_descriptionController.text.trim());
       EasyLoading.dismiss();
       if (!context.mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to edit chat description', e, st);
       if (!context.mounted) {

--- a/app/lib/common/widgets/default_bottom_sheet.dart
+++ b/app/lib/common/widgets/default_bottom_sheet.dart
@@ -34,7 +34,7 @@ class DefaultBottomSheet extends ConsumerWidget {
         : GestureDetector(
             onTap: () {
               // Close the bottom sheet when tapping outside of it.
-              Navigator.of(context).pop();
+              Navigator.pop(context);
             },
             child: Container(
               height: sheetHeight,

--- a/app/lib/common/widgets/dialog_page.dart
+++ b/app/lib/common/widgets/dialog_page.dart
@@ -30,10 +30,10 @@ class DialogPage<T> extends Page<T> {
     return DialogRoute<T>(
       context: context,
       settings: this,
-      builder: (BuildContext ctx) {
+      builder: (BuildContext context) {
         Widget dialogChild = IntrinsicWidth(
           stepWidth: 56,
-          child: builder(ctx),
+          child: builder(context),
         );
         if (label != null) {
           dialogChild = Semantics(

--- a/app/lib/common/widgets/edit_html_description_sheet.dart
+++ b/app/lib/common/widgets/edit_html_description_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
@@ -93,7 +92,7 @@ class _EditHtmlDescriptionSheetState
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.closeDialog(),
+                onPressed: () => Navigator.pop(context),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -104,7 +103,7 @@ class _EditHtmlDescriptionSheetState
                   final plainDescription = textEditorState.intoMarkdown();
                   if (htmlBodyDescription == widget.descriptionHtmlValue ||
                       plainDescription == widget.descriptionMarkdownValue) {
-                    context.closeDialog();
+                    Navigator.pop(context);
                     return;
                   }
                   widget.onSave(htmlBodyDescription, plainDescription);

--- a/app/lib/common/widgets/edit_link_sheet.dart
+++ b/app/lib/common/widgets/edit_link_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -81,7 +80,7 @@ class _EditTitleSheetState extends ConsumerState<EditLinkSheet> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.closeDialog(),
+                onPressed: () => Navigator.pop(context),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -89,7 +88,7 @@ class _EditTitleSheetState extends ConsumerState<EditLinkSheet> {
                 onPressed: () {
                   // no changes to submit
                   if (_linkController.text.trim() == widget.linkValue.trim()) {
-                    context.closeDialog();
+                    Navigator.pop(context);
                     return;
                   }
 

--- a/app/lib/common/widgets/edit_plain_description_sheet.dart
+++ b/app/lib/common/widgets/edit_plain_description_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -71,7 +70,7 @@ class _EditPlainDescriptionSheetState extends State<EditPlainDescriptionSheet> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 OutlinedButton(
-                  onPressed: () => context.closeDialog(),
+                  onPressed: () => Navigator.pop(context),
                   child: Text(L10n.of(context).cancel),
                 ),
                 const SizedBox(width: 20),
@@ -80,7 +79,7 @@ class _EditPlainDescriptionSheetState extends State<EditPlainDescriptionSheet> {
                     final newDescription = _descriptionController.text.trim();
                     // No need to change
                     if (newDescription == widget.descriptionValue.trim()) {
-                      context.closeDialog();
+                      Navigator.pop(context);
                       return;
                     }
 

--- a/app/lib/common/widgets/edit_title_sheet.dart
+++ b/app/lib/common/widgets/edit_title_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -79,7 +78,7 @@ class _EditTitleSheetState extends ConsumerState<EditTitleSheet> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               OutlinedButton(
-                onPressed: () => context.closeDialog(),
+                onPressed: () => Navigator.pop(context),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 20),
@@ -88,7 +87,7 @@ class _EditTitleSheetState extends ConsumerState<EditTitleSheet> {
                   // no changes to submit
                   if (_titleController.text.trim() ==
                       widget.titleValue.trim()) {
-                    context.closeDialog();
+                    Navigator.pop(context);
                     return;
                   }
 

--- a/app/lib/common/widgets/redact_content.dart
+++ b/app/lib/common/widgets/redact_content.dart
@@ -10,7 +10,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::common::redact');
@@ -75,7 +74,7 @@ class RedactContentWidget extends ConsumerWidget {
       actions: <Widget>[
         OutlinedButton(
           key: cancelBtnKey,
-          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).close),
         ),
         ActerPrimaryActionButton(
@@ -88,8 +87,8 @@ class RedactContentWidget extends ConsumerWidget {
     );
   }
 
-  void redactContent(BuildContext ctx, WidgetRef ref, String reason) async {
-    EasyLoading.show(status: L10n.of(ctx).removingContent);
+  void redactContent(BuildContext context, WidgetRef ref, String reason) async {
+    EasyLoading.show(status: L10n.of(context).removingContent);
     try {
       if (isSpace) {
         final space = await ref.read(spaceProvider(roomId).future);
@@ -107,22 +106,22 @@ class RedactContentWidget extends ConsumerWidget {
         );
       }
 
-      if (!ctx.mounted) {
+      if (!context.mounted) {
         EasyLoading.dismiss();
         return;
       }
-      EasyLoading.showToast(L10n.of(ctx).contentSuccessfullyRemoved);
-      if (ctx.canPop()) ctx.pop();
+      EasyLoading.showToast(L10n.of(context).contentSuccessfullyRemoved);
+      Navigator.pop(context);
       if (onSuccess != null) {
         onSuccess!();
       }
     } catch (e) {
-      if (!ctx.mounted) {
+      if (!context.mounted) {
         EasyLoading.dismiss();
         return;
       }
       EasyLoading.showError(
-        '${L10n.of(ctx).redactionFailed} $e',
+        '${L10n.of(context).redactionFailed} $e',
         duration: const Duration(seconds: 3),
       );
     }

--- a/app/lib/common/widgets/report_content.dart
+++ b/app/lib/common/widgets/report_content.dart
@@ -90,7 +90,7 @@ class ReportContentWidget extends ConsumerWidget {
       ),
       actions: <Widget>[
         OutlinedButton(
-          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).close),
         ),
         ActerPrimaryActionButton(
@@ -101,10 +101,10 @@ class ReportContentWidget extends ConsumerWidget {
     );
   }
 
-  void reportContent(BuildContext ctx, WidgetRef ref, String reason) async {
+  void reportContent(BuildContext context, WidgetRef ref, String reason) async {
     bool res = false;
     final ignoreFlag = ref.read(_ignoreUserProvider);
-    EasyLoading.show(status: L10n.of(ctx).sendingReport);
+    EasyLoading.show(status: L10n.of(context).sendingReport);
     try {
       if (isSpace) {
         final space = await ref.read(spaceProvider(roomId).future);
@@ -126,26 +126,26 @@ class ReportContentWidget extends ConsumerWidget {
         }
       }
 
-      if (!ctx.mounted) {
+      if (!context.mounted) {
         EasyLoading.dismiss();
         return;
       }
       if (res) {
-        EasyLoading.showToast(L10n.of(ctx).reportSent);
-        Navigator.of(ctx, rootNavigator: true).pop();
+        EasyLoading.showToast(L10n.of(context).reportSent);
+        Navigator.pop(context);
       } else {
         EasyLoading.showError(
-          L10n.of(ctx).reportSendingFailed,
+          L10n.of(context).reportSendingFailed,
           duration: const Duration(seconds: 3),
         );
       }
     } catch (e) {
-      if (!ctx.mounted) {
+      if (!context.mounted) {
         EasyLoading.dismiss();
         return;
       }
       EasyLoading.showError(
-        L10n.of(ctx).reportSendingFailedDueTo(e),
+        L10n.of(context).reportSendingFailedDueTo(e),
         duration: const Duration(seconds: 3),
       );
     }

--- a/app/lib/common/widgets/side_sheet_page.dart
+++ b/app/lib/common/widgets/side_sheet_page.dart
@@ -28,12 +28,12 @@ class SideSheetPage<T> extends CustomTransitionPage<T> {
   Route<T> createRoute(BuildContext context) {
     return RawDialogRoute<T>(
       pageBuilder: (
-        BuildContext ctx,
+        BuildContext context,
         Animation<double> animation,
         Animation<double> secondaryAnimation,
       ) {
-        final totalWidth = MediaQuery.of(ctx).size.width;
-        double width = MediaQuery.of(ctx).size.width / 1.4;
+        final totalWidth = MediaQuery.of(context).size.width;
+        double width = MediaQuery.of(context).size.width / 1.4;
         if (width < 300) {
           width = totalWidth * 0.95;
         } else if (width > 450) {

--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -89,7 +89,7 @@ class ActivitiesPage extends ConsumerWidget {
       ),
       SliverList(
         delegate: SliverChildBuilderDelegate(
-          (BuildContext ctx, int index) {
+          (BuildContext context, int index) {
             return InvitationCard(
               invitation: invitations[index],
             );

--- a/app/lib/features/attachments/widgets/attachment_options.dart
+++ b/app/lib/features/attachments/widgets/attachment_options.dart
@@ -55,7 +55,7 @@ class AttachmentOptions extends StatelessWidget {
           title: Text(L10n.of(context).file),
         ),
         ListTile(
-          onTap: () => Navigator.of(context).pop(),
+          onTap: () => Navigator.pop(context),
           contentPadding: const EdgeInsets.all(0),
           title: Text(L10n.of(context).cancel, textAlign: TextAlign.center),
         ),

--- a/app/lib/features/attachments/widgets/attachment_section.dart
+++ b/app/lib/features/attachments/widgets/attachment_section.dart
@@ -200,14 +200,14 @@ class FoundAttachmentSectionWidget extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: <Widget>[
                     OutlinedButton(
-                      onPressed: () => Navigator.of(context).pop(),
+                      onPressed: () => Navigator.pop(context),
                       child: Text(L10n.of(context).no),
                     ),
                     const SizedBox(width: 10),
                     ActerDangerActionButton(
                       key: AttachmentSectionWidget.confirmRedactKey,
                       onPressed: () {
-                        Navigator.of(context).pop();
+                        Navigator.pop(context);
                         _handleRedactAttachment(
                           eventId,
                           reasonController.text.trim(),

--- a/app/lib/features/attachments/widgets/post_attachment_selection.dart
+++ b/app/lib/features/attachments/widgets/post_attachment_selection.dart
@@ -78,13 +78,13 @@ class _PostAttachmentSelectionState
         children: <Widget>[
           OutlinedButton(
             onPressed: () {
-              Navigator.of(context).pop();
+              Navigator.pop(context);
             },
             child: const Text('Cancel'),
           ),
           ActerPrimaryActionButton(
             onPressed: () async {
-              Navigator.of(context).pop();
+              Navigator.pop(context);
               handleAttachmentSend();
             },
             child: const Text('Send'),

--- a/app/lib/features/attachments/widgets/views/image_view.dart
+++ b/app/lib/features/attachments/widgets/views/image_view.dart
@@ -50,7 +50,7 @@ class ImageView extends ConsumerWidget {
             context: context,
             barrierDismissible: false,
             useRootNavigator: false,
-            builder: (ctx) => ImageDialog(
+            builder: (context) => ImageDialog(
               title: msgContent.body(),
               imageFile: mediaState.mediaFile!,
             ),
@@ -105,7 +105,7 @@ class ImageView extends ConsumerWidget {
                 context: context,
                 barrierDismissible: false,
                 useRootNavigator: false,
-                builder: (ctx) => ImageDialog(
+                builder: (context) => ImageDialog(
                   title: msgContent.body(),
                   imageFile: mediaState.mediaFile!,
                 ),

--- a/app/lib/features/attachments/widgets/views/video_view.dart
+++ b/app/lib/features/attachments/widgets/views/video_view.dart
@@ -47,7 +47,7 @@ class VideoView extends ConsumerWidget {
             context: context,
             barrierDismissible: false,
             useRootNavigator: false,
-            builder: (ctx) => VideoDialog(
+            builder: (context) => VideoDialog(
               title: msgContent.body(),
               videoFile: mediaState.mediaFile!,
             ),
@@ -101,7 +101,7 @@ class VideoView extends ConsumerWidget {
                 context: context,
                 barrierDismissible: false,
                 useRootNavigator: false,
-                builder: (ctx) => VideoDialog(
+                builder: (context) => VideoDialog(
                   title: msgContent.body(),
                   videoFile: mediaState.mediaFile!,
                 ),

--- a/app/lib/features/auth/pages/register_page.dart
+++ b/app/lib/features/auth/pages/register_page.dart
@@ -5,7 +5,6 @@ import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/no_internet.dart';
 import 'package:acter/features/auth/providers/auth_providers.dart';
 import 'package:acter/features/super_invites/providers/super_invites_providers.dart';
@@ -336,7 +335,7 @@ class _RegisterPageState extends ConsumerState<RegisterPage> {
                     ),
                     IconButton(
                       onPressed: () async {
-                        context.closeDialog(); // close the drawer
+                        Navigator.pop(context); // close the drawer
                         EasyLoading.showToast(
                           L10n.of(context).inviteCopiedToClipboard,
                           toastPosition: EasyLoadingToastPosition.bottom,
@@ -356,7 +355,7 @@ class _RegisterPageState extends ConsumerState<RegisterPage> {
             OutlinedButton(
               child: Text(L10n.of(context).ok),
               onPressed: () {
-                Navigator.of(context).pop();
+                Navigator.pop(context);
               },
             ),
           ],

--- a/app/lib/features/auth/providers/notifiers/auth_notifier.dart
+++ b/app/lib/features/auth/providers/notifiers/auth_notifier.dart
@@ -15,13 +15,9 @@ class AuthStateNotifier extends StateNotifier<bool> {
 
   AuthStateNotifier(this.ref) : super(false);
 
-  Future<void> nuke(BuildContext context) async {
+  Future<void> nuke() async {
     await ActerSdk.nuke();
     ref.invalidate(spacesProvider);
-
-    if (context.mounted) {
-      context.goNamed(Routes.main.name);
-    }
   }
 
   Future<String?> login(String username, String password) async {

--- a/app/lib/features/backups/dialogs/provide_recovery_key_dialog.dart
+++ b/app/lib/features/backups/dialogs/provide_recovery_key_dialog.dart
@@ -62,7 +62,7 @@ class __RecoveryKeyDialogState extends ConsumerState<_RecoveryKeyDialog> {
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).cancel),
           ),
           ActerPrimaryActionButton(
@@ -94,7 +94,7 @@ class __RecoveryKeyDialogState extends ConsumerState<_RecoveryKeyDialog> {
           L10n.of(context).encryptionBackupRecoverRecoveringSuccess,
         );
         if (context.mounted) {
-          Navigator.of(context, rootNavigator: true).pop();
+          Navigator.pop(context);
         }
       } else {
         if (!context.mounted) {
@@ -120,6 +120,6 @@ class __RecoveryKeyDialogState extends ConsumerState<_RecoveryKeyDialog> {
 void showProviderRecoveryKeyDialog(BuildContext context, WidgetRef ref) {
   showDialog(
     context: context,
-    builder: (BuildContext ctx) => const _RecoveryKeyDialog(),
+    builder: (BuildContext context) => const _RecoveryKeyDialog(),
   );
 }

--- a/app/lib/features/backups/dialogs/show_confirm_disabling.dart
+++ b/app/lib/features/backups/dialogs/show_confirm_disabling.dart
@@ -32,7 +32,7 @@ class _ShowConfirmResetDialog extends ConsumerWidget {
       actionsAlignment: MainAxisAlignment.spaceEvenly,
       actions: <Widget>[
         ActerPrimaryActionButton(
-          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).encryptionBackupDisableActionKeepIt),
         ),
         ActerDangerActionButton(
@@ -57,7 +57,7 @@ class _ShowConfirmResetDialog extends ConsumerWidget {
         toastPosition: EasyLoadingToastPosition.bottom,
       );
       if (context.mounted) {
-        Navigator.of(context, rootNavigator: true).pop();
+        Navigator.pop(context);
         showRecoveryKeyDialog(context, ref, newKey);
       }
     } catch (error) {
@@ -75,6 +75,6 @@ class _ShowConfirmResetDialog extends ConsumerWidget {
 void showConfirmResetDialog(BuildContext context, WidgetRef ref) {
   showDialog(
     context: context,
-    builder: (BuildContext ctx) => const _ShowConfirmResetDialog(),
+    builder: (BuildContext context) => const _ShowConfirmResetDialog(),
   );
 }

--- a/app/lib/features/backups/dialogs/show_recovery_key.dart
+++ b/app/lib/features/backups/dialogs/show_recovery_key.dart
@@ -53,7 +53,7 @@ class _ShowRecoveryDialog extends StatelessWidget {
       actionsAlignment: MainAxisAlignment.end,
       actions: <Widget>[
         OutlinedButton(
-          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).okay),
         ),
       ],
@@ -68,6 +68,6 @@ void showRecoveryKeyDialog(
 ) {
   showDialog(
     context: context,
-    builder: (BuildContext ctx) => _ShowRecoveryDialog(recoveryKey),
+    builder: (BuildContext context) => _ShowRecoveryDialog(recoveryKey),
   );
 }

--- a/app/lib/features/bug_report/pages/bug_report_page.dart
+++ b/app/lib/features/bug_report/pages/bug_report_page.dart
@@ -222,7 +222,7 @@ class _BugReportState extends ConsumerState<BugReportPage> {
                     key: BugReportPage.screenshot,
                     width: MediaQuery.of(context).size.width * 0.8,
                     errorBuilder: (
-                      BuildContext ctx,
+                      BuildContext context,
                       Object error,
                       StackTrace? stackTrace,
                     ) {
@@ -241,7 +241,7 @@ class _BugReportState extends ConsumerState<BugReportPage> {
                           if (!await reportBug(context)) return;
                           if (!context.mounted) return;
                           if (context.canPop()) {
-                            context.closeDialog();
+                            Navigator.pop(context);
                           }
                         },
                         child: Text(L10n.of(context).submit),

--- a/app/lib/features/chat/dialogs/encryption_info_drawer.dart
+++ b/app/lib/features/chat/dialogs/encryption_info_drawer.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:go_router/go_router.dart';
@@ -36,7 +35,7 @@ class EncryptionInfoSheet extends StatelessWidget {
               ),
               if (context.canPop())
                 TextButton(
-                  onPressed: () => context.closeDialog(),
+                  onPressed: () => Navigator.pop(context),
                   child: Text(
                     L10n.of(context).close,
                   ),
@@ -50,7 +49,7 @@ class EncryptionInfoSheet extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           OutlinedButton(
-            onPressed: () => context.closeDialog(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).close),
           ),
         ],

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -97,7 +97,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
       automaticallyImplyLeading: !context.isLargeScreen,
       leading: context.isLargeScreen
           ? IconButton(
-              onPressed: () => context.closeDialog(),
+              onPressed: () => Navigator.pop(context),
               icon: const Icon(Atlas.xmark_circle_thin),
             )
           : null,
@@ -190,7 +190,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
       await convo.setName(newName.trim());
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to edit chat name', e, st);
       EasyLoading.dismiss();
@@ -427,7 +427,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   Future<void> showLeaveRoomDialog() async {
     showAdaptiveDialog(
       context: context,
-      builder: (ctx) => DefaultDialog(
+      builder: (context) => DefaultDialog(
         title: Text(
           L10n.of(context).leaveRoom,
           style: Theme.of(context).textTheme.titleSmall,
@@ -438,7 +438,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
         ),
         actions: [
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -451,7 +451,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   }
 
   Future<void> _handleLeaveRoom() async {
-    Navigator.of(context, rootNavigator: true).pop();
+    Navigator.pop(context);
     EasyLoading.show(status: L10n.of(context).leavingRoom);
     try {
       final convo = await ref.read(chatProvider(widget.roomId).future);
@@ -537,7 +537,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
           await convo?.setTopic(newDescription);
           EasyLoading.dismiss();
           if (!context.mounted) return;
-          context.closeDialog();
+          Navigator.pop(context);
         } catch (e) {
           EasyLoading.dismiss();
           if (!context.mounted) return;

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -427,6 +427,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
   Future<void> showLeaveRoomDialog() async {
     showAdaptiveDialog(
       context: context,
+      useRootNavigator: false,
       builder: (context) => DefaultDialog(
         title: Text(
           L10n.of(context).leaveRoom,

--- a/app/lib/features/chat/utils.dart
+++ b/app/lib/features/chat/utils.dart
@@ -193,7 +193,7 @@ void askToJoinRoom(
         topLeft: Radius.circular(20),
       ),
     ),
-    builder: (ctx) => Container(
+    builder: (context) => Container(
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -207,7 +207,7 @@ void askToJoinRoom(
           const SizedBox(height: 20),
           ActerPrimaryActionButton(
             onPressed: () async {
-              Navigator.of(context).pop();
+              Navigator.pop(context);
               final server = roomId.split(':').last;
               await joinRoom(
                 context,

--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -185,7 +185,7 @@ class _ChatBubble extends ConsumerWidget {
                     top: 15,
                   ),
                   child: Consumer(
-                    builder: (ctx, ref, child) => replyProfileBuilder(
+                    builder: (context, ref, child) => replyProfileBuilder(
                       context,
                       ref,
                     ),

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -415,7 +415,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
         final convo = await widget.onCreateConvo(null, null, userIds);
         EasyLoading.dismiss();
         if (!mounted) return;
-        Navigator.of(context).pop();
+        Navigator.pop(context);
         if (convo == null) return;
         context.pushNamed(
           Routes.chatroom.name,
@@ -429,7 +429,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
       String? id = checkUserDMExists(othersUserId, client);
       if (id != null) {
         EasyLoading.dismiss();
-        Navigator.of(context).pop();
+        Navigator.pop(context);
         context.pushNamed(
           Routes.chatroom.name,
           pathParameters: {'roomId': id},
@@ -440,7 +440,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
       final convo = await widget.onCreateConvo(null, null, [othersUserId]);
       EasyLoading.dismiss();
       if (!mounted) return;
-      Navigator.of(context).pop();
+      Navigator.pop(context);
       if (convo == null) return;
       context.pushNamed(
         Routes.chatroom.name,
@@ -606,7 +606,7 @@ class _CreateRoomFormWidgetConsumerState
             mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
               OutlinedButton(
-                onPressed: () => Navigator.of(context).pop(),
+                onPressed: () => Navigator.pop(context),
                 child: Text(L10n.of(context).cancel),
               ),
               const SizedBox(width: 10),

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -365,7 +365,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Consumer(
-                  builder: (ctx, ref, child) =>
+                  builder: (context, ref, child) =>
                       replyBuilder(roomId, repliedToMessage),
                 ),
                 _ReplyContentWidget(
@@ -425,9 +425,9 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
           topLeft: Radius.circular(20),
         ),
       ),
-      builder: (ctx) => AttachmentOptions(
+      builder: (context) => AttachmentOptions(
         onTapCamera: () async {
-          Navigator.of(context).pop();
+          Navigator.pop(context);
           XFile? imageFile =
               await ImagePicker().pickImage(source: ImageSource.camera);
           if (imageFile != null) {
@@ -443,7 +443,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
           }
         },
         onTapImage: () async {
-          Navigator.of(context).pop();
+          Navigator.pop(context);
           XFile? imageFile =
               await ImagePicker().pickImage(source: ImageSource.gallery);
           if (imageFile != null) {
@@ -459,7 +459,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
           }
         },
         onTapVideo: () async {
-          Navigator.of(context).pop();
+          Navigator.pop(context);
           XFile? imageFile =
               await ImagePicker().pickVideo(source: ImageSource.gallery);
           if (imageFile != null) {
@@ -475,8 +475,8 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
           }
         },
         onTapFile: () async {
-          Navigator.of(context).pop();
-          final selectedFiles = await handleFileSelection(ctx);
+          Navigator.pop(context);
+          final selectedFiles = await handleFileSelection(context);
 
           if (context.mounted) {
             attachmentConfirmation(
@@ -528,7 +528,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
             )
           : showModalBottomSheet(
               context: context,
-              builder: (ctx) => Padding(
+              builder: (context) => Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: _FileWidget(selectedFiles, type, handleFileUpload),
               ),
@@ -782,13 +782,13 @@ class _FileWidget extends ConsumerWidget {
         children: <Widget>[
           OutlinedButton(
             onPressed: () {
-              Navigator.of(context).pop();
+              Navigator.pop(context);
             },
             child: Text(L10n.of(context).cancel),
           ),
           ActerPrimaryActionButton(
             onPressed: () async {
-              Navigator.of(context).pop();
+              Navigator.pop(context);
               handleFileUpload(selectedFiles, type);
             },
             child: Text(L10n.of(context).send),
@@ -926,9 +926,9 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
         autocompleteTriggers: [
           AutocompleteTrigger(
             trigger: '@',
-            optionsViewBuilder: (ctx, autocompleteQuery, ctrl) {
+            optionsViewBuilder: (context, autocompleteQuery, ctrl) {
               return MentionProfileBuilder(
-                ctx: ctx,
+                context: context,
                 roomQuery: (
                   query: autocompleteQuery.query,
                   roomId: widget.roomId
@@ -937,14 +937,14 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
             },
           ),
         ],
-        fieldViewBuilder: (ctx, ctrl, focusNode) =>
-            _innerTextField(ctx, focusNode, ctrl),
+        fieldViewBuilder: (context, ctrl, focusNode) =>
+            _innerTextField(context, focusNode, ctrl),
       ),
     );
   }
 
   Widget _innerTextField(
-    BuildContext ctx,
+    BuildContext context,
     FocusNode chatFocus,
     TextEditingController ctrl,
   ) {
@@ -977,7 +977,7 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
         suffixIcon: InkWell(
           onTap: () => onSuffixTap(
             ref.read(chatInputProvider).emojiPickerVisible,
-            ctx,
+            context,
             ref,
           ),
           child: const Icon(Icons.emoji_emotions),

--- a/app/lib/features/chat/widgets/image_message_builder.dart
+++ b/app/lib/features/chat/widgets/image_message_builder.dart
@@ -57,7 +57,7 @@ class ImageMessageBuilder extends ConsumerWidget {
             context: context,
             barrierDismissible: false,
             useRootNavigator: false,
-            builder: (ctx) => ImageDialog(
+            builder: (context) => ImageDialog(
               title: message.name,
               imageFile: mediaState.mediaFile!,
             ),
@@ -118,7 +118,7 @@ class ImageMessageBuilder extends ConsumerWidget {
           context: context,
           barrierDismissible: false,
           useRootNavigator: false,
-          builder: (ctx) => ImageDialog(
+          builder: (context) => ImageDialog(
             title: message.name,
             imageFile: mediaState.mediaFile!,
           ),

--- a/app/lib/features/chat/widgets/mention_profile_builder.dart
+++ b/app/lib/features/chat/widgets/mention_profile_builder.dart
@@ -10,12 +10,12 @@ import 'package:skeletonizer/skeletonizer.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 class MentionProfileBuilder extends ConsumerWidget {
-  final BuildContext ctx;
+  final BuildContext context;
   final RoomQuery roomQuery;
 
   const MentionProfileBuilder({
     super.key,
-    required this.ctx,
+    required this.context,
     required this.roomQuery,
   });
 
@@ -73,7 +73,7 @@ class MentionProfileBuilder extends ConsumerWidget {
                 return ListTile(
                   dense: true,
                   onTap: () {
-                    final autocomplete = MultiTriggerAutocomplete.of(ctx);
+                    final autocomplete = MultiTriggerAutocomplete.of(context);
                     ref
                         .read(chatInputProvider.notifier)
                         .addMention(displayName, id);

--- a/app/lib/features/chat/widgets/message_actions.dart
+++ b/app/lib/features/chat/widgets/message_actions.dart
@@ -2,7 +2,7 @@ import 'package:acter/common/providers/common_providers.dart';
 
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/widgets/default_dialog.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -138,15 +138,13 @@ class MessageActions extends ConsumerWidget {
   }
 
   void onReportMessage(BuildContext context, Message message, String roomId) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => ReportContentWidget(
-        title: L10n.of(context).reportThisMessage,
-        description: L10n.of(context).reportMessageContent,
-        senderId: message.author.id,
-        roomId: roomId,
-        eventId: message.id,
-      ),
+    openReportContentDialog(
+      context,
+      title: L10n.of(context).reportThisMessage,
+      description: L10n.of(context).reportMessageContent,
+      senderId: message.author.id,
+      roomId: roomId,
+      eventId: message.id,
     );
   }
 

--- a/app/lib/features/chat/widgets/message_actions.dart
+++ b/app/lib/features/chat/widgets/message_actions.dart
@@ -163,7 +163,7 @@ class MessageActions extends ConsumerWidget {
         title: Text(L10n.of(context).areYouSureYouWantToDeleteThisMessage),
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -177,12 +177,12 @@ class MessageActions extends ConsumerWidget {
                 );
                 chatInputNotifier.unsetSelectedMessage();
                 if (context.mounted) {
-                  Navigator.of(context, rootNavigator: true).pop();
+                  Navigator.pop(context);
                 }
               } catch (error, stackTrace) {
                 _log.severe('Redacting message failed', error, stackTrace);
                 if (context.mounted) {
-                  Navigator.of(context, rootNavigator: true).pop();
+                  Navigator.pop(context);
                 }
                 EasyLoading.showError(error.toString());
               }

--- a/app/lib/features/chat/widgets/video_message_builder.dart
+++ b/app/lib/features/chat/widgets/video_message_builder.dart
@@ -59,7 +59,7 @@ class VideoMessageBuilder extends ConsumerWidget {
             context: context,
             barrierDismissible: false,
             useRootNavigator: false,
-            builder: (ctx) => VideoDialog(
+            builder: (context) => VideoDialog(
               title: message.name,
               videoFile: mediaState.mediaFile!,
             ),
@@ -122,7 +122,7 @@ class VideoMessageBuilder extends ConsumerWidget {
           context: context,
           barrierDismissible: false,
           useRootNavigator: false,
-          builder: (ctx) => VideoDialog(
+          builder: (context) => VideoDialog(
             title: message.name,
             videoFile: mediaState.mediaFile!,
           ),

--- a/app/lib/features/events/pages/create_edit_event_page.dart
+++ b/app/lib/features/events/pages/create_edit_event_page.dart
@@ -487,7 +487,7 @@ class CreateEditEventPageConsumerState
       ref.invalidate(spaceEventsProvider(spaceId)); // events page in space
 
       if (mounted) {
-        context.closeDialog();
+        Navigator.pop(context);
         context.pushNamed(
           Routes.calendarEvent.name,
           pathParameters: {'calendarId': eventId.toString()},
@@ -544,7 +544,7 @@ class CreateEditEventPageConsumerState
       final spaceId = calendarEvent.roomIdStr();
       ref.invalidate(spaceEventsProvider(spaceId)); // events page in space
 
-      if (mounted) context.closeDialog();
+      if (mounted) Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to update calendar event', e, st);
       if (!mounted) {

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -142,9 +142,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
               eventId: event.eventId().toString(),
               onSuccess: () {
                 ref.invalidate(calendarEventProvider);
-                if (context.canPop()) {
-                  Navigator.of(context, rootNavigator: true).pop();
-                }
+                Navigator.pop(context);
               },
               senderId: event.sender().toString(),
               roomId: roomId,
@@ -170,7 +168,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       PopupMenuItem(
         onTap: () => showAdaptiveDialog(
           context: context,
-          builder: (ctx) => ReportContentWidget(
+          builder: (context) => ReportContentWidget(
             title: L10n.of(context).reportThisEvent,
             description: L10n.of(context).reportThisContent,
             eventId: widget.calendarId,
@@ -194,7 +192,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
 
     return PopupMenuButton(
       key: EventsKeys.appbarMenuActionBtn,
-      itemBuilder: (ctx) => actions,
+      itemBuilder: (context) => actions,
     );
   }
 
@@ -312,7 +310,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
 
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to edit event name', e, st);
       EasyLoading.dismiss();
@@ -416,7 +414,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
   Widget _buildShareAction(CalendarEvent calendarEvent) {
     return PopupMenuButton(
       icon: const Icon(Icons.share),
-      itemBuilder: (ctx) => [
+      itemBuilder: (context) => [
         PopupMenuItem(
           onTap: () => onShareEvent(calendarEvent),
           child: Row(
@@ -667,7 +665,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       updateBuilder.descriptionHtml(plainDescription, htmlBodyDescription);
       await updateBuilder.send();
       EasyLoading.dismiss();
-      if (mounted) context.closeDialog();
+      if (mounted) Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -7,7 +7,7 @@ import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/render_html.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/events/model/keys.dart';
@@ -163,16 +163,14 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
     //Report Event Action
     actions.add(
       PopupMenuItem(
-        onTap: () => showAdaptiveDialog(
-          context: context,
-          builder: (context) => ReportContentWidget(
-            title: L10n.of(context).reportThisEvent,
-            description: L10n.of(context).reportThisContent,
-            eventId: widget.calendarId,
-            roomId: event.roomIdStr(),
-            senderId: event.sender().toString(),
-            isSpace: true,
-          ),
+        onTap: () => openReportContentDialog(
+          context,
+          title: L10n.of(context).reportThisEvent,
+          description: L10n.of(context).reportThisContent,
+          eventId: widget.calendarId,
+          roomId: event.roomIdStr(),
+          senderId: event.sender().toString(),
+          isSpace: true,
         ),
         child: Row(
           children: <Widget>[

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/app_theme.dart';
@@ -5,7 +6,6 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
-import 'package:acter/common/widgets/redact_content.dart';
 import 'package:acter/common/widgets/render_html.dart';
 import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
@@ -134,20 +134,17 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       actions.addAll([
         PopupMenuItem(
           key: EventsKeys.eventDeleteBtn,
-          onTap: () => showAdaptiveDialog(
-            context: context,
-            builder: (context) => RedactContentWidget(
-              removeBtnKey: EventsKeys.eventRemoveBtn,
-              title: L10n.of(context).removeThisPost,
-              eventId: event.eventId().toString(),
-              onSuccess: () {
-                ref.invalidate(calendarEventProvider);
-                Navigator.pop(context);
-              },
-              senderId: event.sender().toString(),
-              roomId: roomId,
-              isSpace: true,
-            ),
+          onTap: () => openRedactContentDialog(
+            context,
+            removeBtnKey: EventsKeys.eventRemoveBtn,
+            title: L10n.of(context).removeThisPost,
+            eventId: event.eventId().toString(),
+            onSuccess: () {
+              ref.invalidate(calendarEventProvider);
+              Navigator.pop(context);
+            },
+            roomId: roomId,
+            isSpace: true,
           ),
           child: Row(
             children: <Widget>[

--- a/app/lib/features/events/widgets/event_item.dart
+++ b/app/lib/features/events/widgets/event_item.dart
@@ -103,7 +103,7 @@ class EventItem extends StatelessWidget {
 
   Widget _buildRsvpStatus(BuildContext context) {
     return Consumer(
-      builder: (ctx, ref, child) {
+      builder: (context, ref, child) {
         final eventId = event.eventId().toString();
         final myRsvpStatus = ref.watch(myRsvpStatusProvider(eventId));
         return myRsvpStatus.when(

--- a/app/lib/features/events/widgets/participants_list.dart
+++ b/app/lib/features/events/widgets/participants_list.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/member/widgets/member_list_entry.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -27,7 +26,7 @@ class ParticipantsList extends ConsumerWidget {
                 child: Text(L10n.of(context).eventParticipants),
               ),
               TextButton(
-                onPressed: () => context.closeDialog(),
+                onPressed: () => Navigator.pop(context),
                 child: Text(L10n.of(context).close),
               ),
             ],

--- a/app/lib/features/home/pages/home_shell.dart
+++ b/app/lib/features/home/pages/home_shell.dart
@@ -257,7 +257,7 @@ class HomeShellState extends ConsumerState<HomeShell> {
       config: <Breakpoint, SlotLayoutConfig?>{
         Breakpoints.large: SlotLayout.from(
           key: const Key('primaryNavigation'),
-          builder: (BuildContext ctx) => SidebarWidget(
+          builder: (BuildContext context) => SidebarWidget(
             navigationShell: widget.navigationShell,
           ),
         ),
@@ -270,7 +270,7 @@ class HomeShellState extends ConsumerState<HomeShell> {
       config: <Breakpoint, SlotLayoutConfig>{
         Breakpoints.standard: SlotLayout.from(
           key: const Key('Body Small'),
-          builder: (BuildContext ctx) => widget.navigationShell,
+          builder: (BuildContext context) => widget.navigationShell,
         ),
       },
     );

--- a/app/lib/features/invite_members/pages/share_invite_code.dart
+++ b/app/lib/features/invite_members/pages/share_invite_code.dart
@@ -193,7 +193,7 @@ class ShareInviteCode extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
       child: ActerPrimaryActionButton(
-        onPressed: () => context.closeDialog(),
+        onPressed: () => Navigator.pop(context),
         child: Text(L10n.of(context).done),
       ),
     );

--- a/app/lib/features/member/dialogs/show_block_user_dialog.dart
+++ b/app/lib/features/member/dialogs/show_block_user_dialog.dart
@@ -24,7 +24,7 @@ Future<void> showBlockUserDialog(BuildContext context, Member member) async {
         ),
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -47,7 +47,7 @@ Future<void> showBlockUserDialog(BuildContext context, Member member) async {
                   duration: const Duration(seconds: 3),
                 );
               }
-              Navigator.of(context, rootNavigator: true).pop();
+              Navigator.pop(context);
             },
             child: Text(L10n.of(context).yes),
           ),

--- a/app/lib/features/member/dialogs/show_kick_and_ban_user_dialog.dart
+++ b/app/lib/features/member/dialogs/show_kick_and_ban_user_dialog.dart
@@ -37,7 +37,7 @@ Future<void> showKickAndBanUserDialog(
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -52,7 +52,7 @@ Future<void> showKickAndBanUserDialog(
                   return;
                 }
                 EasyLoading.showToast(L10n.of(context).kickAndBanSuccess);
-                Navigator.of(context, rootNavigator: true).pop();
+                Navigator.pop(context);
               } catch (error) {
                 if (!context.mounted) {
                   EasyLoading.dismiss();

--- a/app/lib/features/member/dialogs/show_kick_user_dialog.dart
+++ b/app/lib/features/member/dialogs/show_kick_user_dialog.dart
@@ -33,7 +33,7 @@ Future<void> showKickUserDialog(BuildContext context, Member member) async {
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -47,7 +47,7 @@ Future<void> showKickUserDialog(BuildContext context, Member member) async {
                   return;
                 }
                 EasyLoading.showToast(L10n.of(context).kickSuccess);
-                Navigator.of(context, rootNavigator: true).pop();
+                Navigator.pop(context);
               } catch (error) {
                 if (!context.mounted) {
                   EasyLoading.dismiss();

--- a/app/lib/features/member/dialogs/show_unblock_user_dialog.dart
+++ b/app/lib/features/member/dialogs/show_unblock_user_dialog.dart
@@ -27,7 +27,7 @@ Future<void> showUnblockUserDialog(BuildContext context, Member member) async {
         actionsAlignment: MainAxisAlignment.spaceEvenly,
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -50,7 +50,7 @@ Future<void> showUnblockUserDialog(BuildContext context, Member member) async {
                   duration: const Duration(seconds: 3),
                 );
               }
-              Navigator.of(context, rootNavigator: true).pop();
+              Navigator.pop(context);
             },
             child: Text(L10n.of(context).yes),
           ),

--- a/app/lib/features/member/widgets/member_info_drawer.dart
+++ b/app/lib/features/member/widgets/member_info_drawer.dart
@@ -1,7 +1,6 @@
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/toolkit/menu_item_widget.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/room/room_avatar_builder.dart';
 import 'package:acter/features/member/dialogs/show_block_user_dialog.dart';
 import 'package:acter/features/member/dialogs/show_change_power_level_dialog.dart';
@@ -177,7 +176,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                   () async {
                     await changePowerLevel(context, ref);
                     if (context.mounted) {
-                      context.closeDialog();
+                      Navigator.pop(context);
                     }
                   },
                 ),
@@ -195,7 +194,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                   onTap: () async {
                     await showKickUserDialog(context, member);
                     if (context.mounted) {
-                      context.closeDialog();
+                      Navigator.pop(context);
                     }
                   },
                 ),
@@ -210,7 +209,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
                     onTap: () async {
                       await showKickAndBanUserDialog(context, member);
                       if (context.mounted) {
-                        context.closeDialog();
+                        Navigator.pop(context);
                       }
                     },
                   ),
@@ -279,7 +278,7 @@ class _MemberInfoDrawerInner extends ConsumerWidget {
   Widget _buildUserName(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        context.closeDialog(); // close the drawer
+        Navigator.pop(context); // close the drawer
         Clipboard.setData(ClipboardData(text: memberId));
         EasyLoading.showToast(L10n.of(context).usernameCopiedToClipboard);
       },

--- a/app/lib/features/member/widgets/message_user_button.dart
+++ b/app/lib/features/member/widgets/message_user_button.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/providers/create_chat_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/router/utils.dart';
@@ -21,7 +20,7 @@ class MessageUserButton extends ConsumerWidget {
         child: OutlinedButton.icon(
           icon: const Icon(Atlas.chats_thin),
           onPressed: () async {
-            context.closeDialog();
+            Navigator.pop(context);
             goToChat(context, dmId);
           },
           label: const Text('Message'),
@@ -36,9 +35,11 @@ class MessageUserButton extends ConsumerWidget {
             ref.read(createChatSelectedUsersProvider.notifier).state = [
               profile,
             ];
-            context.closeDialog().pushNamed(
-                  Routes.createChat.name,
-                );
+            Navigator.pop(context);
+            Navigator.pushNamed(
+              context,
+              Routes.createChat.name,
+            );
           },
           label: const Text('Start DM'),
         ),

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -4,7 +4,6 @@ import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
@@ -100,7 +99,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
         onPressed: () {
           // Hide Keyboard
           SystemChannels.textInput.invokeMethod('TextInput.hide');
-          context.closeDialog();
+          Navigator.pop(context);
         },
         icon: const Icon(Atlas.xmark_circle),
       ),
@@ -151,7 +150,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
           title: Text(L10n.of(context).addActionWidget),
           content: SelectActionItem(
             onShareEventSelected: () async {
-              Navigator.of(context, rootNavigator: true).pop();
+              Navigator.pop(context);
               if (ref.read(newsStateProvider).newsPostSpaceId == null) {
                 EasyLoading.showToast(L10n.of(context).pleaseFirstSelectASpace);
                 return;
@@ -461,7 +460,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
       ref.invalidate(newsListProvider);
       ref.invalidate(newsStateProvider);
       // Navigate back to update screen.
-      Navigator.of(context).pop();
+      Navigator.pop(context);
       context.pushReplacementNamed(
         Routes.main.name,
       ); // go to the home / main updates

--- a/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
+++ b/app/lib/features/news/widgets/news_post_editor/news_slide_options.dart
@@ -191,7 +191,7 @@ class _NewsSlideOptionsState extends ConsumerState<NewsSlideOptions> {
           topLeft: Radius.circular(20),
         ),
       ),
-      builder: (ctx) => PostAttachmentOptions(
+      builder: (context) => PostAttachmentOptions(
         onTapAddText: () => NewsUtils.addTextSlide(ref),
         onTapImage: () async => await NewsUtils.addImageSlide(ref),
         onTapVideo: () async => await NewsUtils.addVideoSlide(ref),

--- a/app/lib/features/news/widgets/news_post_editor/post_attachment_options.dart
+++ b/app/lib/features/news/widgets/news_post_editor/post_attachment_options.dart
@@ -27,7 +27,7 @@ class PostAttachmentOptions extends StatelessWidget {
         ListTile(
           key: NewsUpdateKeys.addTextSlide,
           onTap: () {
-            Navigator.of(context).pop();
+            Navigator.pop(context);
             if (onTapAddText != null) onTapAddText!();
           },
           leading: const Icon(Atlas.size_text),
@@ -36,7 +36,7 @@ class PostAttachmentOptions extends StatelessWidget {
         ListTile(
           key: NewsUpdateKeys.addImageSlide,
           onTap: () {
-            Navigator.of(context).pop();
+            Navigator.pop(context);
             if (onTapImage != null) onTapImage!();
           },
           leading: const Icon(Atlas.file_image),
@@ -45,7 +45,7 @@ class PostAttachmentOptions extends StatelessWidget {
         ListTile(
           key: NewsUpdateKeys.addVideoSlide,
           onTap: () {
-            Navigator.of(context).pop();
+            Navigator.pop(context);
             if (onTapVideo != null) onTapVideo!();
           },
           leading: const Icon(Atlas.file_video),
@@ -53,7 +53,7 @@ class PostAttachmentOptions extends StatelessWidget {
         ),
         ListTile(
           key: NewsUpdateKeys.cancelButton,
-          onTap: () => Navigator.of(context).pop(),
+          onTap: () => Navigator.pop(context),
           contentPadding: const EdgeInsets.all(0),
           title: Text(L10n.of(context).cancel, textAlign: TextAlign.center),
         ),

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -2,7 +2,6 @@ import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
 import 'package:acter/common/widgets/like_button.dart';
 import 'package:acter/common/widgets/redact_content.dart';
@@ -15,6 +14,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -181,9 +181,14 @@ class ActionBox extends ConsumerWidget {
             builder: (context) => RedactContentWidget(
               title: L10n.of(context).removeThisPost,
               eventId: news.eventId().toString(),
-              onSuccess: () {
-                context.closeDialog(orGo: Routes.main);
+              onSuccess: () async {
                 ref.invalidate(newsListProvider);
+                if (!await Navigator.maybePop(context)) {
+                  if (context.mounted) {
+                    // fallback to go to home
+                    context.goNamed(Routes.main.name);
+                  }
+                }
               },
               senderId: senderId,
               roomId: roomId,

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -5,7 +5,7 @@ import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
 import 'package:acter/common/widgets/like_button.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/news/model/keys.dart';
 import 'package:acter/features/news/providers/news_providers.dart';
 import 'package:acter/router/utils.dart';
@@ -201,16 +201,14 @@ class ActionBox extends ConsumerWidget {
       actions.add(
         TextButton.icon(
           key: NewsUpdateKeys.newsSidebarActionReportBtn,
-          onPressed: () => showAdaptiveDialog(
-            context: context,
-            builder: (context) => ReportContentWidget(
-              title: L10n.of(context).reportThisPost,
-              eventId: news.eventId().toString(),
-              description: L10n.of(context).reportPostContent,
-              senderId: senderId,
-              roomId: roomId,
-              isSpace: true,
-            ),
+          onPressed: () => openReportContentDialog(
+            context,
+            title: L10n.of(context).reportThisPost,
+            eventId: news.eventId().toString(),
+            description: L10n.of(context).reportPostContent,
+            senderId: senderId,
+            roomId: roomId,
+            isSpace: true,
           ),
           icon: const Icon(Atlas.exclamation_chat_thin),
           label: Text(L10n.of(context).reportThis),

--- a/app/lib/features/news/widgets/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_side_bar.dart
@@ -1,10 +1,10 @@
+import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/default_bottom_sheet.dart';
 import 'package:acter/common/widgets/like_button.dart';
-import 'package:acter/common/widgets/redact_content.dart';
 import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/news/model/keys.dart';
 import 'package:acter/features/news/providers/news_providers.dart';
@@ -176,25 +176,22 @@ class ActionBox extends ConsumerWidget {
       actions.add(
         TextButton.icon(
           key: NewsUpdateKeys.newsSidebarActionRemoveBtn,
-          onPressed: () => showAdaptiveDialog(
-            context: context,
-            builder: (context) => RedactContentWidget(
-              title: L10n.of(context).removeThisPost,
-              eventId: news.eventId().toString(),
-              onSuccess: () async {
-                ref.invalidate(newsListProvider);
-                if (!await Navigator.maybePop(context)) {
-                  if (context.mounted) {
-                    // fallback to go to home
-                    context.goNamed(Routes.main.name);
-                  }
+          onPressed: () => openRedactContentDialog(
+            context,
+            title: L10n.of(context).removeThisPost,
+            eventId: news.eventId().toString(),
+            onSuccess: () async {
+              ref.invalidate(newsListProvider);
+              if (!await Navigator.maybePop(context)) {
+                if (context.mounted) {
+                  // fallback to go to home
+                  context.goNamed(Routes.main.name);
                 }
-              },
-              senderId: senderId,
-              roomId: roomId,
-              isSpace: true,
-              removeBtnKey: NewsUpdateKeys.removeButton,
-            ),
+              }
+            },
+            roomId: roomId,
+            isSpace: true,
+            removeBtnKey: NewsUpdateKeys.removeButton,
           ),
           icon: const Icon(Atlas.trash_thin),
           label: Text(L10n.of(context).remove),

--- a/app/lib/features/pins/Utils/pins_utils.dart
+++ b/app/lib/features/pins/Utils/pins_utils.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -16,7 +15,7 @@ Future<void> savePinTitle(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.closeDialog();
+    Navigator.pop(context);
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;
@@ -36,7 +35,7 @@ Future<void> savePinLink(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.closeDialog();
+    Navigator.pop(context);
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;
@@ -58,7 +57,7 @@ Future<void> saveDescription(
     await updateBuilder.send();
     EasyLoading.dismiss();
     if (!context.mounted) return;
-    context.closeDialog();
+    Navigator.pop(context);
   } catch (e) {
     EasyLoading.dismiss();
     if (!context.mounted) return;

--- a/app/lib/features/pins/pages/create_pin_page.dart
+++ b/app/lib/features/pins/pages/create_pin_page.dart
@@ -188,7 +188,7 @@ class _CreatePinSheetConsumerState extends ConsumerState<CreatePinPage> {
         return;
       }
       EasyLoading.showToast(L10n.of(context).pinCreatedSuccessfully);
-      Navigator.of(context, rootNavigator: true).pop(); // pop the create sheet
+      Navigator.pop(context); // pop the create sheet
       context.pushNamed(
         Routes.pin.name,
         pathParameters: {'pinId': pinId.toString()},

--- a/app/lib/features/pins/pages/pin_page.dart
+++ b/app/lib/features/pins/pages/pin_page.dart
@@ -5,7 +5,7 @@ import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_link_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/pins/Utils/pins_utils.dart';
 import 'package:acter/features/pins/providers/pins_provider.dart';
@@ -164,16 +164,14 @@ class PinPage extends ConsumerWidget {
 
   // report pin dialog
   void showReportDialog(BuildContext context, ActerPin pin) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => ReportContentWidget(
-        title: L10n.of(context).reportThisPin,
-        description: L10n.of(context).reportThisContent,
-        eventId: pinId,
-        roomId: pin.roomIdStr(),
-        senderId: pin.sender().toString(),
-        isSpace: true,
-      ),
+    openReportContentDialog(
+      context,
+      title: L10n.of(context).reportThisPin,
+      description: L10n.of(context).reportThisContent,
+      eventId: pinId,
+      roomId: pin.roomIdStr(),
+      senderId: pin.sender().toString(),
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/pins/pages/pin_page.dart
+++ b/app/lib/features/pins/pages/pin_page.dart
@@ -1,10 +1,10 @@
+import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_link_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
-import 'package:acter/common/widgets/redact_content.dart';
 import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/pins/Utils/pins_utils.dart';
@@ -150,18 +150,15 @@ class PinPage extends ConsumerWidget {
     required ActerPin pin,
     required String roomId,
   }) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => RedactContentWidget(
-        title: L10n.of(context).removeThisPin,
-        eventId: pin.eventIdStr(),
-        onSuccess: () {
-          Navigator.pop(context);
-        },
-        senderId: pin.sender().toString(),
-        roomId: roomId,
-        isSpace: true,
-      ),
+    openRedactContentDialog(
+      context,
+      title: L10n.of(context).removeThisPin,
+      eventId: pin.eventIdStr(),
+      onSuccess: () {
+        Navigator.pop(context);
+      },
+      roomId: roomId,
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/pins/pages/pin_page.dart
+++ b/app/lib/features/pins/pages/pin_page.dart
@@ -14,7 +14,6 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -141,7 +140,7 @@ class PinPage extends ConsumerWidget {
     return PopupMenuButton<String>(
       key: PinPage.actionMenuKey,
       icon: const Icon(Atlas.dots_vertical_thin),
-      itemBuilder: (ctx) => actions,
+      itemBuilder: (context) => actions,
     );
   }
 
@@ -157,7 +156,7 @@ class PinPage extends ConsumerWidget {
         title: L10n.of(context).removeThisPin,
         eventId: pin.eventIdStr(),
         onSuccess: () {
-          if (context.canPop()) Navigator.of(context, rootNavigator: true).pop();
+          Navigator.pop(context);
         },
         senderId: pin.sender().toString(),
         roomId: roomId,
@@ -170,7 +169,7 @@ class PinPage extends ConsumerWidget {
   void showReportDialog(BuildContext context, ActerPin pin) {
     showAdaptiveDialog(
       context: context,
-      builder: (ctx) => ReportContentWidget(
+      builder: (context) => ReportContentWidget(
         title: L10n.of(context).reportThisPin,
         description: L10n.of(context).reportThisContent,
         eventId: pinId,

--- a/app/lib/features/search/widgets/quick_actions_builder.dart
+++ b/app/lib/features/search/widgets/quick_actions_builder.dart
@@ -141,7 +141,7 @@ class QuickActionsBuilder extends ConsumerWidget {
               style: Theme.of(context).textTheme.labelMedium,
             ),
             onPressed: () async {
-              context.closeDialog();
+              Navigator.pop(context);
               await openBugReport(context);
             },
           ),

--- a/app/lib/features/search/widgets/quick_jump.dart
+++ b/app/lib/features/search/widgets/quick_jump.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/icons/tasks_icon.dart';
 import 'package:acter/features/public_room_search/widgets/maybe_direct_room_action_widget.dart';
 import 'package:acter/features/search/model/keys.dart';
@@ -11,6 +10,7 @@ import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:go_router/go_router.dart';
 
 class QuickJump extends ConsumerStatefulWidget {
   final bool expand;
@@ -146,7 +146,8 @@ class _QuickJumpState extends ConsumerState<QuickJump> {
   }
 
   void routeTo(Routes route) {
-    context.closeDialog(ignorePopFailure: true).pushNamed(route.name);
+    Navigator.pop(context);
+    context.pushNamed(route.name);
   }
 
   @override

--- a/app/lib/features/search/widgets/spaces_builder.dart
+++ b/app/lib/features/search/widgets/spaces_builder.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/search/providers/search.dart';
 import 'package:acter/features/search/providers/spaces.dart';
 import 'package:acter/router/utils.dart';
@@ -79,7 +78,7 @@ class SpacesBuilder extends ConsumerWidget {
                     ),
                   ),
                   onTap: () {
-                    context.closeDialog(ignorePopFailure: true);
+                    Navigator.pop(context);
                     goToSpace(context, e.navigationTargetId);
                   },
                 ),

--- a/app/lib/features/settings/widgets/email_address_card.dart
+++ b/app/lib/features/settings/widgets/email_address_card.dart
@@ -32,9 +32,9 @@ class EmailAddressCard extends ConsumerWidget {
         title: Text(emailAddress),
         trailing: isConfirmed
             ? PopupMenuButton(
-                itemBuilder: (BuildContext ctx) => <PopupMenuEntry>[
+                itemBuilder: (BuildContext context) => <PopupMenuEntry>[
                   PopupMenuItem(
-                    onTap: () => onUnregister(ctx, ref),
+                    onTap: () => onUnregister(context, ref),
                     child: Row(
                       children: [
                         const Icon(Atlas.trash_can_thin),
@@ -42,7 +42,7 @@ class EmailAddressCard extends ConsumerWidget {
                           padding: const EdgeInsets.symmetric(horizontal: 10),
                           child: Text(
                             L10n.of(context).remove,
-                            style: Theme.of(ctx).textTheme.labelSmall,
+                            style: Theme.of(context).textTheme.labelSmall,
                             softWrap: false,
                           ),
                         ),
@@ -60,7 +60,7 @@ class EmailAddressCard extends ConsumerWidget {
                       icon: const Icon(Atlas.envelope_check_thin),
                     ),
                     PopupMenuButton(
-                      itemBuilder: (BuildContext ctx) => <PopupMenuEntry>[
+                      itemBuilder: (BuildContext context) => <PopupMenuEntry>[
                         PopupMenuItem(
                           onTap: () => alreadyConfirmedAddress(context, ref),
                           child: Row(
@@ -90,7 +90,7 @@ class EmailAddressCard extends ConsumerWidget {
                           ),
                         ),
                         PopupMenuItem(
-                          onTap: () => onUnregister(ctx, ref),
+                          onTap: () => onUnregister(context, ref),
                           child: Row(
                             children: [
                               const Icon(Atlas.trash_can_thin),
@@ -100,7 +100,7 @@ class EmailAddressCard extends ConsumerWidget {
                                 ),
                                 child: Text(
                                   L10n.of(context).remove,
-                                  style: Theme.of(ctx).textTheme.labelSmall,
+                                  style: Theme.of(context).textTheme.labelSmall,
                                   softWrap: false,
                                 ),
                               ),
@@ -123,7 +123,7 @@ class EmailAddressCard extends ConsumerWidget {
         title: Text(L10n.of(context).areYouSureYouWantToUnregisterEmailAddress),
         actions: <Widget>[
           OutlinedButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            onPressed: () => Navigator.pop(context),
             child: Text(L10n.of(context).no),
           ),
           ActerPrimaryActionButton(
@@ -133,7 +133,7 @@ class EmailAddressCard extends ConsumerWidget {
               ref.invalidate(emailAddressesProvider);
 
               if (!context.mounted) return;
-              Navigator.of(context, rootNavigator: true).pop();
+              Navigator.pop(context);
             },
             child: Text(L10n.of(context).yes),
           ),

--- a/app/lib/features/settings/widgets/options_settings_tile.dart
+++ b/app/lib/features/settings/widgets/options_settings_tile.dart
@@ -41,7 +41,7 @@ class __OptionsSettingsTileState<T> extends State<_OptionsSettingsTile<T>> {
         )
         .$2;
     return SettingsTile(
-      onPressed: (ctx) => menuController.open(),
+      onPressed: (context) => menuController.open(),
       title: Text(
         widget.title,
         style: tileTextTheme,

--- a/app/lib/features/settings/widgets/session_card.dart
+++ b/app/lib/features/settings/widgets/session_card.dart
@@ -52,9 +52,9 @@ class SessionCard extends ConsumerWidget {
           separator: ' - ',
         ),
         trailing: PopupMenuButton(
-          itemBuilder: (BuildContext ctx) => <PopupMenuEntry>[
+          itemBuilder: (BuildContext context) => <PopupMenuEntry>[
             PopupMenuItem(
-              onTap: () async => await onLogout(ctx, ref),
+              onTap: () async => await onLogout(context, ref),
               child: Row(
                 children: [
                   const Icon(Atlas.exit_thin),
@@ -62,7 +62,7 @@ class SessionCard extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(horizontal: 5),
                     child: Text(
                       L10n.of(context).logOut,
-                      style: Theme.of(ctx).textTheme.labelSmall,
+                      style: Theme.of(context).textTheme.labelSmall,
                       softWrap: false,
                     ),
                   ),
@@ -70,7 +70,7 @@ class SessionCard extends ConsumerWidget {
               ),
             ),
             PopupMenuItem(
-              onTap: () async => await onVerify(ctx, ref),
+              onTap: () async => await onVerify(context, ref),
               child: Row(
                 children: [
                   const Icon(Atlas.shield_exclamation_thin),
@@ -78,7 +78,7 @@ class SessionCard extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(horizontal: 5),
                     child: Text(
                       L10n.of(context).verifySession,
-                      style: Theme.of(ctx).textTheme.labelSmall,
+                      style: Theme.of(context).textTheme.labelSmall,
                       softWrap: false,
                     ),
                   ),
@@ -91,10 +91,10 @@ class SessionCard extends ConsumerWidget {
     );
   }
 
-  Future<void> onLogout(BuildContext ctx, WidgetRef ref) async {
+  Future<void> onLogout(BuildContext context, WidgetRef ref) async {
     TextEditingController passwordController = TextEditingController();
     final result = await showDialog<bool>(
-      context: ctx,
+      context: context,
       builder: (BuildContext context) {
         return AlertDialog(
           backgroundColor: Theme.of(context).colorScheme.surface,
@@ -115,8 +115,8 @@ class SessionCard extends ConsumerWidget {
             OutlinedButton(
               child: Text(L10n.of(context).cancel),
               onPressed: () {
-                if (ctx.mounted) {
-                  Navigator.of(context).pop(false);
+                if (context.mounted) {
+                  Navigator.pop(context, false);
                 }
               },
             ),
@@ -126,8 +126,8 @@ class SessionCard extends ConsumerWidget {
                 if (passwordController.text.isEmpty) {
                   return;
                 }
-                if (ctx.mounted) {
-                  Navigator.of(context).pop(true);
+                if (context.mounted) {
+                  Navigator.pop(context, true);
                 }
               },
             ),

--- a/app/lib/features/space/actions/set_space_title.dart
+++ b/app/lib/features/space/actions/set_space_title.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -29,7 +28,7 @@ void showEditSpaceNameBottomSheet({
         await space.setName(newName);
         EasyLoading.dismiss();
         if (!context.mounted) return;
-        context.closeDialog();
+        Navigator.pop(context);
       } catch (e, st) {
         _log.severe('Failed to edit space name', e, st);
         EasyLoading.dismiss();

--- a/app/lib/features/space/actions/set_space_topic.dart
+++ b/app/lib/features/space/actions/set_space_topic.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/space_providers.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_plain_description_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -22,7 +21,7 @@ void showEditDescriptionBottomSheet({
         await space.setTopic(newDescription);
         EasyLoading.dismiss();
         if (!context.mounted) return;
-        context.closeDialog();
+        Navigator.pop(context);
       } catch (e) {
         EasyLoading.dismiss();
         if (!context.mounted) return;

--- a/app/lib/features/space/dialogs/leave_space.dart
+++ b/app/lib/features/space/dialogs/leave_space.dart
@@ -38,7 +38,7 @@ void showLeaveSpaceDialog(
       ),
       actions: <Widget>[
         OutlinedButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).noIStay),
         ),
         ActerDangerActionButton(
@@ -55,7 +55,7 @@ void showLeaveSpaceDialog(
                 return;
               }
               EasyLoading.showToast(lang.leavingSpaceSuccessful);
-              Navigator.of(context).pop();
+              Navigator.pop(context);
               context.goNamed(Routes.dashboard.name);
             } catch (error, stack) {
               _log.severe('Error leaving space', error, stack);

--- a/app/lib/features/space/dialogs/leave_space.dart
+++ b/app/lib/features/space/dialogs/leave_space.dart
@@ -21,7 +21,7 @@ void showLeaveSpaceDialog(
   showAdaptiveDialog(
     barrierDismissible: true,
     context: context,
-    useRootNavigator: true,
+    useRootNavigator: false,
     builder: (context) => DefaultDialog(
       title: Column(
         children: <Widget>[

--- a/app/lib/features/space/dialogs/suggested_rooms.dart
+++ b/app/lib/features/space/dialogs/suggested_rooms.dart
@@ -97,7 +97,7 @@ class __SuggestedRoomsState extends ConsumerState<_SuggestedRooms> {
         OutlinedButton(
           onPressed: () {
             markHasSeenSuggested(ref, widget.spaceId);
-            Navigator.of(context).pop();
+            Navigator.pop(context);
           },
           child: Text(L10n.of(context).skip),
         ),
@@ -171,7 +171,7 @@ class __SuggestedRoomsState extends ConsumerState<_SuggestedRooms> {
       markHasSeenSuggested(ref, widget.spaceId);
     }
     if (context.mounted) {
-      Navigator.of(context).pop();
+      Navigator.pop(context);
     }
   }
 

--- a/app/lib/features/space/dialogs/suggested_rooms.dart
+++ b/app/lib/features/space/dialogs/suggested_rooms.dart
@@ -242,7 +242,7 @@ void showSuggestRoomsDialog(
   showAdaptiveDialog(
     barrierDismissible: true,
     context: context,
-    useRootNavigator: true,
+    useRootNavigator: false,
     builder: (context) => _SuggestedRooms(
       spaceId: spaceId,
     ),

--- a/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
+++ b/app/lib/features/space/settings/pages/visibility_accessibility_page.dart
@@ -48,7 +48,7 @@ class _VisibilityAccessibilityPageState
       automaticallyImplyLeading: !context.isLargeScreen,
       leading: widget.impliedClose
           ? IconButton(
-              onPressed: () => context.closeDialog(),
+              onPressed: () => Navigator.pop(context),
               icon: const Icon(Atlas.xmark_circle_thin),
             )
           : null,

--- a/app/lib/features/spaces/pages/create_space_page.dart
+++ b/app/lib/features/spaces/pages/create_space_page.dart
@@ -299,7 +299,7 @@ class _CreateSpacePageConsumerState extends ConsumerState<CreateSpacePage> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         OutlinedButton(
-          onPressed: () => context.closeDialog(),
+          onPressed: () => Navigator.pop(context),
           child: Text(L10n.of(context).cancel),
         ),
         const SizedBox(width: 20),

--- a/app/lib/features/super_invites/dialogs/redeem_dialog.dart
+++ b/app/lib/features/super_invites/dialogs/redeem_dialog.dart
@@ -76,8 +76,7 @@ class _ShowRedeemTokenDialog extends ConsumerWidget {
       actionsAlignment: MainAxisAlignment.spaceEvenly,
       actions: <Widget>[
         OutlinedButton(
-          onPressed: () =>
-              Navigator.of(context, rootNavigator: true).pop(false),
+          onPressed: () => Navigator.pop(context, false),
           child: Text(L10n.of(context).cancel),
         ),
         ActerPrimaryActionButton(
@@ -153,7 +152,7 @@ Future<bool> showReedemTokenDialog(
 ) async {
   return await showDialog(
     context: context,
-    builder: (BuildContext ctx) =>
+    builder: (BuildContext context) =>
         _ShowRedeemTokenDialog(token: superInviteToken),
   );
 }

--- a/app/lib/features/super_invites/pages/create.dart
+++ b/app/lib/features/super_invites/pages/create.dart
@@ -265,6 +265,7 @@ class _CreateSuperInviteTokenPageConsumerState
   Future<void> _deleteIt(BuildContext context) async {
     final bool? confirm = await showAdaptiveDialog(
       context: context,
+      useRootNavigator: false,
       builder: (BuildContext context) {
         return AlertDialog(
           title: Text(L10n.of(context).deleteCode),

--- a/app/lib/features/super_invites/pages/create.dart
+++ b/app/lib/features/super_invites/pages/create.dart
@@ -2,7 +2,6 @@ import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/chat/chat_selector_drawer.dart';
 import 'package:acter/common/widgets/checkbox_form_field.dart';
 import 'package:acter/common/widgets/input_text_field.dart';
@@ -194,7 +193,14 @@ class _CreateSuperInviteTokenPageConsumerState
                 ButtonBar(
                   children: [
                     OutlinedButton(
-                      onPressed: () => context.closeDialog(orGo: Routes.main),
+                      onPressed: () async {
+                        if (!await Navigator.maybePop(context)) {
+                          if (context.mounted) {
+                            // fallback to go to home
+                            context.go(Routes.main.name);
+                          }
+                        }
+                      },
                       child: Text(
                         L10n.of(context).cancel,
                       ),
@@ -243,7 +249,7 @@ class _CreateSuperInviteTokenPageConsumerState
       ref.invalidate(superInvitesTokensProvider);
       EasyLoading.dismiss();
       if (!mounted) return;
-      Navigator.of(context, rootNavigator: true).pop(); // pop the create sheet
+      Navigator.pop(context); // pop the create sheet
     } catch (err) {
       if (!context.mounted) {
         EasyLoading.dismiss();
@@ -259,7 +265,7 @@ class _CreateSuperInviteTokenPageConsumerState
   Future<void> _deleteIt(BuildContext context) async {
     final bool? confirm = await showAdaptiveDialog(
       context: context,
-      builder: (BuildContext ctx) {
+      builder: (BuildContext context) {
         return AlertDialog(
           title: Text(L10n.of(context).deleteCode),
           content: Text(
@@ -268,7 +274,7 @@ class _CreateSuperInviteTokenPageConsumerState
           actionsAlignment: MainAxisAlignment.spaceEvenly,
           actions: <Widget>[
             OutlinedButton(
-              onPressed: () => ctx.pop(),
+              onPressed: () => Navigator.pop(context),
               child: Text(
                 L10n.of(context).no,
               ),
@@ -276,7 +282,7 @@ class _CreateSuperInviteTokenPageConsumerState
             ActerDangerActionButton(
               key: CreateSuperInviteTokenPage.deleteConfirm,
               onPressed: () async {
-                ctx.pop(true);
+                Navigator.pop(context, true);
               },
               child: Text(
                 L10n.of(context).delete,
@@ -299,7 +305,7 @@ class _CreateSuperInviteTokenPageConsumerState
       ref.invalidate(superInvitesTokensProvider);
       EasyLoading.dismiss();
       if (!context.mounted) return;
-      Navigator.of(context, rootNavigator: true).pop(); // pop the create sheet
+      Navigator.pop(context); // pop the create sheet
     } catch (err) {
       if (!context.mounted) {
         EasyLoading.dismiss();

--- a/app/lib/features/tasks/pages/task_item_detail_page.dart
+++ b/app/lib/features/tasks/pages/task_item_detail_page.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
+import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
-import 'package:acter/common/widgets/redact_content.dart';
 import 'package:acter/common/widgets/render_html.dart';
 import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
@@ -144,20 +144,17 @@ class TaskItemDetailPage extends ConsumerWidget {
     required WidgetRef ref,
     required Task task,
   }) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => RedactContentWidget(
-        title: L10n.of(context).deleteTaskItem,
-        onSuccess: () {
-          ref.invalidate(taskItemsListProvider);
-          ref.invalidate(taskListItemProvider);
-          Navigator.pop(context);
-        },
-        eventId: task.eventIdStr(),
-        senderId: task.authorStr(),
-        roomId: task.roomIdStr(),
-        isSpace: true,
-      ),
+    openRedactContentDialog(
+      context,
+      title: L10n.of(context).deleteTaskItem,
+      onSuccess: () {
+        ref.invalidate(taskItemsListProvider);
+        ref.invalidate(taskListItemProvider);
+        Navigator.pop(context);
+      },
+      eventId: task.eventIdStr(),
+      roomId: task.roomIdStr(),
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/tasks/pages/task_item_detail_page.dart
+++ b/app/lib/features/tasks/pages/task_item_detail_page.dart
@@ -151,7 +151,7 @@ class TaskItemDetailPage extends ConsumerWidget {
         onSuccess: () {
           ref.invalidate(taskItemsListProvider);
           ref.invalidate(taskListItemProvider);
-          Navigator.of(context, rootNavigator: true).pop();
+          Navigator.pop(context);
         },
         eventId: task.eventIdStr(),
         senderId: task.authorStr(),
@@ -168,7 +168,7 @@ class TaskItemDetailPage extends ConsumerWidget {
   }) {
     showAdaptiveDialog(
       context: context,
-      builder: (ctx) => ReportContentWidget(
+      builder: (context) => ReportContentWidget(
         title: L10n.of(context).reportTaskItem,
         description: L10n.of(context).reportThisContent,
         eventId: task.eventIdStr(),
@@ -276,7 +276,7 @@ class TaskItemDetailPage extends ConsumerWidget {
       updater.descriptionHtml(plainDescription, htmlBodyDescription);
       await updater.send();
       EasyLoading.dismiss();
-      if (context.mounted) context.closeDialog();
+      if (context.mounted) Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();
@@ -482,7 +482,7 @@ class TaskItemDetailPage extends ConsumerWidget {
       ref.invalidate(taskListProvider);
       EasyLoading.dismiss();
       if (!context.mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
     } catch (e) {
       EasyLoading.dismiss();
       if (!context.mounted) return;

--- a/app/lib/features/tasks/pages/task_item_detail_page.dart
+++ b/app/lib/features/tasks/pages/task_item_detail_page.dart
@@ -7,7 +7,7 @@ import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/render_html.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
@@ -163,16 +163,14 @@ class TaskItemDetailPage extends ConsumerWidget {
     required BuildContext context,
     required Task task,
   }) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => ReportContentWidget(
-        title: L10n.of(context).reportTaskItem,
-        description: L10n.of(context).reportThisContent,
-        eventId: task.eventIdStr(),
-        senderId: task.authorStr(),
-        roomId: task.roomIdStr(),
-        isSpace: true,
-      ),
+    openReportContentDialog(
+      context,
+      title: L10n.of(context).reportTaskItem,
+      description: L10n.of(context).reportThisContent,
+      eventId: task.eventIdStr(),
+      senderId: task.authorStr(),
+      roomId: task.roomIdStr(),
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/tasks/pages/task_list_details_page.dart
+++ b/app/lib/features/tasks/pages/task_list_details_page.dart
@@ -1,6 +1,6 @@
+import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
-import 'package:acter/common/widgets/redact_content.dart';
 import 'package:acter/common/widgets/render_html.dart';
 import 'package:acter/common/widgets/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
@@ -101,16 +101,13 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
 
   // Redact Task List Dialog
   void showRedactDialog({required TaskList taskList}) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => RedactContentWidget(
-        title: L10n.of(context).deleteTaskList,
-        onSuccess: () => Navigator.pop(context),
-        eventId: taskList.eventIdStr(),
-        senderId: taskList.role() ?? '',
-        roomId: taskList.spaceIdStr(),
-        isSpace: true,
-      ),
+    openRedactContentDialog(
+      context,
+      title: L10n.of(context).deleteTaskList,
+      onSuccess: () => Navigator.pop(context),
+      eventId: taskList.eventIdStr(),
+      roomId: taskList.spaceIdStr(),
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/tasks/pages/task_list_details_page.dart
+++ b/app/lib/features/tasks/pages/task_list_details_page.dart
@@ -2,7 +2,7 @@ import 'package:acter/common/actions/redact_content.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/render_html.dart';
-import 'package:acter/common/widgets/report_content.dart';
+import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
@@ -113,16 +113,14 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
 
   // Report Task List Dialog
   void showReportDialog(TaskList taskList) {
-    showAdaptiveDialog(
-      context: context,
-      builder: (context) => ReportContentWidget(
-        title: L10n.of(context).reportTaskList,
-        description: L10n.of(context).reportThisContent,
-        eventId: taskList.eventIdStr(),
-        senderId: taskList.role() ?? '',
-        roomId: taskList.spaceIdStr(),
-        isSpace: true,
-      ),
+    openReportContentDialog(
+      context,
+      title: L10n.of(context).reportTaskList,
+      description: L10n.of(context).reportThisContent,
+      eventId: taskList.eventIdStr(),
+      senderId: taskList.role() ?? '',
+      roomId: taskList.spaceIdStr(),
+      isSpace: true,
     );
   }
 

--- a/app/lib/features/tasks/pages/task_list_details_page.dart
+++ b/app/lib/features/tasks/pages/task_list_details_page.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/redact_content.dart';
@@ -106,7 +105,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
       context: context,
       builder: (context) => RedactContentWidget(
         title: L10n.of(context).deleteTaskList,
-        onSuccess: () => Navigator.of(context, rootNavigator: true).pop(),
+        onSuccess: () => Navigator.pop(context),
         eventId: taskList.eventIdStr(),
         senderId: taskList.role() ?? '',
         roomId: taskList.spaceIdStr(),
@@ -119,7 +118,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
   void showReportDialog(TaskList taskList) {
     showAdaptiveDialog(
       context: context,
-      builder: (ctx) => ReportContentWidget(
+      builder: (context) => ReportContentWidget(
         title: L10n.of(context).reportTaskList,
         description: L10n.of(context).reportThisContent,
         eventId: taskList.eventIdStr(),
@@ -207,7 +206,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
       updater.descriptionHtml(plainDescription, htmlBodyDescription);
       await updater.send();
       EasyLoading.dismiss();
-      if (mounted) context.closeDialog();
+      if (mounted) Navigator.pop(context);
     } catch (e, st) {
       _log.severe('Failed to update event description', e, st);
       EasyLoading.dismiss();
@@ -293,7 +292,7 @@ class _TaskListPageState extends ConsumerState<TaskListDetailPage> {
           ref.invalidate(taskListProvider);
           EasyLoading.dismiss();
           if (!context.mounted) return;
-          context.closeDialog();
+          Navigator.pop(context);
         } catch (e) {
           EasyLoading.dismiss();
           if (!context.mounted) return;

--- a/app/lib/features/tasks/sheets/create_update_task_item.dart
+++ b/app/lib/features/tasks/sheets/create_update_task_item.dart
@@ -259,7 +259,7 @@ class _CreateUpdateItemListConsumerState
       EasyLoading.dismiss();
       if (!mounted) return;
       if (widget.cancel != null) widget.cancel!();
-      context.closeDialog();
+      Navigator.pop(context);
       ref.invalidate(taskListProvider);
     } catch (e) {
       EasyLoading.dismiss();
@@ -290,7 +290,7 @@ class _CreateUpdateItemListConsumerState
       await updater.send();
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
       ref.invalidate(taskListProvider);
     } catch (e) {
       EasyLoading.dismiss();

--- a/app/lib/features/tasks/sheets/create_update_task_list.dart
+++ b/app/lib/features/tasks/sheets/create_update_task_list.dart
@@ -1,6 +1,5 @@
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor.dart';
 import 'package:acter/common/widgets/spaces/select_space_form_field.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
@@ -202,7 +201,7 @@ class _CreateUpdateTaskListConsumerState
 
       EasyLoading.dismiss();
       if (!mounted) return;
-      context.closeDialog();
+      Navigator.pop(context);
       ref.invalidate(taskListProvider);
     } catch (e) {
       if (!mounted) {

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -95,7 +95,7 @@ List<RouteBase> makeGeneralRoutes() {
       name: Routes.bugReport.name,
       path: Routes.bugReport.route,
       pageBuilder: (context, state) => DialogPage(
-        builder: (BuildContext ctx) => BugReportPage(
+        builder: (BuildContext context) => BugReportPage(
           imagePath: state.uri.queryParameters['screenshot'],
         ),
       ),
@@ -114,7 +114,7 @@ List<RouteBase> makeGeneralRoutes() {
       name: Routes.quickJump.name,
       path: Routes.quickJump.route,
       pageBuilder: (context, state) => DialogPage(
-        builder: (BuildContext ctx) => const QuickjumpDialog(),
+        builder: (BuildContext context) => const QuickjumpDialog(),
       ),
     ),
     GoRoute(


### PR DESCRIPTION
follow up of #1986 , which lead to me more learning about how we are actually doing things wrong:

1. this removes the newly added method and replaces all usage of it and `Navigator.of(..).pop` with the more correctly used `Navigator(context).pop(...)` - which is shorter and better
2. Fixes several places where there was a confusing usage of `ctx` and `context`, ensure that `context` is always the most inner context and thus correctly pops wherever we are
3. Fixes the back-routing issue reported in that PR by kumar by putting dialogs _not_ at the rootNavigator. Specifically, outsources two commonly used ones into a single use that fixes that problem: for redactions and reporting.

Before:

https://github.com/user-attachments/assets/318d75c9-7483-4309-b313-dfe172a159eb


After:

https://github.com/user-attachments/assets/6c1cdf5c-86a7-4fd5-80a2-bf75465f923a

