### PR TITLE
Unit Tests for custom chat input

### DIFF
--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -44,7 +44,16 @@ final _allowEdit = StateProvider.family<bool, String>(
   ),
 );
 
+final canSendProvider = FutureProvider.family<bool?, String>(
+  (ref, roomId) async {
+    final membership = ref.watch(roomMembershipProvider(roomId));
+    return membership.valueOrNull?.canString('CanSendChatMessages');
+  },
+);
+
 class CustomChatInput extends ConsumerWidget {
+  static const noAccessKey = Key('custom-chat-no-access');
+  static const loadingKey = Key('custom-chat-loading');
   final String roomId;
   final void Function(bool)? onTyping;
 
@@ -52,12 +61,7 @@ class CustomChatInput extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final canSend = ref.watch(
-      roomMembershipProvider(roomId).select(
-        (membership) =>
-            membership.valueOrNull?.canString('CanSendChatMessages'),
-      ),
-    );
+    final canSend = ref.watch(canSendProvider(roomId)).valueOrNull;
     if (canSend == null) {
       // we are still loading
       return loadingState(context);
@@ -84,6 +88,7 @@ class CustomChatInput extends ConsumerWidget {
               ),
               const SizedBox(width: 4),
               Text(
+                key: noAccessKey,
                 L10n.of(context).chatMissingPermissionsToSend,
                 style: const TextStyle(color: Colors.grey, fontSize: 14),
               ),
@@ -98,6 +103,7 @@ class CustomChatInput extends ConsumerWidget {
     return Skeletonizer(
       child: FrostEffect(
         child: Container(
+          key: loadingKey,
           padding: const EdgeInsets.symmetric(vertical: 15),
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface,

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -54,6 +54,7 @@ final canSendProvider = FutureProvider.family<bool?, String>(
 class CustomChatInput extends ConsumerWidget {
   static const noAccessKey = Key('custom-chat-no-access');
   static const loadingKey = Key('custom-chat-loading');
+  static const sendBtnKey = Key('custom-chat-send-button');
   final String roomId;
   final void Function(bool)? onTyping;
 
@@ -359,6 +360,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
 
     if (allowEditing) {
       return IconButton.filled(
+        key: CustomChatInput.sendBtnKey,
         iconSize: 20,
         onPressed: () => onSendButtonPressed(ref),
         icon: const Icon(

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -1,0 +1,53 @@
+import 'package:acter/features/chat/widgets/custom_input.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/test_wrapper_widget.dart';
+
+void main() {
+  group(
+    'Custom Chat Input General States',
+    () {
+      testWidgets(
+        'No access, no show',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                // Same as before
+                canSendProvider.overrideWith((ref, roomId) => false),
+              ],
+              child: const InActerContextTestWrapper(
+                child: CustomChatInput(
+                  roomId: 'roomId',
+                ),
+              ),
+            ),
+          );
+          expect(find.byKey(CustomChatInput.noAccessKey), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Unknown Access show Loading',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                // Same as before
+                canSendProvider
+                    .overrideWith((ref, roomId) => null), // null means loading
+              ],
+              child: const InActerContextTestWrapper(
+                child: CustomChatInput(
+                  roomId: 'roomId',
+                ),
+              ),
+            ),
+          );
+          expect(find.byKey(CustomChatInput.loadingKey), findsOneWidget);
+        },
+      );
+    },
+  );
+}

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -114,7 +114,9 @@ void main() {
         await tester.pump();
         // not visible
         expect(find.byKey(CustomChatInput.sendBtnKey), findsNothing);
+        // CURRENTLY FAILS
       },
+      skip: true,
     );
   });
 }

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -1,5 +1,6 @@
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/custom_input.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -74,5 +75,46 @@ void main() {
     },
   );
 
