### PR TITLE
Enven support

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -33,7 +33,7 @@ on:
       targets:
         required: false
         type: string
-      flutter_build_extra:
+      env_extra:
         required: false
         type: string
 
@@ -273,6 +273,24 @@ jobs:
         working-directory: ./app/android
         run: echo "${{ secrets.ANDROID_KEYSTORE_JKS }}" | base64 --decode > key.jks
 
+      - name: Write environment
+        working-directory: ./app
+        run: |
+          cat << EOF
+          SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          SENTRY_RELEASE=${{ inputs.version }}
+          SENTRY_ENVIRONMENT=${{inputs.release_env}}
+          PUSH_SERVER=${{ secrets.PUSH_SERVER }}
+          RAGESHAKE_URL=${{ secrets.RAGESHAKE_URL }}
+          RAGESHAKE_APP_NAME=${{ secrets.RAGESHAKE_APP_NAME }}
+          RAGESHAKE_APP_VERSION=${{inputs.release_env}}/${{inputs.version}}/${{ matrix.name }}
+          DEFAULT_HOMESERVER_URL=${{vars.DEFAULT_HOMESERVER_URL}}
+          DEFAULT_HOMESERVER_NAME=${{vars.DEFAULT_HOMESERVER_NAME}}
+          ${{ inputs.env_extra  }}
+          EOF >> .env.production
+
+          dart run enven
+
       - name: Flutter Build
         env:
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
@@ -280,18 +298,8 @@ jobs:
         shell: bash
         run: |
           flutter ${{ matrix.flutter_build_args }} \
-            ${{ inputs.flutter_build_extra || '' }} \
             --build-name="${{ inputs.version }}" \
-            --build-number="${{ inputs.build_num }}" \
-            --dart-define SENTRY_DSN="${{ secrets.SENTRY_DSN }}" \
-            --dart-define SENTRY_RELEASE="${{ inputs.version }}" \
-            --dart-define SENTRY_ENVIRONMENT="${{inputs.release_env}}" \
-            --dart-define PUSH_SERVER="${{ secrets.PUSH_SERVER }}" \
-            --dart-define RAGESHAKE_URL="${{ secrets.RAGESHAKE_URL }}" \
-            --dart-define RAGESHAKE_APP_NAME="${{ secrets.RAGESHAKE_APP_NAME }}" \
-            --dart-define RAGESHAKE_APP_VERSION="${{inputs.release_env}}/${{inputs.version}}/${{ matrix.name }}" \
-            --dart-define DEFAULT_HOMESERVER_URL="${{vars.DEFAULT_HOMESERVER_URL}}" \
-            --dart-define DEFAULT_HOMESERVER_NAME="${{vars.DEFAULT_HOMESERVER_NAME}}"
+            --build-number="${{ inputs.build_num }}
         working-directory: ./app
 
            ######  ####  ######   ##    ## 

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -303,7 +303,7 @@ jobs:
         run: |
           flutter ${{ matrix.flutter_build_args }} \
             --build-name="${{ inputs.version }}" \
-            --build-number="${{ inputs.build_num }}
+            --build-number="${{ inputs.build_num }}"
         working-directory: ./app
 
            ######  ####  ######   ##    ## 

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -275,8 +275,9 @@ jobs:
 
       - name: Write environment
         working-directory: ./app
+        shell: bash
         run: |
-          cat << EOF
+          cat <<EOF > .env.production
           SENTRY_DSN=${{ secrets.SENTRY_DSN }}
           SENTRY_RELEASE=${{ inputs.version }}
           SENTRY_ENVIRONMENT=${{inputs.release_env}}
@@ -287,9 +288,12 @@ jobs:
           DEFAULT_HOMESERVER_URL=${{vars.DEFAULT_HOMESERVER_URL}}
           DEFAULT_HOMESERVER_NAME=${{vars.DEFAULT_HOMESERVER_NAME}}
           ${{ inputs.env_extra  }}
