### PR TITLE
Ensure we only render AnimatedList between render calls

### DIFF
--- a/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/chat_room_notifier.dart
@@ -227,7 +227,14 @@ class ChatRoomNotifier extends StateNotifier<ChatRoomState> {
 
   // fetch original content media for reply msg, i.e. text/image/file etc.
   Future<void> fetchOriginalContent(String originalId, String replyId) async {
-    final roomMsg = await timeline.getMessage(originalId);
+    RoomMessage roomMsg;
+    try {
+      roomMsg = await timeline.getMessage(originalId);
+    } catch (error, stack) {
+      _log.severe('Failing to load reference $replyId (from $originalId)',
+          error, stack,);
+      return;
+    }
 
     // reply is allowed for only EventItem not VirtualItem
     // user should be able to get original event as RoomMessage

--- a/app/lib/features/chat/widgets/chats_list.dart
+++ b/app/lib/features/chat/widgets/chats_list.dart
@@ -134,25 +134,27 @@ class __AnimatedChatsListState extends State<_AnimatedChatsList> {
   }
 
   void refreshList() {
-    final diffResult = calculateListDiff<String>(
-      _currentList,
-      widget.entries,
-      detectMoves: false,
-    );
-    for (final update in diffResult.getUpdatesWithData()) {
-      update.when(
-        insert: _insert,
-        remove: _remove,
-        change: (pos, oldData, newData) {
-          _remove(pos, oldData);
-          _insert(pos, newData);
-        },
-        move: (from, to, item) {
-          _remove(from, item);
-          _insert(to, item);
-        },
+    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+      final diffResult = calculateListDiff<String>(
+        _currentList,
+        widget.entries,
+        detectMoves: false,
       );
-    }
+      for (final update in diffResult.getUpdatesWithData()) {
+        update.when(
+          insert: _insert,
+          remove: _remove,
+          change: (pos, oldData, newData) {
+            _remove(pos, oldData);
+            _insert(pos, newData);
+          },
+          move: (from, to, item) {
+            _remove(from, item);
+            _insert(to, item);
+          },
+        );
+      }
+    });
   }
 
   void _insert(int pos, String data) {


### PR DESCRIPTION
The internal problem was that we might be re-ordering items while the rendering is going on. Leading to the case where we might be breaking some internal assumptions in the Sliver-builder about the order of its children. By instead only calculating the diff and applying it between render-calls, we ensure that we aren't messing with the internal state during the render-cycle itself.

Fixes #2009 .