### PR TITLE
Quickjump routing fixes

### DIFF
--- a/.changes/meta-449.md
+++ b/.changes/meta-449.md
@@ -1,0 +1,1 @@
+- Fix bug in quick jump navigation, where it used to go black rather than properly jump sometimes

--- a/app/lib/features/search/pages/quick_jump.dart
+++ b/app/lib/features/search/pages/quick_jump.dart
@@ -16,6 +16,7 @@ class QuickjumpDialog extends ConsumerWidget {
         appBar: AppBar(title: Text(L10n.of(context).jumpTo)),
         body: const QuickJump(
           expand: false,
+          popBeforeRoute: true,
         ),
       ),
     );

--- a/app/lib/features/search/pages/search.dart
+++ b/app/lib/features/search/pages/search.dart
@@ -2,8 +2,6 @@ import 'package:acter/features/search/widgets/quick_jump.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-const Map<String, String> empty = {};
-
 class SearchPage extends ConsumerWidget {
   const SearchPage({super.key});
 

--- a/app/lib/features/search/widgets/pins_builder.dart
+++ b/app/lib/features/search/widgets/pins_builder.dart
@@ -6,8 +6,10 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:go_router/go_router.dart';
 
 class PinsBuilder extends ConsumerWidget {
+  final bool popBeforeRoute;
   const PinsBuilder({
     super.key,
+    required this.popBeforeRoute,
   });
 
   @override
@@ -34,10 +36,15 @@ class PinsBuilder extends ConsumerWidget {
                       ],
                     ),
                   ),
-                  onTap: () async => context.pushNamed(
-                    Routes.pin.name,
-                    pathParameters: {'pinId': e.navigationTargetId},
-                  ),
+                  onTap: () async {
+                    if (popBeforeRoute) {
+                      Navigator.pop(context);
+                    }
+                    context.pushNamed(
+                      Routes.pin.name,
+                      pathParameters: {'pinId': e.navigationTargetId},
+                    );
+                  },
                 ),
               )
               .toList();

