### PR TITLE
Fix spaces chats screen.

### DIFF
--- a/.changes/1998-subspace.md
+++ b/.changes/1998-subspace.md
@@ -1,0 +1,1 @@
+- Fix issue in displaying chats of a space if there aren't any further to show

--- a/app/lib/features/space/pages/sub_spaces_page.dart
+++ b/app/lib/features/space/pages/sub_spaces_page.dart
@@ -6,7 +6,7 @@ import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
-import 'package:acter/features/space/widgets/related_spaces/helpers.dart';
+import 'package:acter/features/space/widgets/related/spaces_helpers.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/lib/features/space/widgets/related/chats_helpers.dart
+++ b/app/lib/features/space/widgets/related/chats_helpers.dart
@@ -7,10 +7,7 @@ import 'package:acter/router/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:logging/logging.dart';
 import 'package:skeletonizer/skeletonizer.dart';
-
-final _log = Logger('a3::space::widget::related::chat_helpers');
 
 Widget chatsListUI(WidgetRef ref, List<String> chats, int chatsLimit) {
   return ListView.builder(

--- a/app/lib/features/space/widgets/related/chats_helpers.dart
+++ b/app/lib/features/space/widgets/related/chats_helpers.dart
@@ -1,0 +1,75 @@
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/widgets/chat/convo_card.dart';
+import 'package:acter/common/widgets/chat/convo_hierarchy_card.dart';
+import 'package:acter/common/widgets/chat/loading_convo_card.dart';
+import 'package:acter/router/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:logging/logging.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+final _log = Logger('a3::space::widget::related::chat_helpers');
+
+Widget chatsListUI(WidgetRef ref, List<String> chats, int chatsLimit) {
+  return ListView.builder(
+    shrinkWrap: true,
+    itemCount: chatsLimit,
+    padding: EdgeInsets.zero,
+    physics: const NeverScrollableScrollPhysics(),
+    itemBuilder: (context, index) {
+      final roomId = chats[index];
+      return ref.watch(chatProvider(roomId)).when(
+            data: (room) => ConvoCard(
+              room: room,
+              showParents: false,
+              showSelectedIndication: false,
+              onTap: () => goToChat(context, roomId),
+            ),
+            error: (error, stack) => ListTile(
+              title: Text(roomId),
+              subtitle: Text(L10n.of(context).loadingFailed(error)),
+            ),
+            loading: () => LoadingConvoCard(roomId: roomId),
+          );
+    },
+  );
+}
+
+Widget renderFurther(
+  BuildContext context,
+  WidgetRef ref,
+  String spaceId,
+  int? maxItems,
+) {
+  final remoteChats = ref.watch(remoteChatRelationsProvider(spaceId));
+
+  return remoteChats.when(
+    data: (chats) {
+      if (chats.isEmpty) {
+        return const SizedBox.shrink();
+      }
+
+      return ListView.builder(
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: maxItems ?? chats.length,
+        itemBuilder: (context, idx) {
+          final item = chats[idx];
+          return ConvoHierarchyCard(
+            showIconIfSuggested: true,
+            parentId: spaceId,
+            roomInfo: item,
+          );
+        },
+      );
+    },
+    error: (e, s) =>
+        Card(child: Text(L10n.of(context).errorLoadingRelatedChats(e))),
+    loading: () => Skeletonizer(
+      child: Card(child: Text(L10n.of(context).loadingOtherChats)),
+    ),
+  );
+}

--- a/app/lib/features/space/widgets/related/spaces_helpers.dart
+++ b/app/lib/features/space/widgets/related/spaces_helpers.dart
@@ -9,7 +9,7 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:logging/logging.dart';
 
-final _log = Logger('a3::space::widget::related_spaces::helpers');
+final _log = Logger('a3::space::widget::related::spaces_helpers');
 
 List<Widget>? _renderKnownSubspaces(
   BuildContext context,

--- a/app/lib/features/space/widgets/space_sections/chats_section.dart
+++ b/app/lib/features/space/widgets/space_sections/chats_section.dart
@@ -1,11 +1,7 @@
-import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/widgets/chat/convo_card.dart';
-import 'package:acter/common/widgets/chat/convo_hierarchy_card.dart';
-import 'package:acter/common/widgets/chat/loading_convo_card.dart';
+import 'package:acter/features/space/widgets/related/chats_helpers.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
-import 'package:acter/router/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -85,65 +81,8 @@ class ChatsSection extends ConsumerWidget {
           ),
         ),
         chatsListUI(ref, chats, chatsLimit),
-        if (renderRemote) renderFurther(context, ref, moreCount),
+        if (renderRemote) renderFurther(context, ref, spaceId, moreCount),
       ],
-    );
-  }
-
-  Widget chatsListUI(WidgetRef ref, List<String> chats, int chatsLimit) {
-    return ListView.builder(
-      shrinkWrap: true,
-      itemCount: chatsLimit,
-      padding: EdgeInsets.zero,
-      physics: const NeverScrollableScrollPhysics(),
-      itemBuilder: (context, index) {
-        final roomId = chats[index];
-        return ref.watch(chatProvider(roomId)).when(
-              data: (room) => ConvoCard(
-                room: room,
-                showParents: false,
-                showSelectedIndication: false,
-                onTap: () => goToChat(context, roomId),
-              ),
-              error: (error, stack) => ListTile(
-                title: Text(roomId),
-                subtitle: Text(L10n.of(context).loadingFailed(error)),
-              ),
-              loading: () => LoadingConvoCard(roomId: roomId),
-            );
-      },
-    );
-  }
-
-  Widget renderFurther(BuildContext context, WidgetRef ref, int maxItems) {
-    final remoteChats = ref.watch(remoteChatRelationsProvider(spaceId));
-
-    return remoteChats.when(
-      data: (chats) {
-        if (chats.isEmpty) {
-          return const SizedBox.shrink();
-        }
-
-        return ListView.builder(
-          shrinkWrap: true,
-          padding: EdgeInsets.zero,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: maxItems,
-          itemBuilder: (context, idx) {
-            final item = chats[idx];
-            return ConvoHierarchyCard(
-              showIconIfSuggested: true,
-              parentId: spaceId,
-              roomInfo: item,
-            );
-          },
-        );
-      },
-      error: (e, s) =>
-          Card(child: Text(L10n.of(context).errorLoadingRelatedChats(e))),
-      loading: () => Skeletonizer(
-        child: Card(child: Text(L10n.of(context).loadingOtherChats)),
-      ),
     );
   }
 }

--- a/app/lib/features/space/widgets/space_sections/spaces_section.dart
+++ b/app/lib/features/space/widgets/space_sections/spaces_section.dart
@@ -1,7 +1,7 @@
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/spaces/space_card.dart';
-import 'package:acter/features/space/widgets/related_spaces/helpers.dart';
+import 'package:acter/features/space/widgets/related/spaces_helpers.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';


### PR DESCRIPTION
Follow up to #1976 :
Also fix the spaces chats screen by using the same feature as the overview widget. Reduces the usage of a custom scroll view and slivers by using the same listviews as for the overview widgets.

Fixes https://github.com/acterglobal/a3-meta/issues/422 .