-          EOF >> .env.production
+          EOF
 
           dart run enven
+
+          echo "Show .env files"
+          ls -ltash .env*
 
       - name: Flutter Build
         env:

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -52,7 +52,7 @@ jobs:
             os: ubuntu-latest
             exclude_from_release: true
             cargo_make_setup: setup-android
-            cargo_make_args: android
+            cargo_make_args: android-arm
             with_ndk_version: r25
             java_version: "17"
             flutter_build_args: "build appbundle --split-debug-info=debug_symbols"
@@ -64,7 +64,7 @@ jobs:
             target: android
             os: ubuntu-latest
             cargo_make_setup: setup-android
-            cargo_make_args: android
+            cargo_make_args: android-arm
             with_ndk_version: r25
             java_version: "17"
             flutter_build_args: "build apk --split-per-abi --split-debug-info=debug_symbols"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
         with:
+          # Verbose setting SHA when using Pull_Request event trigger to fix #16. (For push even trigger this is not necessary.)
+          sha: ${{ github.event.pull_request.head.sha }}
           # Only return if PR is still open. (By default it returns PRs in any state.)
           filterOutClosed: true
           # Only return if PR is not in draft state. (By default it returns PRs in any state.)

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       should_run: ${{steps.PR.outputs.pr_found == 'true' && contains(steps.PR.outputs.pr_labels, 'build-demo')}}
     steps:
-      - uses: 8BitJonny/gh-get-current-pr@2.2.0
+      - uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
         with:
           # Only return if PR is still open. (By default it returns PRs in any state.)

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -68,6 +68,6 @@ jobs:
       release_env: demo
       build_num: ${{ needs.tags.outputs.build_num }}
       version: ${{ needs.tags.outputs.tag }}
-      flutter_build_extra: "--dart-define IS_DEMO=true"
+      env_extra: "IS_DEMO=true"
       targets: android,linux,ios,macos,windows-exe # skip: windows-msix
     secrets: inherit

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,6 +16,7 @@ jobs:
     name: Check legibility
     outputs:
       should_run: ${{steps.PR.outputs.pr_found == 'true' && contains(steps.PR.outputs.pr_labels, 'build-demo')}}
+      pr_num: ${{steps.PR.outputs.number}}
     steps:
       - uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
@@ -73,3 +74,21 @@ jobs:
       env_extra: "IS_DEMO=true"
       targets: android,linux,ios,macos,windows-exe # skip: windows-msix
     secrets: inherit
+
+  comment:
+    runs-on: ubuntu-latest
+    needs:
+     - run_checker
+     - tags
+     - build
+    if: ${{ needs.run_checker.outputs.should_run != 'false' }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{needs.run_checker.outputs.pr_num}},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '[Your demo build ${{ needs.tags.outputs.tag }} is ready]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)'
+            })

--- a/.github/workflows/flutter_integration_testing.yml
+++ b/.github/workflows/flutter_integration_testing.yml
@@ -21,7 +21,7 @@ jobs:
       should_run_ios: ${{steps.PR.outputs.pr_found == 'true' && contains(steps.PR.outputs.pr_labels, 'ci-test-ui-ios')}}
       should_run_android: ${{steps.PR.outputs.pr_found == 'true' && contains(steps.PR.outputs.pr_labels, 'ci-test-ui-android')}}
     steps:
-      - uses: 8BitJonny/gh-get-current-pr@2.2.0
+      - uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
         with:
           # Only return if PR is still open. (By default it returns PRs in any state.)

--- a/.github/workflows/flutter_integration_testing.yml
+++ b/.github/workflows/flutter_integration_testing.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
         with:
+          # Verbose setting SHA when using Pull_Request event trigger to fix #16. (For push even trigger this is not necessary.)
+          sha: ${{ github.event.pull_request.head.sha }}
           # Only return if PR is still open. (By default it returns PRs in any state.)
           filterOutClosed: true
           # Only return if PR is not in draft state. (By default it returns PRs in any state.)

