### PR TITLE
Upgrade labs, new dev-default-on-labs

### DIFF
--- a/app/integration_test/tests/tasks.dart
+++ b/app/integration_test/tests/tasks.dart
@@ -1,4 +1,4 @@
-import 'package:acter/common/utils/utils.dart';
+
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/space/providers/space_navbar_provider.dart';
@@ -24,7 +24,6 @@ typedef TaskListCreateResult = ({
 
 extension ActerTasks on ConvenientTest {
   Future<void> ensureTasksAreEnabled(String? spaceId) async {
-    await ensureLabEnabled(LabsFeature.tasks);
     if (spaceId != null) {
       await gotoSpace(spaceId);
 
@@ -41,7 +40,6 @@ extension ActerTasks on ConvenientTest {
         await tester.ensureVisible(taskLabsSwitch);
         await taskLabsSwitch.tap();
       }
-    }
   }
 
   Future<void> addTasks(

--- a/app/integration_test/tests/tasks.dart
+++ b/app/integration_test/tests/tasks.dart
@@ -1,4 +1,3 @@
-
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/space/providers/space_navbar_provider.dart';
@@ -40,6 +39,7 @@ extension ActerTasks on ConvenientTest {
         await tester.ensureVisible(taskLabsSwitch);
         await taskLabsSwitch.tap();
       }
+    }
   }
 
   Future<void> addTasks(

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -431,14 +431,12 @@ enum LabsFeature {
       isDevBuild || isNightly ? nightlyDefaults : releaseDefaults;
 
   static List<LabsFeature> get releaseDefaults => [
-        LabsFeature.comments,
         LabsFeature.mobilePushNotifications,
       ];
 
   static List<LabsFeature> get nightlyDefaults => [
         LabsFeature.encryptionBackup,
         LabsFeature.deviceCalendarSync,
-        LabsFeature.comments,
         LabsFeature.mobilePushNotifications,
       ];
 }

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -408,25 +409,35 @@ enum LabsFeature {
   cobudget,
   polls,
   discussions,
-  comments,
 
   // specific features
   chatUnread,
 
   // system features
   deviceCalendarSync,
+  encryptionBackup,
 
-  // not a lab anymore but needs to stay for backwards compat
+  // candidates for always on
+  comments,
+  mobilePushNotifications,
+
+  // -- not a lab anymore but needs to stay for backwards compat
   tasks,
   events,
   pins,
+  showNotifications; // old name for desktop notifications
 
-  // searchOptions
-  encryptionBackup,
-  showNotifications, // FIXME: old name for desktop notifications
-  mobilePushNotifications;
+  static List<LabsFeature> get defaults =>
+      isDevBuild || isNightly ? nightlyDefaults : releaseDefaults;
 
-  static List<LabsFeature> get defaults => [
+  static List<LabsFeature> get releaseDefaults => [
+        LabsFeature.comments,
+        LabsFeature.mobilePushNotifications,
+      ];
+
+  static List<LabsFeature> get nightlyDefaults => [
+        LabsFeature.encryptionBackup,
+        LabsFeature.deviceCalendarSync,
         LabsFeature.comments,
         LabsFeature.mobilePushNotifications,
       ];

--- a/app/lib/features/comments/widgets/comments_section.dart
+++ b/app/lib/features/comments/widgets/comments_section.dart
@@ -1,7 +1,5 @@
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/comments/providers/comments.dart';
 import 'package:acter/features/comments/widgets/comments_list.dart';
-import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
@@ -21,10 +19,6 @@ class CommentsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(featuresProvider);
-    if (!provider.isActive(LabsFeature.comments)) {
-      return const SizedBox.shrink();
-    }
     final managerLoader = ref.watch(commentsManagerProvider(manager));
     return managerLoader.when(
       data: (manager) => found(context, manager),

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -102,14 +102,6 @@ class SettingsLabsPage extends ConsumerWidget {
               title: Text(L10n.of(context).apps),
               tiles: [
                 SettingsTile.switchTile(
-                  title: const Text('Comments'),
-                  description: const Text('Commenting on space objects'),
-                  initialValue:
-                      ref.watch(isActiveProvider(LabsFeature.comments)),
-                  onToggle: (newVal) =>
-                      updateFeatureState(ref, LabsFeature.comments, newVal),
-                ),
-                SettingsTile.switchTile(
                   title: Text(L10n.of(context).polls),
                   description: Text(L10n.of(context).pollsAndSurveys),
                   initialValue: ref.watch(isActiveProvider(LabsFeature.polls)),


### PR DESCRIPTION
- New facilities to have a distinct set of default on for dev/nightly and release build
- switch both device calendar sync and `encryptionBackup` on for nightly/dev build
- Elevates comments out of labs
- clear old check for tasks labs