### PR TITLE
Chat/Spaces section calculation fixes the XIth 

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+
+name: Flutter Unit tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flutter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        name: Set up flutter
+        with:
+          channel: 'stable'
+      - name: Run flutter unit tests
+        working-directory: app
+        run: flutter test

--- a/app/lib/features/space/widgets/related/util.dart
+++ b/app/lib/features/space/widgets/related/util.dart
@@ -1,0 +1,60 @@
+class SectionConfig {
+  /// How many to show of the initial list
+  final int listingLimit;
+
+  /// Whether or not show the "show all" button
+  final bool isShowSeeAllButton;
+
+  /// whether or not to render remote entires
+  final bool renderRemote;
+
+  /// how many remote entries to render
+  final int remoteCount;
+
+  SectionConfig({
+    this.isShowSeeAllButton = false,
+    this.listingLimit = 0,
+    this.renderRemote = false,
+    this.remoteCount = 0,
+  });
+}
+
+/// Calculate the configuration for a specific space overview section
+/// for chat or space
+SectionConfig calculateSectionConfig({
+  required int localListLen,
+  required int limit,
+  required int remoteListLen,
+}) {
+  int listingLimit;
+  bool isShowSeeAllButton = false;
+  bool renderRemote = false;
+  int remoteCount;
+  // our local list is already going beyond the limits
+  if (localListLen > limit) {
+    listingLimit = limit;
+    isShowSeeAllButton = true;
+    remoteCount = 0;
+  } else {
+    // the local list is not filling the list
+    listingLimit = localListLen;
+    remoteCount = limit - localListLen;
+    if (remoteCount > 0) {
+      if (remoteListLen > 0) {
+        renderRemote = true;
+        if (remoteListLen < remoteCount) {
+          remoteCount = remoteListLen;
+        }
+        if (remoteListLen > remoteCount) {
+          isShowSeeAllButton = true;
+        }
+      }
+    }
+  }
+  return SectionConfig(
+    listingLimit: listingLimit,
+    renderRemote: renderRemote,
+    remoteCount: remoteCount,
+    isShowSeeAllButton: isShowSeeAllButton,
+  );
+}

--- a/app/lib/features/space/widgets/related/util.dart
+++ b/app/lib/features/space/widgets/related/util.dart
@@ -26,15 +26,18 @@ SectionConfig calculateSectionConfig({
   required int limit,
   required int remoteListLen,
 }) {
-  int listingLimit;
+  int listingLimit = 0;
   bool isShowSeeAllButton = false;
   bool renderRemote = false;
-  int remoteCount;
+  int remoteCount = 0;
   // our local list is already going beyond the limits
   if (localListLen > limit) {
     listingLimit = limit;
     isShowSeeAllButton = true;
-    remoteCount = 0;
+  } else if (localListLen == limit) {
+    // locally fills the list
+    listingLimit = limit;
+    isShowSeeAllButton = remoteListLen > 0;
   } else {
     // the local list is not filling the list
     listingLimit = localListLen;

--- a/app/lib/features/space/widgets/space_sections/chats_section.dart
+++ b/app/lib/features/space/widgets/space_sections/chats_section.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/space/widgets/related/chats_helpers.dart';
+import 'package:acter/features/space/widgets/related/util.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -42,46 +43,33 @@ class ChatsSection extends ConsumerWidget {
     WidgetRef ref,
     List<String> chats,
   ) {
-    int chatsLimit;
-    bool isShowSeeAllButton = false;
-    bool renderRemote = false;
-    int moreCount;
-    if (chats.length > limit) {
-      chatsLimit = limit;
-      isShowSeeAllButton = true;
-      moreCount = 0;
-    } else {
-      chatsLimit = chats.length;
-      moreCount = limit - chats.length;
-      if (moreCount > 0) {
-        final remoteCount =
-            (ref.watch(remoteChatRelationsProvider(spaceId)).valueOrNull ?? [])
-                .length;
-        if (remoteCount > 0) {
-          renderRemote = true;
-          if (remoteCount < moreCount) {
-            moreCount = remoteCount;
-          }
-          if (remoteCount > moreCount) {
-            isShowSeeAllButton = true;
-          }
-        }
-      }
-    }
+    final config = calculateSectionConfig(
+      localListLen: chats.length,
+      limit: limit,
+      remoteListLen:
+          (ref.watch(remoteChatRelationsProvider(spaceId)).valueOrNull ?? [])
+              .length,
+    );
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SectionHeader(
           title: L10n.of(context).chats,
-          isShowSeeAllButton: isShowSeeAllButton,
+          isShowSeeAllButton: config.isShowSeeAllButton,
           onTapSeeAll: () => context.pushNamed(
             Routes.spaceChats.name,
             pathParameters: {'spaceId': spaceId},
           ),
         ),
-        chatsListUI(ref, chats, chatsLimit),
-        if (renderRemote) renderFurther(context, ref, spaceId, moreCount),
+        chatsListUI(ref, chats, config.listingLimit),
+        if (config.renderRemote)
+          renderFurther(
+            context,
+            ref,
+            spaceId,
+            config.remoteCount,
+          ),
       ],
     );
   }

--- a/app/lib/features/space/widgets/space_sections/spaces_section.dart
+++ b/app/lib/features/space/widgets/space_sections/spaces_section.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/spaces/space_card.dart';
 import 'package:acter/features/space/widgets/related/spaces_helpers.dart';