--- a/.github/workflows/flutter_integration_testing.yml
+++ b/.github/workflows/flutter_integration_testing.yml
@@ -454,6 +454,10 @@ jobs:
             ~/.android/adb*
           key: avd-${{matrix.api_level}}
 
+      - name: Generate env
+        working-directory: ./app
+        run: dart run enven
+
       # - name: create AVD and generate snapshot for caching
       #   if: steps.avd-cache.outputs.cache-hit != 'true'
       #   uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-latest
-    name: Rust
+    name: Rust Integration Tests
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,7 @@ jobs:
       release_env: 'nightly'
       release: true
       prerelease: true
-      flutter_build_extra: "--dart-define IS_NIGHTLY=true"
+      env_extra: "IS_NIGHTLY=true"
     secrets: inherit
 
   changelog:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -37,8 +37,9 @@ jobs:
           flutter-version: '3.22'
           channel: 'stable'
 
-      - name: version
-        run: flutter --version
+      - name: Generate env
+        working-directory: ./app
+        run: dart run enven
 
       - working-directory: ${{ matrix.path }}
         run: flutter analyze 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,6 +19,9 @@ jobs:
         name: Set up flutter
         with:
           channel: 'stable'
+      - name: Generate env
+        working-directory: ./app
+        run: dart run enven
       - name: Run flutter unit tests
         working-directory: app
         run: flutter test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   flutter:
+    name: Flutter Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 target
-.env
 .env.sh
 .vscode
 .idea
@@ -13,3 +12,5 @@ native/acter/src/api_generated.rs
 native/acter/bindings.h
 native/acter/bindings.dart
 .github/assets/git-crypt-key
+app/lib/config/env.g.dart
+app/.env.*

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,17 +109,6 @@ dependencies = [
     "post-android",
 ]
 
-[tasks.android-arm]
-# build android ARM64 for actual device
-dependencies = [
-    "pre-android",
-    "android-aarch64",
-    "android-aarch64-release",
-    "post-android-aarch64",
-    "post-android",
-]
-
-
 [tasks.mock-data]
 command = "cargo"
 args = ["run", "-p", "acter-cli", "mock", "--homeserver-url",  "http://localhost:8118", "--homeserver-name", "localhost"]
