### PR TITLE
Bookmarking events and generic features

### DIFF
--- a/app/lib/features/bookmarks/actions/bookmarking.dart
+++ b/app/lib/features/bookmarks/actions/bookmarking.dart
@@ -1,20 +1,19 @@
 import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:acter/features/bookmarks/types.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 Future<bool> bookmark({
   required WidgetRef ref,
-  required String key,
-  required id,
+  required Bookmarker bookmarker,
 }) async {
   final manager = await ref.read(bookmarksManagerProvider.future);
-  return await manager.add(key, id);
+  return await manager.add(bookmarker.type.name, bookmarker.id);
 }
 
 Future<bool> unbookmark({
   required WidgetRef ref,
-  required String key,
-  required id,
+  required Bookmarker bookmarker,
 }) async {
   final manager = await ref.read(bookmarksManagerProvider.future);
-  return await manager.remove(key, id);
+  return await manager.remove(bookmarker.type.name, bookmarker.id);
 }

--- a/app/lib/features/bookmarks/actions/bookmarking.dart
+++ b/app/lib/features/bookmarks/actions/bookmarking.dart
@@ -1,0 +1,20 @@
+import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<bool> bookmark({
+  required WidgetRef ref,
+  required String key,
+  required id,
+}) async {
+  final manager = await ref.read(bookmarksManagerProvider.future);
+  return await manager.add(key, id);
+}
+
+Future<bool> unbookmark({
+  required WidgetRef ref,
+  required String key,
+  required id,
+}) async {
+  final manager = await ref.read(bookmarksManagerProvider.future);
+  return await manager.remove(key, id);
+}

--- a/app/lib/features/bookmarks/providers/bookmarks_provider.dart
+++ b/app/lib/features/bookmarks/providers/bookmarks_provider.dart
@@ -1,0 +1,22 @@
+import 'package:acter/features/bookmarks/providers/notifiers.dart';
+import 'package:acter/features/bookmarks/types.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final bookmarksManagerProvider =
+    AsyncNotifierProvider<BookmarksManagerNotifier, Bookmarks>(
+  () => BookmarksManagerNotifier(),
+);
+
+final bookmarkByKeyProvider =
+    FutureProvider.family<List<String>, String>((ref, key) async {
+  final bookmarks = await ref.watch(bookmarksManagerProvider.future);
+  return (bookmarks.entries(key)).map((s) => s.toDartString()).toList();
+});
+
+final isBookmarkedProvider =
+    StateProvider.family<bool, Bookmarker>((ref, query) {
+  final bookmarks =
+      ref.watch(bookmarkByKeyProvider(query.type)).valueOrNull ?? [];
+  return bookmarks.contains(query.id);
+});

--- a/app/lib/features/bookmarks/providers/bookmarks_provider.dart
+++ b/app/lib/features/bookmarks/providers/bookmarks_provider.dart
@@ -8,15 +8,15 @@ final bookmarksManagerProvider =
   () => BookmarksManagerNotifier(),
 );
 
