### PR TITLE
Rename process from app to acter

### DIFF
--- a/.changes/2070-windows-process-name
+++ b/.changes/2070-windows-process-name
@@ -1,0 +1,1 @@
+- Rename process from app to acter in task manager on windows

--- a/app/windows/runner/Runner.rc
+++ b/app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "global.acter" "\0"
-            VALUE "FileDescription", "app" "\0"
+            VALUE "FileDescription", "Acter" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "app" "\0"
+            VALUE "InternalName", "Acter" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2022 global.acter. All rights reserved." "\0"
-            VALUE "OriginalFilename", "app.exe" "\0"
-            VALUE "ProductName", "app" "\0"
+            VALUE "OriginalFilename", "acter.exe" "\0"
+            VALUE "ProductName", "Acter" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
We changed binary name [here](https://github.com/acterglobal/a3/blob/7d4f2b8542e5eabb114568b1e7db9aba9b0b38ee/app/windows/CMakeLists.txt#L7).
If this project is built, we can find `acter.exe` in `./app/build/windows/x64/runner/Debug`.
![image](https://github.com/user-attachments/assets/ffd97048-1357-4f8b-93aa-640f1f7858c8)
This is some of debug console log.
```
"ar": 18 untranslated message(s).
"da": 757 untranslated message(s).
"de": 103 untranslated message(s).
"es": 63 untranslated message(s).
"fr": 63 untranslated message(s).
"pl": 206 untranslated message(s).
"pt": 1051 untranslated message(s).
To see a detailed report, use the untranslated-messages-file
option in the l10n.yaml file:
untranslated-messages-file: desiredFileName.txt
<other option>: <other selection>

This will generate a JSON format file containing all messages that
need to be translated.
Launching lib\main.dart on Windows in debug mode...
√ Built build\windows\x64\runner\Debug\acter.exe
```
But we see `app` entry in Task Manager.
![image](https://github.com/user-attachments/assets/9f069282-bb66-4f99-9031-11c3fc145c54)
I think flutter wraps `acter.exe` by keyword of `app`.