--- a/app/lib/features/search/widgets/quick_actions_builder.dart
+++ b/app/lib/features/search/widgets/quick_actions_builder.dart
@@ -17,8 +17,11 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 final _log = Logger('a3::search::quick_actions_builder');
 
 class QuickActionsBuilder extends ConsumerWidget {
+  final bool popBeforeRoute;
+
   const QuickActionsBuilder({
     super.key,
+    required this.popBeforeRoute,
   });
 
   @override
@@ -52,7 +55,7 @@ class QuickActionsBuilder extends ConsumerWidget {
           if (canPostNews)
             OutlinedButton.icon(
               key: QuickJumpKeys.createUpdateAction,
-              onPressed: () => context.pushNamed(Routes.actionAddUpdate.name),
+              onPressed: () => routeTo(context, Routes.actionAddUpdate),
               icon: const Icon(
                 Atlas.plus_circle_thin,
                 size: 18,
@@ -65,7 +68,7 @@ class QuickActionsBuilder extends ConsumerWidget {
           if (canPostPin)
             OutlinedButton.icon(
               key: QuickJumpKeys.createPinAction,
-              onPressed: () => context.pushNamed(Routes.actionAddPin.name),
+              onPressed: () => routeTo(context, Routes.actionAddPin),
               icon: const Icon(
                 Atlas.plus_circle_thin,
                 size: 18,
@@ -78,7 +81,7 @@ class QuickActionsBuilder extends ConsumerWidget {
           if (canPostEvent)
             OutlinedButton.icon(
               key: QuickJumpKeys.createEventAction,
-              onPressed: () => context.pushNamed(Routes.createEvent.name),
+              onPressed: () => routeTo(context, Routes.createEvent),
               icon: const Icon(Atlas.plus_circle_thin, size: 18),
               label: Text(
                 L10n.of(context).event,
@@ -123,7 +126,7 @@ class QuickActionsBuilder extends ConsumerWidget {
           OutlinedButton.icon(
             icon: const Icon(Atlas.connection),
             key: SpacesKeys.actionCreate,
-            onPressed: () => context.pushNamed(Routes.createSpace.name),
+            onPressed: () => routeTo(context, Routes.createSpace),
             label: Text(L10n.of(context).createSpace),
           ),
           OutlinedButton.icon(
@@ -141,12 +144,21 @@ class QuickActionsBuilder extends ConsumerWidget {
               style: Theme.of(context).textTheme.labelMedium,
             ),
             onPressed: () async {
-              Navigator.pop(context);
+              if (popBeforeRoute) {
+                Navigator.pop(context);
+              }
               await openBugReport(context);
             },
           ),
         ],
       ),
     );
+  }
+
+  void routeTo(BuildContext context, Routes route) {
+    if (popBeforeRoute) {
+      Navigator.pop(context);
+    }
+    context.pushNamed(route.name);
   }
 }

--- a/app/lib/features/search/widgets/quick_jump.dart
+++ b/app/lib/features/search/widgets/quick_jump.dart
@@ -14,10 +14,12 @@ import 'package:go_router/go_router.dart';
 
 class QuickJump extends ConsumerStatefulWidget {
   final bool expand;
+  final bool popBeforeRoute;
 
   const QuickJump({
     super.key,
     this.expand = false,
+    this.popBeforeRoute = false,
   });
 
   @override
@@ -146,7 +148,9 @@ class _QuickJumpState extends ConsumerState<QuickJump> {
   }
 
   void routeTo(Routes route) {
-    Navigator.pop(context);
+    if (widget.popBeforeRoute) {
+      Navigator.pop(context);
+    }
     context.pushNamed(route.name);
   }
 
@@ -159,8 +163,8 @@ class _QuickJumpState extends ConsumerState<QuickJump> {
 
     List<Widget> body = [
       MaybeDirectRoomActionWidget(searchVal: searchValue),
-      const SpacesBuilder(),
-      const PinsBuilder(),
+      SpacesBuilder(popBeforeRoute: widget.popBeforeRoute),
+      PinsBuilder(popBeforeRoute: widget.popBeforeRoute),
     ];
     if (!hasSearchTerm) {
       body.add(
@@ -174,7 +178,11 @@ class _QuickJumpState extends ConsumerState<QuickJump> {
           const Divider(indent: 24, endIndent: 24),
         );
       }
-      body.add(const QuickActionsBuilder());
+      body.add(
+        QuickActionsBuilder(
+          popBeforeRoute: widget.popBeforeRoute,
+        ),
+      );
     }
 
     return Scaffold(

--- a/app/lib/features/search/widgets/spaces_builder.dart
+++ b/app/lib/features/search/widgets/spaces_builder.dart
@@ -10,8 +10,11 @@ import 'package:go_router/go_router.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class SpacesBuilder extends ConsumerWidget {
+  final bool popBeforeRoute;
+
   const SpacesBuilder({
     super.key,
+    this.popBeforeRoute = false,
   });
 
   @override
@@ -78,7 +81,9 @@ class SpacesBuilder extends ConsumerWidget {
                     ),
                   ),
                   onTap: () {
-                    Navigator.pop(context);
+                    if (popBeforeRoute) {
+                      Navigator.pop(context);
+                    }
                     goToSpace(context, e.navigationTargetId);
                   },
                 ),


### PR DESCRIPTION
We neglected to look after whether we are in the dialog or page screen mode in the updates of QuickJump. As a result issues like https://github.com/acterglobal/a3-meta/issues/449 occurred. This PR fixes that and navigation from quick jump works again fine

**on mobile**

https://github.com/user-attachments/assets/77d46f81-bc33-444e-b9ee-cec3f41e5073

and **on desktop**

https://github.com/user-attachments/assets/d9ce34bc-403f-47de-83d3-dca887f0cc55


Fixes https://github.com/acterglobal/a3-meta/issues/449