-  group('Custom Chat Input - Edit States', () {});
+  group('Custom Chat Input - Edit States', () {
+    final overrides = [
+      canSendProvider.overrideWith((ref, roomId) => true),
+      isRoomEncryptedProvider.overrideWith((ref, roomId) => true),
+    ];
+
+    testWidgets(
+      'Showing and hiding send button simple',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: overrides,
+            child: const InActerContextTestWrapper(
+              child: CustomChatInput(
+                roomId: 'roomId',
+              ),
+            ),
+          ),
+        );
+        expect(find.byKey(CustomChatInput.noAccessKey), findsNothing);
+        expect(find.byKey(CustomChatInput.loadingKey), findsNothing);
+
+        // not visible
+        expect(find.byKey(CustomChatInput.sendBtnKey), findsNothing);
+        expect(find.byType(TextField), findsOneWidget);
+
+        await tester.enterText(find.byType(TextField), 'testing code');
+
+        await tester.pump();
+        // now visible
+        expect(find.byKey(CustomChatInput.sendBtnKey), findsOneWidget);
+
+        // -- reset
+        final TextField textField = tester.widget(find.byType(TextField));
+        textField.controller!.clear();
+
+        await tester.pump();
+        // not visible
+        expect(find.byKey(CustomChatInput.sendBtnKey), findsNothing);
+      },
+    );
+  });
 }

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/custom_input.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -6,7 +7,7 @@ import '../../helpers/test_wrapper_widget.dart';
 
 void main() {
   group(
-    'Custom Chat Input General States',
+    'Custom Chat Input - General States',
     () {
       testWidgets(
         'No access, no show',
@@ -48,6 +49,30 @@ void main() {
           expect(find.byKey(CustomChatInput.loadingKey), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'Show input',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                // Same as before
+                canSendProvider.overrideWith((ref, roomId) => true),
+                isRoomEncryptedProvider.overrideWith((ref, roomId) => true),
+              ],
+              child: const InActerContextTestWrapper(
+                child: CustomChatInput(
+                  roomId: 'roomId',
+                ),
+              ),
+            ),
+          );
+          expect(find.byKey(CustomChatInput.noAccessKey), findsNothing);
+          expect(find.byKey(CustomChatInput.loadingKey), findsNothing);
+        },
+      );
     },
   );
+
+  group('Custom Chat Input - Edit States', () {});
 }

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -1,9 +1,12 @@
+import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/custom_input.dart';
+import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/mock_chat_message.dart';
 import '../../helpers/test_wrapper_widget.dart';
 
 void main() {
@@ -115,6 +118,103 @@ void main() {
         // not visible
         expect(find.byKey(CustomChatInput.sendBtnKey), findsNothing);
         // CURRENTLY FAILS
+      },
+      skip: true,
+    );
+
+    testWidgets(
+      'Adding text in the middle',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: overrides,
+            child: const InActerContextTestWrapper(
+              child: CustomChatInput(
+                roomId: 'roomId',
+              ),
+            ),
+          ),
+        );
+        expect(find.byKey(CustomChatInput.noAccessKey), findsNothing);
+        expect(find.byKey(CustomChatInput.loadingKey), findsNothing);
+
+        // not visible
+        expect(find.byKey(CustomChatInput.sendBtnKey), findsNothing);
+        expect(find.byType(TextField), findsOneWidget);
+
+        final TextField textField = tester.widget(find.byType(TextField));
+        final controller = textField.controller!;
+
+        await tester.enterTextWithoutReplace(
+          find.byType(TextField),
+          'teing code',
+        );
+
+        await tester.pump();
+        expect(controller.text, 'teing code');
+
+        // lest move the cursor to fix our typos.
+        controller.selection =
+            TextSelection.fromPosition(const TextPosition(offset: 2));
+
+        await tester.pump();
+        await tester.enterTextWithoutReplace(find.byType(TextField), 's');
+        await tester.pump();
+        await tester.enterTextWithoutReplace(find.byType(TextField), 't');
+        await tester.pump();
+        expect(controller.text, 'testing code');
+      },
+    );
+
+    testWidgets(
+      'Adding text in the middle in reply',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: overrides,
+            child: const InActerContextTestWrapper(
+              child: CustomChatInput(
+                roomId: 'roomId',
+              ),
+            ),
+          ),
+        );
+        expect(find.byKey(CustomChatInput.noAccessKey), findsNothing);
+        expect(find.byKey(CustomChatInput.loadingKey), findsNothing);
+
+        // not visible
+
+        final element = tester.element(find.byType(CustomChatInput));
+        final container = ProviderScope.containerOf(element);
+
+        final TextField textField = tester.widget(find.byType(TextField));
+        final controller = textField.controller!;
+
+        await tester.enterTextWithoutReplace(
+          find.byType(TextField),
+          'teing code',
+        );
+
+        await tester.pump();
+        expect(controller.text, 'teing code');
+
+        // lest move the cursor to fix our typos.
+        controller.selection =
+            TextSelection.fromPosition(const TextPosition(offset: 2));
+
+        await tester.pump();
+        await tester.enterTextWithoutReplace(find.byType(TextField), 's');
+
+        // now we select the one we want to reply to
+        final chatInputNotifier = container.read(chatInputProvider.notifier);
+        chatInputNotifier.setReplyToMessage(buildMockTextMessage());
+
+        // without moving the cursor!
+        await tester.pump();
+        await tester.enterTextWithoutReplace(find.byType(TextField), 't');
+
+        await tester.pump();
+        expect(controller.text, 'testing code'); // <- cursor moved
       },
       skip: true,
     );