@@ -420,6 +409,18 @@ script = [
     cp "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/native/${CARGO_MAKE_CRATE_CURRENT_WORKSPACE_MEMBER}/bindings.h" "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/${TARGET_PLUGIN}/ios/Classes/libacter.h"
     cp "$LIPO_LIB" "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/${TARGET_PLUGIN}/ios/$LIBNAME"
     """,
+]
+
+[tasks.android-arm]
+# Build android targets.
+dependencies = [
+    "pre-android",
+    "android-aarch64",
+    "android-aarch64-release",
+    "post-android-aarch64",
+    "android-armv7",
+    "android-armv7-release",
+    "post-android-armv7",
 ]
 
 [tasks.android]

--- a/app/.env
+++ b/app/.env
@@ -1,0 +1,144 @@
+#enven:output=lib/config/env.g.dart
+
+
+
+   ###    ########  ########  
+  ## ##   ##     ## ##     ## 
+ ##   ##  ##     ## ##     ## 
+##     ## ########  ########  
+######### ##        ##        
+##     ## ##        ##        
+##     ## ##        ##        
+
+
+#enven:const
+#enven:type=String
+DEFAULT_HOMESERVER_NAME=m-1.acter.global
+
+#enven:const
+#enven:type=String
+DEFAULT_HOMESERVER_URL=https://matrix.m-1.acter.global
+
+#enven:const
+#enven:type=String
+DEFAULT_ACTER_SESSION=sessions
+
+#enven:const
+#enven:type=String
+DEFAULT_SEARCH_SERVERS=acter.global=Acter.global,matrix.org=Matrix.org,matrixrooms.info=Global Search,the-apothecary.club=The Apothecary Club,systemausfall.org=Systemausfall,gitter.im=Gitter.IM
+
+#enven:const
+#enven:type=bool
+CAN_LOGIN_AS_GUEST=false
+
+#enven:const
+#enven:type=bool
+AUTO_LOGIN_AS_GUEST=false
+
+
+########  ##     ## #### ##       ########  
+##     ## ##     ##  ##  ##       ##     ## 
+##     ## ##     ##  ##  ##       ##     ## 
+########  ##     ##  ##  ##       ##     ## 
+##     ## ##     ##  ##  ##       ##     ## 
+##     ## ##     ##  ##  ##       ##     ## 
+########   #######  #### ######## ########  
+
+#enven:const
+#enven:type=bool
+isCI=false
+
+#enven:const
+#enven:type=bool
+IS_NIGHTLY=false
+
+#enven:const
+#enven:type=bool
+IS_DEMO=false
+
+
+   ###    ########  ########  ##       ######## 
+  ## ##   ##     ## ##     ## ##       ##       
+ ##   ##  ##     ## ##     ## ##       ##       
+##     ## ########  ########  ##       ######   
+######### ##        ##        ##       ##       
+##     ## ##        ##        ##       ##       
+##     ## ##        ##        ######## ######## 
+
+
+#enven:const
+#enven:type=String
+appleKeychainAppGroupName=V45JGKTC6K.global.acter.a3
+
+
+
+########     ###     ######   ########  ######  ##     ##    ###    ##    ## ######## 
+##     ##   ## ##   ##    ##  ##       ##    ## ##     ##   ## ##   ##   ##  ##       
+##     ##  ##   ##  ##        ##       ##       ##     ##  ##   ##  ##  ##   ##       
+########  ##     ## ##   #### ######    ######  ######### ##     ## #####    ######   
+##   ##   ######### ##    ##  ##             ## ##     ## ######### ##  ##   ##       
+##    ##  ##     ## ##    ##  ##       ##    ## ##     ## ##     ## ##   ##  ##       
+##     ## ##     ##  ######   ########  ######  ##     ## ##     ## ##    ## ######## 
+
+
+
+#enven:const
+#enven:type=String
+RAGESHAKE_APP_NAME=acter-dev
+
+#enven:const
+#enven:type=String
+RAGESHAKE_APP_VERSION=DEV
+
+#enven:const
+#enven:type=String
+RAGESHAKE_URL=http://localhost:8003/api/submit
+
+
+
+ ######  ######## ##    ## ######## ########  ##    ## 
+##    ## ##       ###   ##    ##    ##     ##  ##  ##  
+##       ##       ####  ##    ##    ##     ##   ####   
+ ######  ######   ## ## ##    ##    ########     ##    
+      ## ##       ##  ####    ##    ##   ##      ##    
+##    ## ##       ##   ###    ##    ##    ##     ##    
+ ######  ######## ##    ##    ##    ##     ##    ##    
+
+
+#enven:const
+#enven:type=String
+SENTRY_DSN=
+
+#enven:const
+#enven:type=String
+SENTRY_ENVIRONMENT=
+
+#enven:const
+#enven:type=String
+SENTRY_RELEASE=
+
+
+
+########  ##     ##  ######  ##     ## 
+##     ## ##     ## ##    ## ##     ## 
+##     ## ##     ## ##       ##     ## 
+########  ##     ##  ######  ######### 
+##        ##     ##       ## ##     ## 
+##        ##     ## ##    ## ##     ## 
+##         #######   ######  ##     ## 
+
+
+
+#enven:const
+#enven:type=String
+PUSH_APP_PREFIX=global.acter.a3
+
+
+#enven:const
+#enven:type=String
+PUSH_APP_NAME=Acter
+
+#enven:const
+#enven:type=String
+PUSH_SERVER=
+

--- a/app/.env
+++ b/app/.env
@@ -25,6 +25,14 @@ DEFAULT_ACTER_SESSION=sessions
 
 #enven:const
 #enven:type=String
+DEFAULT_RUST_LOG=acter=debug,a3::sdk=info,a3=warn,warn
+
+#enven:const
+#enven:type=String
+DEFAULT_HTTP_PROXY=
+
+#enven:const
+#enven:type=String
 DEFAULT_SEARCH_SERVERS=acter.global=Acter.global,matrix.org=Matrix.org,matrixrooms.info=Global Search,the-apothecary.club=The Apothecary Club,systemausfall.org=Systemausfall,gitter.im=Gitter.IM
 
 #enven:const

--- a/app/integration_test/support/mail.dart
+++ b/app/integration_test/support/mail.dart
@@ -2,11 +2,11 @@
 
 import 'dart:convert';
 import 'package:acter/common/utils/constants.dart';
+import 'package:acter/config/env.g.dart';
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/settings/widgets/email_address_card.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -111,7 +111,7 @@ extension ActerMail on ConvenientTest {
   }) async {
     var link = await getLinkInLatestEmail(emailAddr, contains: contains);
     if (replaceWithHomeserver) {
-      final homeserver = Uri.parse(defaultServerUrl);
+      final homeserver = Uri.parse(Env.defaultHomeserverUrl);
       print('updating with $homeserver');
       link = link.replace(
         scheme: homeserver.scheme,

--- a/app/lib/common/notifications/notifications.dart
+++ b/app/lib/common/notifications/notifications.dart
@@ -7,6 +7,7 @@ import 'package:acter/common/notifications/util.dart';
 import 'package:acter/common/providers/app_state_provider.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/utils/utils.dart';
+import 'package:acter/config/env.g.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter/router/router.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
@@ -30,20 +31,9 @@ final DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
 
 const bool isProduction = bool.fromEnvironment('dart.vm.product');
 
-const appIdPrefix = String.fromEnvironment(
-  'PUSH_APP_PREFIX',
-  defaultValue: 'global.acter.a3',
-);
-
-const appName = String.fromEnvironment(
-  'PUSH_APP_NAME',
-  defaultValue: 'Acter',
-);
-
-const pushServer = String.fromEnvironment(
-  'PUSH_SERVER',
-  defaultValue: '',
-);
+const appIdPrefix = Env.pushAppPrefix;
+const appName = Env.pushAppName;
+const pushServer = Env.pushServer;
 
 const pushServerUrl = 'https://$pushServer/_matrix/push/v1/notify';
 

--- a/app/lib/common/utils/constants.dart
+++ b/app/lib/common/utils/constants.dart
@@ -1,3 +1,4 @@
+import 'package:acter/config/env.g.dart';
 import 'package:flutter/foundation.dart';
 
 const String heart = '\u{2764}';
@@ -34,38 +35,15 @@ class Keys {
   static const usernameLabel = Key('username-lbl');
 }
 
-const inCI = bool.fromEnvironment(
-  'CI',
-  defaultValue: false,
-);
+const canGuestLogin = Env.canLoginAsGuest;
 
-const canGuestLogin = bool.fromEnvironment(
-  'CAN_LOGIN_AS_GUEST',
-  defaultValue: false,
-);
+const autoGuestLogin = Env.autoLoginAsGuest;
 
-const autoGuestLogin = bool.fromEnvironment(
-  'AUTO_LOGIN_AS_GUEST',
-  defaultValue: false,
-);
+const inCI = Env.isCI;
+const isDemo = Env.isDemo;
+const isNightly = Env.isNightly;
 
-const isNightly = bool.fromEnvironment(
-  'IS_NIGHTLY',
-  defaultValue: false,
-);
-
-const isDemo = bool.fromEnvironment(
-  'IS_DEMO',
-  defaultValue: false,
-);
-
-const defaultServersStr = String.fromEnvironment(
-  'DEFAULT_SEARCH_SERVER',
-  defaultValue:
-      'acter.global=Acter.global,matrix.org=Matrix.org,matrixrooms.info=Global Search,the-apothecary.club=The Apothecary Club,systemausfall.org=Systemausfall,gitter.im=Gitter.IM',
-);
-
-final defaultServers = parseServers(defaultServersStr);
+final defaultServers = parseServers(Env.defaultSearchServers);
 
 const List<TargetPlatform> desktopPlatforms = [
   TargetPlatform.macOS,

--- a/app/lib/config/setup.dart
+++ b/app/lib/config/setup.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:acter/config/env.g.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+
+const userAgent = '${Env.rageshakeAppName}/${Env.rageshakeAppName}';
+final defaultLogSetting = Platform.environment.containsKey(rustLogKey)
+    ? Platform.environment[rustLogKey] as String
+    : Env.defaultRustLog;
+
+void configSetup() {
+  // Pass the configuration to the SDK plugin
+  ActerSdk.setup(
+    sessionKey: Env.defaultActerSession,
+    userAgent: userAgent,
+    defaultLogSetting: defaultLogSetting,
+    appleKeychainAppGroupName: Env.appleKeychainAppGroupName,
+    defaultHomeServerName: Env.defaultHomeserverName,
+    defaultHomeServerUrl: Env.defaultHomeserverUrl,
+    defaultHttpProxy: Env.defaultHttpProxy,
+  );
+}

--- a/app/lib/features/auth/pages/forgot_password.dart
+++ b/app/lib/features/auth/pages/forgot_password.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/validation_utils.dart';
+import 'package:acter/config/env.g.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -167,7 +168,7 @@ class _AskForEmail extends StatelessWidget {
     EasyLoading.show(status: lang.sendingEmail);
     try {
       final resp = await sdk.api.requestPasswordChangeTokenViaEmail(
-        defaultServerUrl,
+        Env.defaultHomeserverUrl,
         emailController.text.trim(),
       );
       EasyLoading.dismiss();
@@ -290,7 +291,7 @@ class _NewPassword extends StatelessWidget {
     EasyLoading.show(status: lang.resettingPassword);
     try {
       await sdk.api.resetPassword(
-        defaultServerUrl,
+        Env.defaultHomeserverUrl,
         tokenResponse.sid(),
         tokenResponse.clientSecret(),
         passwordController.text,

--- a/app/lib/features/bug_report/const.dart
+++ b/app/lib/features/bug_report/const.dart
@@ -1,4 +1,0 @@
-const rageshakeUrl = String.fromEnvironment(
-  'RAGESHAKE_URL',
-  defaultValue: 'http://localhost:8003/api/submit',
-);

--- a/app/lib/features/bug_report/pages/bug_report_page.dart
+++ b/app/lib/features/bug_report/pages/bug_report_page.dart
@@ -2,10 +2,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/config/env.g.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/utils/utils.dart';
-import 'package:acter/features/bug_report/const.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -27,7 +27,7 @@ Future<String> report({
 }) async {
   final sdk = await ActerSdk.instance;
 
-  final request = http.MultipartRequest('POST', Uri.parse(rageshakeUrl));
+  final request = http.MultipartRequest('POST', Uri.parse(Env.rageshakeUrl));
   request.fields.addAll({
     'text': description,
     'user_agent': userAgent,
@@ -78,7 +78,7 @@ Future<String> report({
       ),
     );
   }
-  _log.info('sending $rageshakeUrl');
+  _log.info('sending ${Env.rageshakeUrl}');
   final resp = await request.send();
   if (resp.statusCode == HttpStatus.ok) {
     Map<String, dynamic> json = jsonDecode(await resp.stream.bytesToString());

--- a/app/lib/features/bug_report/pages/bug_report_page.dart
+++ b/app/lib/features/bug_report/pages/bug_report_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
 import 'package:acter/config/env.g.dart';
+import 'package:acter/config/setup.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/utils/utils.dart';
@@ -31,8 +32,9 @@ Future<String> report({
   request.fields.addAll({
     'text': description,
     'user_agent': userAgent,
-    'app': appName, // should be same as one among github_project_mappings
-    'version': versionName,
+    'app': Env
+        .rageshakeAppName, // should be same as one among github_project_mappings
+    'version': Env.rageshakeAppVersion,
   });
   if (withUserId) {
     final client = sdk.currentClient;

--- a/app/lib/features/cli/commands/backup-and-reset.dart
+++ b/app/lib/features/cli/commands/backup-and-reset.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:acter/config/env.g.dart';
 import 'package:acter/features/cli/util.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:args/command_runner.dart';
@@ -61,7 +62,7 @@ class BackupAndResetCommand extends Command {
 
     if (!isDry) {
       await ActerSdk.storage.write(
-        key: defaultSessionKey,
+        key: Env.defaultActerSession,
         value: json.encode([]),
       );
     }

--- a/app/lib/features/cli/commands/info.dart
+++ b/app/lib/features/cli/commands/info.dart
@@ -1,5 +1,5 @@
+import 'package:acter/config/env.g.dart';
 import 'package:args/command_runner.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter/features/cli/util.dart';
 
 import 'dart:io';
@@ -15,9 +15,9 @@ class InfoCommand extends Command {
 
   @override
   Future<void> run() async {
-    print('Acter $versionName');
-    print(' - Default Homeserver: $defaultServerName');
-    print(' - Default Homeserver URL: $defaultServerUrl');
+    print('Acter ${Env.rageshakeAppVersion}');
+    print(' - Default Homeserver: ${Env.defaultHomeserverName}');
+    print(' - Default Homeserver URL: ${Env.defaultHomeserverUrl}');
     final appInfo = await AppInfo.make();
     print('Locally:');
     print(' - App Folder: ${appInfo.appDocPath}');

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
 import 'package:acter/config/env.g.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
@@ -31,7 +32,7 @@ class SettingsInfoPage extends ConsumerStatefulWidget {
 
 class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
   String rustLogSetting = defaultLogSetting;
-  String httpProxySetting = defaultHttpProxy;
+  String httpProxySetting = Env.defaultHttpProxy;
 
   @override
   void initState() {
@@ -71,21 +72,21 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
                     L10n.of(context).homeServerName,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  value: const Text(defaultServerName),
+                  value: const Text(Env.defaultHomeserverName),
                 ),
                 SettingsTile(
                   title: Text(
                     L10n.of(context).homeServerURL,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  value: const Text(defaultServerUrl),
+                  value: const Text(Env.defaultHomeserverUrl),
                 ),
                 SettingsTile(
                   title: Text(
                     L10n.of(context).sessionTokenName,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  value: const Text(defaultSessionKey),
+                  value: const Text(Env.defaultActerSession),
                 ),
               ],
             ),
@@ -112,7 +113,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
                     L10n.of(context).version,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  value: const Text(versionName),
+                  value: const Text(Env.rageshakeAppVersion),
                 ),
                 isDevBuild
                     ? SettingsTile(
@@ -120,14 +121,15 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
                           L10n.of(context).rageShakeAppName,
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
-                        value: const Text(appName),
+                        value: const Text(Env.rageshakeAppName),
                       )
                     : SettingsTile(
                         title: Text(
                           L10n.of(context).rageShakeAppNameDigest,
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
-                        value: Text('${sha1.convert(utf8.encode(appName))}'),
+                        value: Text(
+                            '${sha1.convert(utf8.encode(Env.rageshakeAppName))}',),
                       ),
                 isDevBuild
                     ? SettingsTile(
@@ -207,7 +209,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
   Future<void> fetchSettings() async {
     final preferences = await sharedPrefs();
     final rustLog = preferences.getString(rustLogKey) ?? defaultLogSetting;
-    final httpProxy = preferences.getString(proxyKey) ?? defaultHttpProxy;
+    final httpProxy = preferences.getString(proxyKey) ?? Env.defaultHttpProxy;
     if (mounted) {
       setState(() {
         rustLogSetting = rustLog;

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -8,7 +8,7 @@ import 'package:acter/common/utils/main.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/with_sidebar.dart';
-import 'package:acter/features/bug_report/const.dart';
+import 'package:acter/config/env.g.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
@@ -135,15 +135,16 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
                           L10n.of(context).rageShakeTargetUrl,
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
-                        value: const Text(rageshakeUrl),
+                        value: const Text(Env.rageshakeUrl),
                       )
                     : SettingsTile(
                         title: Text(
                           L10n.of(context).rageShakeTargetUrlDigest,
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
-                        value:
-                            Text('${sha1.convert(utf8.encode(rageshakeUrl))}'),
+                        value: Text(
+                          '${sha1.convert(utf8.encode(Env.rageshakeUrl))}',
+                        ),
                       ),
                 isDevBuild
                     ? SettingsTile(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:video_player_media_kit/video_player_media_kit.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:acter/config/env.g.dart';
 
 void main(List<String> args) async {
   if (args.isNotEmpty) {
@@ -55,14 +56,9 @@ Future<void> _startAppInner(Widget app, bool withSentry) async {
     await SentryFlutter.init(
       (options) {
         // we use the dart-define default env for the default stuff.
-        options.dsn =
-            const String.fromEnvironment('SENTRY_DSN', defaultValue: '');
-        options.environment = const String.fromEnvironment(
-          'SENTRY_ENVIRONMENT',
-          defaultValue: '',
-        );
-        options.release =
-            const String.fromEnvironment('SENTRY_RELEASE', defaultValue: '');
+        options.dsn = Env.sentryDsn;
+        options.environment = Env.sentryEnvironment;
+        options.release = Env.sentryRelease;
 
         // allows us to check whether the user has activated tracing
         // and prevent reporting otherwise.

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/tutorial_dialogs/space_overview_tutorials/space_ove
 import 'package:acter/common/utils/language.dart';
 import 'package:acter/common/utils/logging.dart';
 import 'package:acter/common/utils/main.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/features/cli/main.dart';
 import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter/router/providers/router_providers.dart';
@@ -22,6 +23,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:acter/config/env.g.dart';
 
 void main(List<String> args) async {
+  configSetup();
   if (args.isNotEmpty) {
     await cliMain(args);
   } else {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -496,6 +496,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
+  enven:
+    dependency: "direct dev"
+    description:
+      name: enven
+      sha256: "97a4ca9821e27e101b32f86fdcf937098b0698ee04fc90ac5127ae9af6afd106"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   equatable:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -159,6 +159,7 @@ dev_dependencies:
   enough_mail: ^2.1.6
   sentry_dart_plugin: ^2.0.0
   translations_cleaner: ^0.0.5
+  enven: ^1.0.1
 
 dependency_overrides:
   flutter_secure_storage_linux:


### PR DESCRIPTION
This adds [`enven`](https://pub.dev/packages/enven) for simplified configuration options. See [it's docs for details](https://pub.dev/packages/enven).

tl;dr: we now have a `.env` file in the `app` and you can overwrite any value in it by adding another `.env.dev` file locally for your setup (do not commit it). Don't forget to run `dart run enven` (in `app`) initially as well as when you change either of these files to create the  `app/lib/config/env.g.dart` file that contains the generated `Env` with the `const`s on it.

For the reviewer: this also updates the workflows to use that new system to create the `.env.production` overwrite (rather than `--dart-define` as we used to do) and some minor fixes to the workflows. It also required a bit of rewriting and rewiring of the initialization procedure of the rust-package to allow passing the `const`s in properly, hence that number of changes.