### PR TITLE
Relations after interactions

### DIFF
--- a/.changes/2037-spaces-relations.md
+++ b/.changes/2037-spaces-relations.md
@@ -1,0 +1,1 @@
+- Fix on showing the relations of spaces and chats properly if you've left any of the rooms

--- a/app/lib/common/providers/room_providers.dart
+++ b/app/lib/common/providers/room_providers.dart
@@ -7,7 +7,6 @@ import 'package:acter/common/models/types.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/notifiers/room_notifiers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
-import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -202,13 +201,6 @@ final joinRulesAllowedRoomsProvider = FutureProvider.autoDispose
     return [];
   }
   return room.restrictedRoomIdsStr().map((e) => e.toDartString()).toList();
-});
-
-/// The list of suggested RoomIDs
-final suggestedRelationsIdsProvider =
-    FutureProvider.family<List<String>, String>((ref, spaceId) async {
-  return (await ref.watch(spaceRelationsOverviewProvider(spaceId).future))
-      .suggestedIds;
 });
 
 /// Get the user's membership for a specific space based off the roomId

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -240,10 +240,14 @@ final spaceRelationsOverviewProvider =
     if (related.suggested()) {
       suggested.add(roomId);
     }
-    if (targetType == 'Unknown') {
-      // this one is not found locally
+    final room = ref.watch(maybeRoomProvider(roomId)).valueOrNull;
+    if (room == null || !room.isJoined()) {
+      // we don't know this room or are not in it
       hasMore = true;
-    } else if (targetType == 'ChatRoom') {
+      continue;
+    }
+
+    if (targetType == 'ChatRoom') {
       // we know this as a chat room
       knownChats.add(roomId);
     } else {

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -306,7 +306,7 @@ final hasSubSpacesProvider =
   () => HasSubSpacesNotifier(),
 );
 
-final _spaceRemoteRelationsProvider =
+final spaceRemoteRelationsProvider =
     FutureProvider.family<List<SpaceHierarchyRoomInfo>, String>(
         (ref, spaceId) async {
   final relatedSpaces = await ref.watch(spaceRelationsProvider(spaceId).future);
@@ -324,7 +324,7 @@ final remoteChatRelationsProvider =
         await ref.watch(spaceRelationsOverviewProvider(spaceId).future);
     final toIgnore = relatedSpaces.knownChats.toList();
     final roomHierarchy =
-        await ref.watch(_spaceRemoteRelationsProvider(spaceId).future);
+        await ref.watch(spaceRemoteRelationsProvider(spaceId).future);
     // filter out the known rooms
     return roomHierarchy
         .where((r) => !r.isSpace() && !toIgnore.contains(r.roomIdStr()))
@@ -348,7 +348,7 @@ final remoteSubspaceRelationsProvider =
     toIgnore.add(spaceId); // the hierarchy also gives us ourselfes ...
 
     final roomHierarchy =
-        await ref.watch(_spaceRemoteRelationsProvider(spaceId).future);
+        await ref.watch(spaceRemoteRelationsProvider(spaceId).future);
     // filter out the known rooms
     return roomHierarchy
         .where((r) => r.isSpace() && !toIgnore.contains(r.roomIdStr()))

--- a/app/lib/common/widgets/chat/convo_hierarchy_card.dart
+++ b/app/lib/common/widgets/chat/convo_hierarchy_card.dart
@@ -132,7 +132,8 @@ class ConvoHierarchyCard extends ConsumerWidget {
                 forward: (roomId) {
                   goToChat(context, roomId);
                   // make sure the UI refreshes when the user comes back here
-                  ref.invalidate(spaceRelationsOverviewProvider(parentId));
+                  ref.invalidate(spaceRelationsProvider(parentId));
+                  ref.invalidate(spaceRemoteRelationsProvider(parentId));
                 },
               ),
               RoomHierarchyOptionsMenu(

--- a/app/lib/common/widgets/room/room_hierarchy_join_button.dart
+++ b/app/lib/common/widgets/room/room_hierarchy_join_button.dart
@@ -23,7 +23,7 @@ class RoomHierarchyJoinButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final maybeRoom = ref.watch(maybeRoomProvider(roomId)).valueOrNull;
-    if (maybeRoom != null) {
+    if (maybeRoom != null && maybeRoom.isJoined()) {
       // we know that room already \o/
       return OutlinedButton(
         onPressed: () => forward(roomId),

--- a/app/lib/common/widgets/spaces/space_hierarchy_card.dart
+++ b/app/lib/common/widgets/spaces/space_hierarchy_card.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/widgets/room/room_hierarchy_join_button.dart';
 import 'package:acter/common/widgets/room/room_hierarchy_options_menu.dart';
 
@@ -140,6 +141,7 @@ class SpaceHierarchyCard extends ConsumerWidget {
                 forward: (spaceId) {
                   goToSpace(context, spaceId);
                   ref.invalidate(spaceRelationsProvider(parentId));
+                  ref.invalidate(spaceRemoteRelationsProvider(parentId));
                 },
               ),
               RoomHierarchyOptionsMenu(

--- a/app/lib/features/chat/actions/create_chat.dart
+++ b/app/lib/features/chat/actions/create_chat.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
@@ -52,7 +53,8 @@ Future<String?> createChat(
       final space = await ref.read(spaceProvider(parentId).future);
       await space.addChildRoom(roomIdStr, suggested);
       // spaceRelations come from the server and must be manually invalidated
-      ref.invalidate(spaceRelationsOverviewProvider(parentId));
+      ref.invalidate(spaceRelationsProvider(parentId));
+      ref.invalidate(spaceRemoteRelationsProvider(parentId));
     }
     return roomIdStr;
   } catch (e) {

--- a/app/lib/features/chat/pages/room_profile_page.dart
+++ b/app/lib/features/chat/pages/room_profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/actions/close_room.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -507,6 +508,7 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
     Navigator.pop(context);
     EasyLoading.show(status: L10n.of(context).leavingRoom);
     try {
+      final parentIds = await ref.read(parentIdsProvider(widget.roomId).future);
       final convo = await ref.read(chatProvider(widget.roomId).future);
       if (convo == null) {
         throw RoomNotFound();
@@ -515,6 +517,11 @@ class _RoomProfilePageState extends ConsumerState<RoomProfilePage> {
       if (!mounted) {
         EasyLoading.dismiss();
         return;
+      }
+
+      for (final parentId in parentIds) {
+        ref.invalidate(spaceRelationsProvider(parentId));
+        ref.invalidate(spaceRemoteRelationsProvider(parentId));
       }
       if (res) {
         EasyLoading.dismiss();

--- a/app/lib/features/room/actions/join_room.dart
+++ b/app/lib/features/room/actions/join_room.dart
@@ -15,8 +15,8 @@ Future<String?> joinRoom(
   EasyLoading.show(status: displayMsg);
   final client = ref.read(alwaysClientProvider);
   try {
-    final newSpace = await client.joinSpace(roomIdOrAlias, server);
-    final roomId = newSpace.getRoomIdStr();
+    final newRoom = await client.joinRoom(roomIdOrAlias, server);
+    final roomId = newRoom.roomIdStr();
     EasyLoading.dismiss();
     if (forward != null) forward(roomId);
     return roomId;

--- a/app/lib/features/room/actions/join_room.dart
+++ b/app/lib/features/room/actions/join_room.dart
@@ -1,4 +1,6 @@
+import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -21,8 +23,10 @@ Future<String?> joinRoom(
     EasyLoading.dismiss();
     // ensure we re-evaluate the room data on our end. This is necessary
     // if we knew of the room prior (e.g. we had left it), but hadn't joined
-    // this should properly re-evaluate
+    // this should properly re-evaluate all possible readers
     ref.invalidate(maybeRoomProvider(roomId));
+    ref.invalidate(chatProvider(roomId));
+    ref.invalidate(spaceProvider(roomId));
     if (forward != null) forward(roomId);
     return roomId;
   } catch (err) {

--- a/app/lib/features/room/actions/join_room.dart
+++ b/app/lib/features/room/actions/join_room.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -18,6 +19,10 @@ Future<String?> joinRoom(
     final newRoom = await client.joinRoom(roomIdOrAlias, server);
     final roomId = newRoom.roomIdStr();
     EasyLoading.dismiss();
+    // ensure we re-evaluate the room data on our end. This is necessary
+    // if we knew of the room prior (e.g. we had left it), but hadn't joined
+    // this should properly re-evaluate
+    ref.invalidate(maybeRoomProvider(roomId));
     if (forward != null) forward(roomId);
     return roomId;
   } catch (err) {

--- a/app/lib/features/space/actions/unlink_child_room.dart
+++ b/app/lib/features/space/actions/unlink_child_room.dart
@@ -23,5 +23,6 @@ Future<void> unlinkChildRoom(
     await room.removeParentRoom(parentId, reason);
   }
   // spaceRelations come from the server and must be manually invalidated
-  ref.invalidate(spaceRelationsOverviewProvider(parentId));
+  ref.invalidate(spaceRelationsProvider(parentId));
+  ref.invalidate(spaceRemoteRelationsProvider(parentId));
 }

--- a/app/lib/features/space/dialogs/leave_space.dart
+++ b/app/lib/features/space/dialogs/leave_space.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
@@ -47,12 +48,18 @@ void showLeaveSpaceDialog(
             final lang = L10n.of(context);
             try {
               EasyLoading.show(status: lang.leavingSpace);
+              final parentIds =
+                  await ref.read(parentIdsProvider(spaceId).future);
               final space = await ref.read(spaceProvider(spaceId).future);
               await space.leave();
               if (!context.mounted) {
                 return;
               }
               EasyLoading.showToast(lang.leavingSpaceSuccessful);
+              for (final parentId in parentIds) {
+                ref.invalidate(spaceRelationsProvider(parentId));
+                ref.invalidate(spaceRemoteRelationsProvider(parentId));
+              }
               Navigator.pop(context);
               context.goNamed(Routes.dashboard.name);
             } catch (error, stack) {

--- a/app/lib/features/space/sheets/link_room_sheet.dart
+++ b/app/lib/features/space/sheets/link_room_sheet.dart
@@ -413,7 +413,8 @@ class _LinkRoomPageConsumerState extends ConsumerState<LinkRoomPage> {
       childRoomsIds.add(roomId);
     }
     // spaceRelations come from the server and must be manually invalidated
-    ref.invalidate(spaceRelationsOverviewProvider(selectedParentSpaceId));
+    ref.invalidate(spaceRelationsProvider(selectedParentSpaceId));
+    ref.invalidate(spaceRemoteRelationsProvider(selectedParentSpaceId));
   }
 
 //Unlink child room

--- a/app/lib/features/spaces/actions/create_space.dart
+++ b/app/lib/features/spaces/actions/create_space.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -50,7 +51,8 @@ Future<String?> createSpace(
       final space = await ref.read(spaceProvider(parentRoomId).future);
       await space.addChildRoom(roomId, false);
       // spaceRelations come from the server and must be manually invalidated
-      ref.invalidate(spaceRelationsOverviewProvider(parentRoomId));
+      ref.invalidate(spaceRelationsProvider(parentRoomId));
+      ref.invalidate(spaceRemoteRelationsProvider(parentRoomId));
     }
     EasyLoading.dismiss();
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2661,11 +2661,8 @@ object Client {
     /// fires immediately with the current state of spaces
     fn spaces_stream() -> Stream<SpaceDiff>;
 
-    /// attempt to join a space
-    fn join_space(room_id_or_alias: string, server_name: Option<string>) -> Future<Result<Space>>;
-
     /// attempt to join a room
-    fn join_convo(room_id_or_alias: string, server_name: Option<string>) -> Future<Result<Convo>>;
+    fn join_room(room_id_or_alias: string, server_name: Option<string>) -> Future<Result<Room>>;
 
     /// Get the space that user belongs to
     fn space(room_id_or_alias: string) -> Future<Result<Space>>;

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -459,20 +459,6 @@ impl Client {
             .await?
     }
 
-    pub async fn join_convo(
-        &self,
-        room_id_or_alias: String,
-        server_name: Option<String>,
-    ) -> Result<Convo> {
-        let room = self
-            .join_room(
-                room_id_or_alias,
-                server_name.map(|s| vec![s]).unwrap_or_default(),
-            )
-            .await?;
-        Ok(Convo::new(self.clone(), room).await)
-    }
-
     // ***_typed fn accepts rust-typed input, not string-based one
     async fn convo_by_alias_typed(&self, room_alias: OwnedRoomAliasId) -> Result<Convo> {
         let convo = self

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -558,7 +558,7 @@ impl SpaceRelations {
                 let mut next : Option<String> = Some("".to_owned());
                 let mut rooms = Vec::new();
                 while next.is_some() {
-                    let request = assign!(get_hierarchy::v1::Request::new(room_id.clone()), { from: next.clone(), max_depth: Some(2u32.into()) });
+                    let request = assign!(get_hierarchy::v1::Request::new(room_id.clone()), { from: next.clone(), max_depth: Some(1u32.into()) });
                     let resp = c.client().send(request, None).await?;
                     if (resp.rooms.is_empty()) {
                         break; // we are done

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -728,23 +728,6 @@ impl Client {
             .await?
     }
 
-    pub async fn join_space(
-        &self,
-        room_id_or_alias: String,
-        server_name: Option<String>,
-    ) -> Result<Space> {
-        let room = self
-            .join_room(
-                room_id_or_alias,
-                server_name.map(|s| vec![s]).unwrap_or_default(),
-            )
-            .await?;
-        Ok(Space {
-            client: self.clone(),
-            inner: room,
-        })
-    }
-
     pub async fn spaces(&self) -> Result<Vec<Space>> {
         Ok(self.spaces.read().await.clone().into_iter().collect())
     }

--- a/native/core/src/spaces.rs
+++ b/native/core/src/spaces.rs
@@ -1,5 +1,5 @@
 use derive_builder::Builder;
-use matrix_sdk::room::Room;
+use matrix_sdk::{room::Room, RoomState};
 use ruma::assign;
 use ruma_client_api::room::{create_room, Visibility};
 use ruma_common::{
@@ -349,7 +349,10 @@ impl CoreClient {
             let target = ev.state_key();
             let target_type = match self.client().get_room(target) {
                 Some(child) => {
-                    if !child.is_space() {
+                    if !matches!(child.state(), RoomState::Joined) {
+                        // we count rooms we are not currently in as unknown
+                        RelationTargetType::Unknown
+                    } else if !child.is_space() {
                         RelationTargetType::ChatRoom
                     } else if is_acter_space(&child).await {
                         RelationTargetType::ActerSpace

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -11824,7 +11824,7 @@ class Api {
     return tmp7;
   }
 
-  Space? __clientJoinSpaceFuturePoll(
+  Room? __clientJoinRoomFuturePoll(
     int boxed,
     int postCobject,
     int port,
@@ -11838,7 +11838,7 @@ class Api {
     tmp1 = tmp0;
     tmp3 = tmp2;
     tmp5 = tmp4;
-    final tmp6 = _clientJoinSpaceFuturePoll(
+    final tmp6 = _clientJoinRoomFuturePoll(
       tmp1,
       tmp3,
       tmp5,
@@ -11865,56 +11865,9 @@ class Api {
       throw tmp9_0;
     }
     final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_Space");
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_Room");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp7 = Space._(this, tmp13_1);
-    return tmp7;
-  }
-
-  Convo? __clientJoinConvoFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _clientJoinConvoFuturePoll(
-      tmp1,
-      tmp3,
-      tmp5,
-    );
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 =
-          utf8.decode(tmp10_0.asTypedList(tmp11), allowMalformed: true);
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(this, tmp13_0, "drop_box_Convo");
-    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
-    final tmp7 = Convo._(this, tmp13_1);
+    final tmp7 = Room._(this, tmp13_1);
     return tmp7;
   }
 
@@ -25934,7 +25887,7 @@ class Api {
       int Function(
         int,
       )>();
-  late final _clientJoinSpacePtr = _lookup<
+  late final _clientJoinRoomPtr = _lookup<
       ffi.NativeFunction<
           ffi.IntPtr Function(
             ffi.IntPtr,
@@ -25945,33 +25898,9 @@ class Api {
             ffi.IntPtr,
             ffi.UintPtr,
             ffi.UintPtr,
-          )>>("__Client_join_space");
+          )>>("__Client_join_room");
 
-  late final _clientJoinSpace = _clientJoinSpacePtr.asFunction<
-      int Function(
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-      )>();
-  late final _clientJoinConvoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.IntPtr Function(
-            ffi.IntPtr,
-            ffi.IntPtr,
-            ffi.UintPtr,
-            ffi.UintPtr,
-            ffi.Uint8,
-            ffi.IntPtr,
-            ffi.UintPtr,
-            ffi.UintPtr,
-          )>>("__Client_join_convo");
-
-  late final _clientJoinConvo = _clientJoinConvoPtr.asFunction<
+  late final _clientJoinRoom = _clientJoinRoomPtr.asFunction<
       int Function(
         int,
         int,
@@ -30820,32 +30749,17 @@ class Api {
         int,
         int,
       )>();
-  late final _clientJoinSpaceFuturePollPtr = _lookup<
+  late final _clientJoinRoomFuturePollPtr = _lookup<
       ffi.NativeFunction<
-          _ClientJoinSpaceFuturePollReturn Function(
+          _ClientJoinRoomFuturePollReturn Function(
             ffi.IntPtr,
             ffi.IntPtr,
             ffi.Int64,
-          )>>("__Client_join_space_future_poll");
+          )>>("__Client_join_room_future_poll");
 
-  late final _clientJoinSpaceFuturePoll =
-      _clientJoinSpaceFuturePollPtr.asFunction<
-          _ClientJoinSpaceFuturePollReturn Function(
-            int,
-            int,
-            int,
-          )>();
-  late final _clientJoinConvoFuturePollPtr = _lookup<
-      ffi.NativeFunction<
-          _ClientJoinConvoFuturePollReturn Function(
-            ffi.IntPtr,
-            ffi.IntPtr,
-            ffi.Int64,
-          )>>("__Client_join_convo_future_poll");
-
-  late final _clientJoinConvoFuturePoll =
-      _clientJoinConvoFuturePollPtr.asFunction<
-          _ClientJoinConvoFuturePollReturn Function(
+  late final _clientJoinRoomFuturePoll =
+      _clientJoinRoomFuturePollPtr.asFunction<
+          _ClientJoinRoomFuturePollReturn Function(
             int,
             int,
             int,
@@ -53086,64 +53000,8 @@ class Client {
     return tmp2;
   }
 
-  /// attempt to join a space
-  Future<Space> joinSpace(
-    String roomIdOrAlias,
-    String? serverName,
-  ) {
-    final tmp1 = roomIdOrAlias;
-    final tmp5 = serverName;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    var tmp3 = 0;
-    var tmp4 = 0;
-    var tmp6 = 0;
-    var tmp8 = 0;
-    var tmp9 = 0;
-    var tmp10 = 0;
-    tmp0 = _box.borrow();
-    final tmp1_0 = utf8.encode(tmp1);
-    tmp3 = tmp1_0.length;
-
-    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
-    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
-    tmp2_1.setAll(0, tmp1_0);
-    tmp2 = tmp2_0.address;
-    tmp4 = tmp3;
-    if (tmp5 == null) {
-      tmp6 = 0;
-    } else {
-      tmp6 = 1;
-      final tmp7 = tmp5;
-      final tmp7_0 = utf8.encode(tmp7);
-      tmp9 = tmp7_0.length;
-
-      final ffi.Pointer<ffi.Uint8> tmp8_0 = _api.__allocate(tmp9 * 1, 1);
-      final Uint8List tmp8_1 = tmp8_0.asTypedList(tmp9);
-      tmp8_1.setAll(0, tmp7_0);
-      tmp8 = tmp8_0.address;
-      tmp10 = tmp9;
-    }
-    final tmp11 = _api._clientJoinSpace(
-      tmp0,
-      tmp2,
-      tmp3,
-      tmp4,
-      tmp6,
-      tmp8,
-      tmp9,
-      tmp10,
-    );
-    final tmp13 = tmp11;
-    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(_api, tmp13_0, "__Client_join_space_future_drop");
-    tmp13_1._finalizer = _api._registerFinalizer(tmp13_1);
-    final tmp12 = _nativeFuture(tmp13_1, _api.__clientJoinSpaceFuturePoll);
-    return tmp12;
-  }
-
   /// attempt to join a room
-  Future<Convo> joinConvo(
+  Future<Room> joinRoom(
     String roomIdOrAlias,
     String? serverName,
   ) {
@@ -53180,7 +53038,7 @@ class Client {
       tmp8 = tmp8_0.address;
       tmp10 = tmp9;
     }
-    final tmp11 = _api._clientJoinConvo(
+    final tmp11 = _api._clientJoinRoom(
       tmp0,
       tmp2,
       tmp3,
@@ -53192,9 +53050,9 @@ class Client {
     );
     final tmp13 = tmp11;
     final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
-    final tmp13_1 = _Box(_api, tmp13_0, "__Client_join_convo_future_drop");
+    final tmp13_1 = _Box(_api, tmp13_0, "__Client_join_room_future_drop");
     tmp13_1._finalizer = _api._registerFinalizer(tmp13_1);
-    final tmp12 = _nativeFuture(tmp13_1, _api.__clientJoinConvoFuturePoll);
+    final tmp12 = _nativeFuture(tmp13_1, _api.__clientJoinRoomFuturePoll);
     return tmp12;
   }
 
@@ -62915,22 +62773,7 @@ class _ClientSpacesFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _ClientJoinSpaceFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.IntPtr()
-  external int arg2;
-  @ffi.UintPtr()
-  external int arg3;
-  @ffi.UintPtr()
-  external int arg4;
-  @ffi.IntPtr()
-  external int arg5;
-}
-
-class _ClientJoinConvoFuturePollReturn extends ffi.Struct {
+class _ClientJoinRoomFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()


### PR DESCRIPTION
This fixes to update the appropriate relationships status when we have joined, left, rejoined, re-left any rooms that have relationships. See yourself:


https://github.com/user-attachments/assets/e2acb4ff-0aad-4dad-82d7-c447385e3e0d

and 

https://github.com/user-attachments/assets/4de023a9-34a5-486a-94f1-b018116125b4


As you can see the relationships are accurately updated.

This is done through several changes:
1. we only fetch the first level of depth... Not sure why we had to change it, 6653333fd6595fb9feaaa484e408642407ba0917
2. A simplification in room joining on the rust side, 3dbc700fbbf276380671cd2c49394d7d81eef7a3
3. accurately invalidating the approriate providers and calculating based on local knowledge, in particular checking for `isJoined` in some instances. 

Fixes https://github.com/acterglobal/a3-meta/issues/445, https://github.com/acterglobal/a3-meta/issues/349, https://github.com/acterglobal/a3-meta/issues/447, https://github.com/acterglobal/a3-meta/issues/452