-final bookmarkByKeyProvider =
-    FutureProvider.family<List<String>, String>((ref, key) async {
+final bookmarkByTypeProvider =
+    FutureProvider.family<List<String>, BookmarkType>((ref, type) async {
   final bookmarks = await ref.watch(bookmarksManagerProvider.future);
-  return (bookmarks.entries(key)).map((s) => s.toDartString()).toList();
+  return (bookmarks.entries(type.name)).map((s) => s.toDartString()).toList();
 });
 
 final isBookmarkedProvider =
-    StateProvider.family<bool, Bookmarker>((ref, query) {
+    StateProvider.family<bool, Bookmarker>((ref, bookmarker) {
   final bookmarks =
-      ref.watch(bookmarkByKeyProvider(query.type)).valueOrNull ?? [];
-  return bookmarks.contains(query.id);
+      ref.watch(bookmarkByTypeProvider(bookmarker.type)).valueOrNull ?? [];
+  return bookmarks.contains(bookmarker.id);
 });

--- a/app/lib/features/bookmarks/providers/notifiers.dart
+++ b/app/lib/features/bookmarks/providers/notifiers.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
+import 'package:riverpod/riverpod.dart';
+
+class BookmarksManagerNotifier extends AsyncNotifier<ffi.Bookmarks> {
+  late Stream<bool> _listener;
+
+  Future<ffi.Bookmarks> _getBookmarkManager() async {
+    final account = ref.read(accountProvider);
+    return await account.bookmarks();
+  }
+
+  @override
+  Future<ffi.Bookmarks> build() async {
+    final client = ref.watch(alwaysClientProvider);
+
+    _listener = client.subscribeStream('global.acter.bookmarks');
+
+    _listener.forEach((e) async {
+      state = await AsyncValue.guard(_getBookmarkManager);
+    });
+    return await _getBookmarkManager();
+  }
+}

--- a/app/lib/features/bookmarks/types.dart
+++ b/app/lib/features/bookmarks/types.dart
@@ -1,1 +1,22 @@
-typedef Bookmarker = ({String type, String id});
+typedef Bookmarker = ({BookmarkType type, String id});
+
+// referencing the inner type
+enum BookmarkType {
+  events,
+  pins,
+  // ignore: constant_identifier_names
+  task_lists,
+  tasks,
+  news;
+
+  static Bookmarker forEvent(String id) =>
+      (type: BookmarkType.events, id: id);
+  static Bookmarker forNewsEntry(String id) =>
+      (type: BookmarkType.news, id: id);
+  static Bookmarker forTaskList(String id) =>
+      (type: BookmarkType.task_lists, id: id);
+  static Bookmarker forTask(String id) =>
+      (type: BookmarkType.tasks, id: id);
+  static Bookmarker forPins(String id) =>
+      (type: BookmarkType.pins, id: id);
+}

--- a/app/lib/features/bookmarks/types.dart
+++ b/app/lib/features/bookmarks/types.dart
@@ -1,0 +1,1 @@
+typedef Bookmarker = ({String type, String id});

--- a/app/lib/features/bookmarks/widgets/bookmark_action.dart
+++ b/app/lib/features/bookmarks/widgets/bookmark_action.dart
@@ -1,31 +1,30 @@
 import 'package:acter/features/bookmarks/actions/bookmarking.dart';
 import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:acter/features/bookmarks/types.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class BookmarkAction extends ConsumerWidget {
-  final String type;
-  final String id;
+  final Bookmarker bookmarker;
   const BookmarkAction({
     super.key,
-    required this.type,
-    required this.id,
+    required this.bookmarker,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isBookmarked = ref.watch(isBookmarkedProvider((type: type, id: id)));
+    final isBookmarked = ref.watch(isBookmarkedProvider(bookmarker));
 
     if (isBookmarked) {
       return IconButton(
-        onPressed: () => unbookmark(ref: ref, key: type, id: id),
+        onPressed: () => unbookmark(ref: ref, bookmarker: bookmarker),
         icon: const Icon(Icons.bookmark),
       );
     }
 
     return IconButton(
       icon: const Icon(Icons.bookmark_border),
-      onPressed: () async => bookmark(id: id, ref: ref, key: type),
+      onPressed: () async => bookmark(ref: ref, bookmarker: bookmarker),
     );
   }
 }

--- a/app/lib/features/bookmarks/widgets/bookmark_action.dart
+++ b/app/lib/features/bookmarks/widgets/bookmark_action.dart
@@ -1,0 +1,31 @@
+import 'package:acter/features/bookmarks/actions/bookmarking.dart';
+import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class BookmarkAction extends ConsumerWidget {
+  final String type;
+  final String id;
+  const BookmarkAction({
+    super.key,
+    required this.type,
+    required this.id,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isBookmarked = ref.watch(isBookmarkedProvider((type: type, id: id)));
+
+    if (isBookmarked) {
+      return IconButton(
+        onPressed: () => unbookmark(ref: ref, key: type, id: id),
+        icon: const Icon(Icons.bookmark),
+      );
+    }
+
+    return IconButton(
+      icon: const Icon(Icons.bookmark_border),
+      onPressed: () async => bookmark(id: id, ref: ref, key: type),
+    );
+  }
+}

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/render_html.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
+import 'package:acter/features/bookmarks/widgets/bookmark_action.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/events/event_utils/event_utils.dart';
 import 'package:acter/features/events/model/keys.dart';
@@ -87,6 +88,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       pinned: true,
       actions: [
         _buildShareAction(calendarEvent),
+        BookmarkAction(type: 'event', id: widget.calendarId),
         _buildActionMenu(calendarEvent),
       ],
       flexibleSpace: Container(

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
 import 'package:acter/common/widgets/render_html.dart';
 import 'package:acter/features/attachments/widgets/attachment_section.dart';
+import 'package:acter/features/bookmarks/types.dart';
 import 'package:acter/features/bookmarks/widgets/bookmark_action.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
 import 'package:acter/features/events/event_utils/event_utils.dart';
@@ -88,7 +89,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       pinned: true,
       actions: [
         _buildShareAction(calendarEvent),
-        BookmarkAction(type: 'event', id: widget.calendarId),
+        BookmarkAction(bookmarker: BookmarkType.forEvent(widget.calendarId)),
         _buildActionMenu(calendarEvent),
       ],
       flexibleSpace: Container(


### PR DESCRIPTION
@kumarpalsinh25 as you wanted: the riverpod infrastructure (and a widget) for bookmarking.

This is what is does/looks like (right now).

https://github.com/user-attachments/assets/6eef6d31-438d-472f-80be-fd5bfe2ae1bc

Only implemented the toggle and for events only at the moment. Though the provider should make clear how to get a full list per type (`event`, `pins`, etc) and the toggle widget should work everywhere essentially.