+import 'package:acter/features/space/widgets/related/util.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -40,53 +41,33 @@ class SpacesSection extends ConsumerWidget {
     WidgetRef ref,
     List<String> spaces,
   ) {
-    int spacesLimit;
-    bool isShowSeeAllButton = false;
-    bool renderRemote = false;
-    int moreCount;
-    if (spaces.length > limit) {
-      spacesLimit = limit;
-      isShowSeeAllButton = true;
-      moreCount = 0;
-    } else {
-      spacesLimit = spaces.length;
-      moreCount = limit - spaces.length;
-      if (moreCount > 0) {
-        // we have space for more
-        final remoteCount =
-            (ref.watch(remoteSubspaceRelationsProvider(spaceId)).valueOrNull ??
-                    [])
-                .length;
-        if (remoteCount > 0) {
-          renderRemote = true;
-          if (remoteCount < moreCount) {
-            moreCount = remoteCount;
-          }
-          if (remoteCount > moreCount) {
-            isShowSeeAllButton = true;
-          }
-        }
-      }
-    }
+    final config = calculateSectionConfig(
+      localListLen: spaces.length,
+      limit: limit,
+      remoteListLen:
+          (ref.watch(remoteSubspaceRelationsProvider(spaceId)).valueOrNull ??
+                  [])
+              .length,
+    );
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SectionHeader(
           title: L10n.of(context).spaces,
-          isShowSeeAllButton: isShowSeeAllButton,
+          isShowSeeAllButton: config.isShowSeeAllButton,
           onTapSeeAll: () => context.pushNamed(
             Routes.spaceRelatedSpaces.name,
             pathParameters: {'spaceId': spaceId},
           ),
         ),
-        spacesListUI(spaces, spacesLimit),
-        if (renderRemote)
+        spacesListUI(spaces, config.listingLimit),
+        if (config.renderRemote)
           renderMoreSubspaces(
             context,
             ref,
             spaceId,
-            maxLength: moreCount,
+            maxLength: config.remoteCount,
             padding: EdgeInsets.zero,
           ),
       ],

--- a/app/test/features/spaces/space_section_calculator_tests.dart
+++ b/app/test/features/spaces/space_section_calculator_tests.dart
@@ -1,0 +1,71 @@
+import 'package:acter/features/space/widgets/related/util.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Related Widget Calculations', () {
+    test('too many local', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 5,
+        remoteListLen: 0,
+      );
+
+      assert(config.listingLimit == 3, 'Wrong listing limit');
+      assert(config.isShowSeeAllButton, 'Wrong show all');
+      assert(!config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 0, 'Wrong remote count');
+    });
+
+    test('none local, more remote', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 0,
+        remoteListLen: 5,
+      );
+
+      assert(config.listingLimit == 0, 'Wrong listing limit');
+      assert(config.isShowSeeAllButton, 'Wrong show all');
+      assert(config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 3, 'Wrong remote count');
+    });
+
+    test('less local, fill remote', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 2,
+        remoteListLen: 1,
+      );
+
+      assert(config.listingLimit == 2, 'Wrong listing limit');
+      assert(!config.isShowSeeAllButton, 'Wrong show all');
+      assert(config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 1, 'Wrong remote count');
+    });
+
+    test('less local, fill remote with more', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 1,
+        remoteListLen: 4,
+      );
+
+      assert(config.listingLimit == 1, 'Wrong listing limit');
+      assert(config.isShowSeeAllButton, 'Wrong show all');
+      assert(config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 2, 'Wrong remote count');
+    });
+
+    test('exact local, more remote', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 3,
+        remoteListLen: 4,
+      );
+
+      assert(config.listingLimit == 3, 'Wrong listing limit');
+      assert(config.isShowSeeAllButton, 'Wrong show all');
+      assert(!config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 0, 'Wrong remote count');
+    });
+  });
+}

--- a/app/test/features/spaces/space_section_calculator_tests.dart
+++ b/app/test/features/spaces/space_section_calculator_tests.dart
@@ -67,5 +67,18 @@ void main() {
       assert(!config.renderRemote, 'Wrong render remote');
       assert(config.remoteCount == 0, 'Wrong remote count');
     });
+
+    test('exact local, none remote', () {
+      final config = calculateSectionConfig(
+        limit: 3,
+        localListLen: 3,
+        remoteListLen: 0,
+      );
+
+      assert(config.listingLimit == 3, 'Wrong listing limit');
+      assert(!config.isShowSeeAllButton, 'Wrong show all');
+      assert(!config.renderRemote, 'Wrong render remote');
+      assert(config.remoteCount == 0, 'Wrong remote count');
+    });
   });
 }


### PR DESCRIPTION
Okay, I had it now. Another weird edge case of the [chats/spaces section in the overview not behaving properly](https://github.com/acterglobal/a3-meta/issues/435). Screws this, I am adding tests!

This brings:
1. a refactor of the complex code to calculate the configuration of a space/chat section into its own helper function, reused in both sections: 796604e083f7d04e158cced5af60382454104742
2. tests for that helper function: 796604e083f7d04e158cced5af60382454104742
3. a new tests that shows that bug and then a fix to it, as its own commit 796604e083f7d04e158cced5af60382454104742
4. running `flutter tests` for unit tests in `app` as a CI job 56b45f3cebd2f1e006f4682d55106acaebceb37a

Note: the CI is currently failing due to other old test not passing. I'll put that and some other clean up into a follow up.