--- a/app/test/features/chat/custom_input.dart
+++ b/app/test/features/chat/custom_input.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/custom_input.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';

--- a/app/test/helpers/mock_chat_message.dart
+++ b/app/test/helpers/mock_chat_message.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_chat_types/flutter_chat_types.dart';
+
+int id = 0;
+
+TextMessage buildMockTextMessage() {
+  id += 1;
+  return TextMessage(
+    author: User(id: '$id-user'),
+    id: '$id-msg',
+    text: 'text of $id',
+  );
+}

--- a/app/test/helpers/test_wrapper_widget.dart
+++ b/app/test/helpers/test_wrapper_widget.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/themes/acter_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:acter_trigger_auto_complete/acter_trigger_autocomplete.dart';
 
 class InActerContextTestWrapper extends StatelessWidget {
   final Widget child;
@@ -9,14 +10,16 @@ class InActerContextTestWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ActerTheme.theme,
-      title: 'Acter',
-      builder: (context, other) => Scaffold(body: child),
-      locale: const Locale('en', 'US'),
-      localizationsDelegates: L10n.localizationsDelegates,
-      supportedLocales: L10n.supportedLocales,
-      // MaterialApp contains our top-level Navigator
+    return Portal(
+      child: MaterialApp(
+        theme: ActerTheme.theme,
+        title: 'Acter',
+        builder: (context, other) => Scaffold(body: child),
+        locale: const Locale('en', 'US'),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        // MaterialApp contains our top-level Navigator
+      ),
     );
   }
 }

--- a/app/test/helpers/test_wrapper_widget.dart
+++ b/app/test/helpers/test_wrapper_widget.dart
@@ -14,7 +14,14 @@ class InActerContextTestWrapper extends StatelessWidget {
       child: MaterialApp(
         theme: ActerTheme.theme,
         title: 'Acter',
-        builder: (context, other) => Scaffold(body: child),
+        home: child,
+        builder: (context, child) => Overlay(
+          initialEntries: [
+            OverlayEntry(
+              builder: (context) => Scaffold(body: child),
+            ),
+          ],
+        ),
         locale: const Locale('en', 'US'),
         localizationsDelegates: L10n.localizationsDelegates,
         supportedLocales: L10n.supportedLocales,

--- a/app/test/helpers/test_wrapper_widget.dart
+++ b/app/test/helpers/test_wrapper_widget.dart
@@ -1,0 +1,22 @@
+import 'package:acter/common/themes/acter_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+class InActerContextTestWrapper extends StatelessWidget {
+  final Widget child;
+
+  const InActerContextTestWrapper({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ActerTheme.theme,
+      title: 'Acter',
+      builder: (context, other) => Scaffold(body: child),
+      locale: const Locale('en', 'US'),
+      localizationsDelegates: L10n.localizationsDelegates,
+      supportedLocales: L10n.supportedLocales,
+      // MaterialApp contains our top-level Navigator
+    );
+  }
+}


### PR DESCRIPTION
Showing at least two UX errors already, which are skipped at the moment:
 - putting it into reply-mode while typing makes the cursor skip
 - clearing the text doesn't actually hide the send-button - which indicates the state updates aren't linked up properly.