### PR TITLE
Fix default app permissions

### DIFF
--- a/.changes/2131-backwards-compat-settings.md
+++ b/.changes/2131-backwards-compat-settings.md
@@ -1,0 +1,1 @@
+- [Fix] where the app settings of previously created spaces where interpreted under the new defaults incorrectly. Instead we are keeping the old fallback and default behavior and the wire protocol as is and instead create all futures spaces with the explicit having the features turned off now.

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1972,8 +1972,18 @@ object RoomPowerLevels {
     fn task_lists_key() -> string;
 }
 
-object SimpleSettingWithTurnOff {
+object SimpleOnOffSetting {
+    fn active() -> bool;
+}
 
+object SimpleOnOffSettingBuilder {
+    fn active(active: bool);
+    fn build() -> Result<SimpleOnOffSetting>;
+}
+
+
+object SimpleSettingWithTurnOff {
+    fn active() -> bool;
 }
 
 object SimpleSettingWithTurnOffBuilder {
@@ -1982,10 +1992,6 @@ object SimpleSettingWithTurnOffBuilder {
 }
 
 
-object TasksSettingsBuilder {
-    fn active(active: bool);
-    fn build() -> Result<TasksSettings>;
-}
 object NewsSettings {
     fn active() -> bool;
     fn updater() -> SimpleSettingWithTurnOffBuilder;
@@ -1993,7 +1999,7 @@ object NewsSettings {
 
 object TasksSettings {
     fn active() -> bool;
-    fn updater() -> TasksSettingsBuilder;
+    fn updater() -> SimpleOnOffSettingBuilder;
 }
 
 object EventsSettings {
@@ -2018,7 +2024,7 @@ object ActerAppSettingsBuilder {
     fn news(news: Option<SimpleSettingWithTurnOff>);
     fn pins(pins: Option<SimpleSettingWithTurnOff>);
     fn events(events: Option<SimpleSettingWithTurnOff>);
-    fn tasks(tasks: Option<TasksSettings>);
+    fn tasks(tasks: Option<SimpleOnOffSetting>);
 }
 
 

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1972,33 +1972,38 @@ object RoomPowerLevels {
     fn task_lists_key() -> string;
 }
 
-object SimpleSettingWithTurnOn {
+object SimpleSettingWithTurnOff {
 
 }
 
-object SimpleSettingWithTurnOnBuilder {
+object SimpleSettingWithTurnOffBuilder {
     fn active(active: bool);
-    fn build() -> Result<SimpleSettingWithTurnOn>;
+    fn build() -> Result<SimpleSettingWithTurnOff>;
 }
 
+
+object TasksSettingsBuilder {
+    fn active(active: bool);
+    fn build() -> Result<TasksSettings>;
+}
 object NewsSettings {
     fn active() -> bool;
-    fn updater() -> SimpleSettingWithTurnOnBuilder;
+    fn updater() -> SimpleSettingWithTurnOffBuilder;
 }
 
 object TasksSettings {
     fn active() -> bool;
-    fn updater() -> SimpleSettingWithTurnOnBuilder;
+    fn updater() -> TasksSettingsBuilder;
 }
 
 object EventsSettings {
     fn active() -> bool;
-    fn updater() -> SimpleSettingWithTurnOnBuilder;
+    fn updater() -> SimpleSettingWithTurnOffBuilder;
 }
 
 object PinsSettings {
     fn active() -> bool;
-    fn updater() -> SimpleSettingWithTurnOnBuilder;
+    fn updater() -> SimpleSettingWithTurnOffBuilder;
 }
 
 object ActerAppSettings {
@@ -2010,10 +2015,10 @@ object ActerAppSettings {
 }
 
 object ActerAppSettingsBuilder {
-    fn news(news: Option<SimpleSettingWithTurnOn>);
-    fn pins(pins: Option<SimpleSettingWithTurnOn>);
-    fn events(events: Option<SimpleSettingWithTurnOn>);
-    fn tasks(tasks: Option<SimpleSettingWithTurnOn>);
+    fn news(news: Option<SimpleSettingWithTurnOff>);
+    fn pins(pins: Option<SimpleSettingWithTurnOff>);
+    fn events(events: Option<SimpleSettingWithTurnOff>);
+    fn tasks(tasks: Option<TasksSettings>);
 }
 
 

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -112,8 +112,9 @@ pub use rsvp::{Rsvp, RsvpDraft, RsvpManager, RsvpStatus};
 pub use search::{PublicSearchResult, PublicSearchResultItem};
 pub use settings::{
     ActerAppSettings, ActerAppSettingsBuilder, ActerUserAppSettings, ActerUserAppSettingsBuilder,
-    EventsSettings, NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOff,
-    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
+    EventsSettings, NewsSettings, PinsSettings, RoomPowerLevels, SimpleOnOffSetting,
+    SimpleOnOffSettingBuilder, SimpleSettingWithTurnOff, SimpleSettingWithTurnOffBuilder,
+    TasksSettings,
 };
 pub use spaces::{
     new_space_settings_builder, CreateSpaceSettings, CreateSpaceSettingsBuilder,

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -112,8 +112,8 @@ pub use rsvp::{Rsvp, RsvpDraft, RsvpManager, RsvpStatus};
 pub use search::{PublicSearchResult, PublicSearchResultItem};
 pub use settings::{
     ActerAppSettings, ActerAppSettingsBuilder, ActerUserAppSettings, ActerUserAppSettingsBuilder,
-    EventsSettings, NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOn,
-    SimpleSettingWithTurnOnBuilder, TasksSettings,
+    EventsSettings, NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOff,
+    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
 };
 pub use spaces::{
     new_space_settings_builder, CreateSpaceSettings, CreateSpaceSettingsBuilder,

--- a/native/acter/src/api/settings.rs
+++ b/native/acter/src/api/settings.rs
@@ -3,8 +3,8 @@ mod user;
 
 pub use space::{
     ActerAppSettings, ActerAppSettingsBuilder, ActerAppSettingsContent, EventsSettings,
-    NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOff,
-    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
+    NewsSettings, PinsSettings, RoomPowerLevels, SimpleOnOffSetting, SimpleOnOffSettingBuilder,
+    SimpleSettingWithTurnOff, SimpleSettingWithTurnOffBuilder, TasksSettings,
 };
 
 pub use user::{ActerUserAppSettings, ActerUserAppSettingsBuilder};

--- a/native/acter/src/api/settings.rs
+++ b/native/acter/src/api/settings.rs
@@ -3,8 +3,8 @@ mod user;
 
 pub use space::{
     ActerAppSettings, ActerAppSettingsBuilder, ActerAppSettingsContent, EventsSettings,
-    NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOn,
-    SimpleSettingWithTurnOnBuilder, TasksSettings,
+    NewsSettings, PinsSettings, RoomPowerLevels, SimpleSettingWithTurnOff,
+    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
 };
 
 pub use user::{ActerUserAppSettings, ActerUserAppSettingsBuilder};

--- a/native/acter/src/api/settings/space.rs
+++ b/native/acter/src/api/settings/space.rs
@@ -1,6 +1,6 @@
 pub use acter_core::events::settings::{
-    ActerAppSettingsContent, EventsSettings, NewsSettings, PinsSettings, SimpleSettingWithTurnOn,
-    SimpleSettingWithTurnOnBuilder, TasksSettings,
+    ActerAppSettingsContent, EventsSettings, NewsSettings, PinsSettings, SimpleSettingWithTurnOff,
+    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
 };
 use acter_core::events::{
     calendar::CalendarEventEventContent,
@@ -30,13 +30,13 @@ impl From<ActerAppSettingsContentBuilder> for ActerAppSettingsBuilder {
     }
 }
 impl ActerAppSettingsBuilder {
-    pub fn news(&mut self, value: Option<Box<SimpleSettingWithTurnOn>>) {
+    pub fn news(&mut self, value: Option<Box<SimpleSettingWithTurnOff>>) {
         self.inner.news(value.map(|i| *i));
     }
-    pub fn pins(&mut self, value: Option<Box<SimpleSettingWithTurnOn>>) {
+    pub fn pins(&mut self, value: Option<Box<SimpleSettingWithTurnOff>>) {
         self.inner.pins(value.map(|i| *i));
     }
-    pub fn events(&mut self, value: Option<Box<SimpleSettingWithTurnOn>>) {
+    pub fn events(&mut self, value: Option<Box<SimpleSettingWithTurnOff>>) {
         self.inner.events(value.map(|i| *i));
     }
     pub fn tasks(&mut self, value: Option<Box<TasksSettings>>) {

--- a/native/acter/src/api/settings/space.rs
+++ b/native/acter/src/api/settings/space.rs
@@ -1,6 +1,7 @@
 pub use acter_core::events::settings::{
-    ActerAppSettingsContent, EventsSettings, NewsSettings, PinsSettings, SimpleSettingWithTurnOff,
-    SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
+    ActerAppSettingsContent, EventsSettings, NewsSettings, PinsSettings, SimpleOnOffSetting,
+    SimpleOnOffSettingBuilder, SimpleSettingWithTurnOff, SimpleSettingWithTurnOffBuilder,
+    TasksSettings,
 };
 use acter_core::events::{
     calendar::CalendarEventEventContent,

--- a/native/core/src/events/settings.rs
+++ b/native/core/src/events/settings.rs
@@ -7,7 +7,7 @@ pub static APP_USER_SETTINGS: &str = "global.acter.user_app_settings";
 pub use space::{
     ActerAppSettings, ActerAppSettingsContent, ActerAppSettingsContentBuilder,
     ActerAppSettingsContentBuilderError, EventsSettings, NewsSettings, PinsSettings,
-    SimpleSettingWithTurnOn, SimpleSettingWithTurnOnBuilder, TasksSettings,
+    SimpleSettingWithTurnOff, SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
 };
 pub use user::{
     ActerUserAppSettingsContent, ActerUserAppSettingsContentBuilder, AppChatSettings, AutoDownload,

--- a/native/core/src/events/settings.rs
+++ b/native/core/src/events/settings.rs
@@ -7,7 +7,8 @@ pub static APP_USER_SETTINGS: &str = "global.acter.user_app_settings";
 pub use space::{
     ActerAppSettings, ActerAppSettingsContent, ActerAppSettingsContentBuilder,
     ActerAppSettingsContentBuilderError, EventsSettings, NewsSettings, PinsSettings,
-    SimpleSettingWithTurnOff, SimpleSettingWithTurnOffBuilder, TasksSettings, TasksSettingsBuilder,
+    SimpleOnOffSetting, SimpleOnOffSettingBuilder, SimpleSettingWithTurnOff,
+    SimpleSettingWithTurnOffBuilder, TasksSettings,
 };
 pub use user::{
     ActerUserAppSettingsContent, ActerUserAppSettingsContentBuilder, AppChatSettings, AutoDownload,

--- a/native/core/src/events/settings/space.rs
+++ b/native/core/src/events/settings/space.rs
@@ -3,26 +3,48 @@ use ruma_events::EmptyStateKey;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize, Builder, Default)]
-pub struct SimpleSettingWithTurnOn {
+#[derive(Clone, Debug, Deserialize, Serialize, Builder)]
+pub struct SimpleSettingWithTurnOff {
     active: bool,
 }
 
-impl SimpleSettingWithTurnOn {
+impl Default for SimpleSettingWithTurnOff {
+    fn default() -> Self {
+        SimpleSettingWithTurnOff { active: true }
+    }
+}
+
+impl SimpleSettingWithTurnOff {
     pub fn active(&self) -> bool {
         self.active
     }
-    pub fn updater(&self) -> SimpleSettingWithTurnOnBuilder {
-        SimpleSettingWithTurnOnBuilder::default()
+    pub fn updater(&self) -> SimpleSettingWithTurnOffBuilder {
+        SimpleSettingWithTurnOffBuilder::default()
             .active(self.active)
             .to_owned()
     }
 }
 
-pub type NewsSettings = SimpleSettingWithTurnOn;
-pub type PinsSettings = SimpleSettingWithTurnOn;
-pub type EventsSettings = SimpleSettingWithTurnOn;
-pub type TasksSettings = SimpleSettingWithTurnOn;
+// TasksSettings
+#[derive(Clone, Debug, Deserialize, Serialize, Builder, Default)]
+pub struct TasksSettings {
+    // Tasks are off by default
+    active: bool,
+}
+impl TasksSettings {
+    pub fn active(&self) -> bool {
+        self.active
+    }
+    pub fn updater(&self) -> TasksSettingsBuilder {
+        TasksSettingsBuilder::default()
+            .active(self.active)
+            .to_owned()
+    }
+}
+
+pub type NewsSettings = SimpleSettingWithTurnOff;
+pub type PinsSettings = SimpleSettingWithTurnOff;
+pub type EventsSettings = SimpleSettingWithTurnOff;
 
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent, Builder, Default)]
 #[ruma_event(type = "global.acter.app_settings", kind = State, state_key_type = EmptyStateKey)]

--- a/native/core/src/events/settings/space.rs
+++ b/native/core/src/events/settings/space.rs
@@ -15,6 +15,9 @@ impl Default for SimpleSettingWithTurnOff {
 }
 
 impl SimpleSettingWithTurnOff {
+    pub fn off() -> Option<Self> {
+        Some(SimpleSettingWithTurnOff { active: false })
+    }
     pub fn active(&self) -> bool {
         self.active
     }
@@ -25,27 +28,39 @@ impl SimpleSettingWithTurnOff {
     }
 }
 
-// TasksSettings
 #[derive(Clone, Debug, Deserialize, Serialize, Builder, Default)]
-pub struct TasksSettings {
-    // Tasks are off by default
+pub struct SimpleOnOffSetting {
+    // default: off
     active: bool,
 }
-impl TasksSettings {
+impl SimpleOnOffSetting {
+    pub fn off() -> Option<Self> {
+        // no need, we are off by default
+        None
+    }
+
     pub fn active(&self) -> bool {
         self.active
     }
-    pub fn updater(&self) -> TasksSettingsBuilder {
-        TasksSettingsBuilder::default()
+    pub fn updater(&self) -> SimpleOnOffSettingBuilder {
+        SimpleOnOffSettingBuilder::default()
             .active(self.active)
             .to_owned()
     }
 }
 
+pub type TasksSettings = SimpleOnOffSetting;
 pub type NewsSettings = SimpleSettingWithTurnOff;
 pub type PinsSettings = SimpleSettingWithTurnOff;
 pub type EventsSettings = SimpleSettingWithTurnOff;
 
+/// Backwards compatibility note:
+///
+/// In an earlier version, we agreed that if pins, news and events hadn't changed,
+/// we'd assume they are activated. Even switching the default today means, we'd
+/// change that behavior for all where at least _some_ had been changed. Thus, we
+/// are keeping that behavior but _recommend_ using `off` to explicitly set
+/// the right behavior up for all future cases.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent, Builder, Default)]
 #[ruma_event(type = "global.acter.app_settings", kind = State, state_key_type = EmptyStateKey)]
 pub struct ActerAppSettingsContent {
@@ -67,6 +82,15 @@ impl ActerAppSettingsContent {
     }
     pub fn tasks(&self) -> TasksSettings {
         self.tasks.clone().unwrap_or_default()
+    }
+
+    pub fn off() -> ActerAppSettingsContent {
+        ActerAppSettingsContent {
+            news: NewsSettings::off(),
+            pins: PinsSettings::off(),
+            events: EventsSettings::off(),
+            tasks: TasksSettings::off(),
+        }
     }
 
     pub fn updater(&self) -> ActerAppSettingsContentBuilder {

--- a/native/core/src/spaces.rs
+++ b/native/core/src/spaces.rs
@@ -22,6 +22,7 @@ use tracing::error;
 use crate::{
     client::CoreClient,
     error::{Error, Result},
+    events::settings::ActerAppSettingsContent,
     statics::{default_acter_space_states, PURPOSE_FIELD, PURPOSE_FIELD_DEV, PURPOSE_TEAM_VALUE},
 };
 
@@ -71,6 +72,9 @@ pub struct CreateSpaceSettings {
 
     #[builder(setter(strip_option), default)]
     parent: Option<OwnedRoomId>,
+
+    #[builder(setter(strip_option), default = "ActerAppSettingsContent::off()")]
+    app_settings: ActerAppSettingsContent,
 }
 
 // helper for built-in setters
@@ -192,8 +196,11 @@ impl CoreClient {
             topic,
             avatar_uri, // remote or local
             parent,
+            app_settings,
         } = settings;
         let mut initial_states = default_acter_space_states();
+        // the space app settings as configured
+        initial_states.push(InitialStateEvent::new(app_settings).to_raw_any());
 
         if let Some(avatar_uri) = avatar_uri {
             let uri = Box::<MxcUri>::from(avatar_uri.as_str());

--- a/native/core/src/spaces.rs
+++ b/native/core/src/spaces.rs
@@ -74,6 +74,7 @@ pub struct CreateSpaceSettings {
     parent: Option<OwnedRoomId>,
 
     #[builder(setter(strip_option), default = "ActerAppSettingsContent::off()")]
+    #[serde(default = "ActerAppSettingsContent::off")]
     app_settings: ActerAppSettingsContent,
 }
 

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -23639,28 +23639,52 @@ class Api {
           _RoomPowerLevelsTaskListsKeyReturn Function(
             int,
           )>();
-  late final _simpleSettingWithTurnOnBuilderActivePtr = _lookup<
+  late final _simpleSettingWithTurnOffBuilderActivePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
             ffi.IntPtr,
             ffi.Uint8,
-          )>>("__SimpleSettingWithTurnOnBuilder_active");
+          )>>("__SimpleSettingWithTurnOffBuilder_active");
 
-  late final _simpleSettingWithTurnOnBuilderActive =
-      _simpleSettingWithTurnOnBuilderActivePtr.asFunction<
+  late final _simpleSettingWithTurnOffBuilderActive =
+      _simpleSettingWithTurnOffBuilderActivePtr.asFunction<
           void Function(
             int,
             int,
           )>();
-  late final _simpleSettingWithTurnOnBuilderBuildPtr = _lookup<
+  late final _simpleSettingWithTurnOffBuilderBuildPtr = _lookup<
       ffi.NativeFunction<
-          _SimpleSettingWithTurnOnBuilderBuildReturn Function(
+          _SimpleSettingWithTurnOffBuilderBuildReturn Function(
             ffi.IntPtr,
-          )>>("__SimpleSettingWithTurnOnBuilder_build");
+          )>>("__SimpleSettingWithTurnOffBuilder_build");
 
-  late final _simpleSettingWithTurnOnBuilderBuild =
-      _simpleSettingWithTurnOnBuilderBuildPtr.asFunction<
-          _SimpleSettingWithTurnOnBuilderBuildReturn Function(
+  late final _simpleSettingWithTurnOffBuilderBuild =
+      _simpleSettingWithTurnOffBuilderBuildPtr.asFunction<
+          _SimpleSettingWithTurnOffBuilderBuildReturn Function(
+            int,
+          )>();
+  late final _tasksSettingsBuilderActivePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__TasksSettingsBuilder_active");
+
+  late final _tasksSettingsBuilderActive =
+      _tasksSettingsBuilderActivePtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _tasksSettingsBuilderBuildPtr = _lookup<
+      ffi.NativeFunction<
+          _TasksSettingsBuilderBuildReturn Function(
+            ffi.IntPtr,
+          )>>("__TasksSettingsBuilder_build");
+
+  late final _tasksSettingsBuilderBuild =
+      _tasksSettingsBuilderBuildPtr.asFunction<
+          _TasksSettingsBuilderBuildReturn Function(
             int,
           )>();
   late final _newsSettingsActivePtr = _lookup<
@@ -48474,11 +48498,11 @@ class RoomPowerLevels {
   }
 }
 
-class SimpleSettingWithTurnOn {
+class SimpleSettingWithTurnOff {
   final Api _api;
   final _Box _box;
 
-  SimpleSettingWithTurnOn._(this._api, this._box);
+  SimpleSettingWithTurnOff._(this._api, this._box);
 
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
@@ -48486,11 +48510,11 @@ class SimpleSettingWithTurnOn {
   }
 }
 
-class SimpleSettingWithTurnOnBuilder {
+class SimpleSettingWithTurnOffBuilder {
   final Api _api;
   final _Box _box;
 
-  SimpleSettingWithTurnOnBuilder._(this._api, this._box);
+  SimpleSettingWithTurnOffBuilder._(this._api, this._box);
 
   void active(
     bool active,
@@ -48500,17 +48524,17 @@ class SimpleSettingWithTurnOnBuilder {
     var tmp2 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1 ? 1 : 0;
-    _api._simpleSettingWithTurnOnBuilderActive(
+    _api._simpleSettingWithTurnOffBuilderActive(
       tmp0,
       tmp2,
     );
     return;
   }
 
-  SimpleSettingWithTurnOn build() {
+  SimpleSettingWithTurnOff build() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._simpleSettingWithTurnOnBuilderBuild(
+    final tmp1 = _api._simpleSettingWithTurnOffBuilderBuild(
       tmp0,
     );
     final tmp3 = tmp1.arg0;
@@ -48531,9 +48555,66 @@ class SimpleSettingWithTurnOnBuilder {
       throw tmp3_0;
     }
     final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_SimpleSettingWithTurnOn");
+    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_SimpleSettingWithTurnOff");
     tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp2 = SimpleSettingWithTurnOn._(_api, tmp7_1);
+    final tmp2 = SimpleSettingWithTurnOff._(_api, tmp7_1);
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class TasksSettingsBuilder {
+  final Api _api;
+  final _Box _box;
+
+  TasksSettingsBuilder._(this._api, this._box);
+
+  void active(
+    bool active,
+  ) {
+    final tmp1 = active;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._tasksSettingsBuilderActive(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  TasksSettings build() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._tasksSettingsBuilderBuild(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    final tmp7 = tmp1.arg4;
+    if (tmp3 == 0) {
+      debugAllocation("handle error", tmp4, tmp5);
+      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      final tmp3_0 =
+          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
+      if (tmp5 > 0) {
+        final ffi.Pointer<ffi.Void> tmp4_0;
+        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+        _api.__deallocate(tmp4_0, tmp6, 1);
+      }
+      throw tmp3_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_TasksSettings");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp2 = TasksSettings._(_api, tmp7_1);
     return tmp2;
   }
 
@@ -48560,7 +48641,7 @@ class NewsSettings {
     return tmp2;
   }
 
-  SimpleSettingWithTurnOnBuilder updater() {
+  SimpleSettingWithTurnOffBuilder updater() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._newsSettingsUpdater(
@@ -48569,9 +48650,9 @@ class NewsSettings {
     final tmp3 = tmp1;
     final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
     final tmp3_1 =
-        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOnBuilder");
+        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOffBuilder");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = SimpleSettingWithTurnOnBuilder._(_api, tmp3_1);
+    final tmp2 = SimpleSettingWithTurnOffBuilder._(_api, tmp3_1);
     return tmp2;
   }
 
@@ -48598,7 +48679,7 @@ class TasksSettings {
     return tmp2;
   }
 
-  SimpleSettingWithTurnOnBuilder updater() {
+  TasksSettingsBuilder updater() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._tasksSettingsUpdater(
@@ -48606,10 +48687,9 @@ class TasksSettings {
     );
     final tmp3 = tmp1;
     final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 =
-        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOnBuilder");
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_TasksSettingsBuilder");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = SimpleSettingWithTurnOnBuilder._(_api, tmp3_1);
+    final tmp2 = TasksSettingsBuilder._(_api, tmp3_1);
     return tmp2;
   }
 
@@ -48636,7 +48716,7 @@ class EventsSettings {
     return tmp2;
   }
 
-  SimpleSettingWithTurnOnBuilder updater() {
+  SimpleSettingWithTurnOffBuilder updater() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._eventsSettingsUpdater(
@@ -48645,9 +48725,9 @@ class EventsSettings {
     final tmp3 = tmp1;
     final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
     final tmp3_1 =
-        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOnBuilder");
+        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOffBuilder");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = SimpleSettingWithTurnOnBuilder._(_api, tmp3_1);
+    final tmp2 = SimpleSettingWithTurnOffBuilder._(_api, tmp3_1);
     return tmp2;
   }
 
@@ -48674,7 +48754,7 @@ class PinsSettings {
     return tmp2;
   }
 
-  SimpleSettingWithTurnOnBuilder updater() {
+  SimpleSettingWithTurnOffBuilder updater() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._pinsSettingsUpdater(
@@ -48683,9 +48763,9 @@ class PinsSettings {
     final tmp3 = tmp1;
     final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
     final tmp3_1 =
-        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOnBuilder");
+        _Box(_api, tmp3_0, "drop_box_SimpleSettingWithTurnOffBuilder");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = SimpleSettingWithTurnOnBuilder._(_api, tmp3_1);
+    final tmp2 = SimpleSettingWithTurnOffBuilder._(_api, tmp3_1);
     return tmp2;
   }
 
@@ -48784,7 +48864,7 @@ class ActerAppSettingsBuilder {
   ActerAppSettingsBuilder._(this._api, this._box);
 
   void news(
-    SimpleSettingWithTurnOn? news,
+    SimpleSettingWithTurnOff? news,
   ) {
     final tmp1 = news;
     var tmp0 = 0;
@@ -48807,7 +48887,7 @@ class ActerAppSettingsBuilder {
   }
 
   void pins(
-    SimpleSettingWithTurnOn? pins,
+    SimpleSettingWithTurnOff? pins,
   ) {
     final tmp1 = pins;
     var tmp0 = 0;
@@ -48830,7 +48910,7 @@ class ActerAppSettingsBuilder {
   }
 
   void events(
-    SimpleSettingWithTurnOn? events,
+    SimpleSettingWithTurnOff? events,
   ) {
     final tmp1 = events;
     var tmp0 = 0;
@@ -48853,7 +48933,7 @@ class ActerAppSettingsBuilder {
   }
 
   void tasks(
-    SimpleSettingWithTurnOn? tasks,
+    TasksSettings? tasks,
   ) {
     final tmp1 = tasks;
     var tmp0 = 0;
@@ -60093,7 +60173,20 @@ class _RoomPowerLevelsTaskListsKeyReturn extends ffi.Struct {
   external int arg2;
 }
 
-class _SimpleSettingWithTurnOnBuilderBuildReturn extends ffi.Struct {
+class _SimpleSettingWithTurnOffBuilderBuildReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.IntPtr()
+  external int arg4;
+}
+
+class _TasksSettingsBuilderBuildReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.IntPtr()

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -23639,6 +23639,52 @@ class Api {
           _RoomPowerLevelsTaskListsKeyReturn Function(
             int,
           )>();
+  late final _simpleOnOffSettingActivePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.IntPtr,
+          )>>("__SimpleOnOffSetting_active");
+
+  late final _simpleOnOffSettingActive =
+      _simpleOnOffSettingActivePtr.asFunction<
+          int Function(
+            int,
+          )>();
+  late final _simpleOnOffSettingBuilderActivePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__SimpleOnOffSettingBuilder_active");
+
+  late final _simpleOnOffSettingBuilderActive =
+      _simpleOnOffSettingBuilderActivePtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _simpleOnOffSettingBuilderBuildPtr = _lookup<
+      ffi.NativeFunction<
+          _SimpleOnOffSettingBuilderBuildReturn Function(
+            ffi.IntPtr,
+          )>>("__SimpleOnOffSettingBuilder_build");
+
+  late final _simpleOnOffSettingBuilderBuild =
+      _simpleOnOffSettingBuilderBuildPtr.asFunction<
+          _SimpleOnOffSettingBuilderBuildReturn Function(
+            int,
+          )>();
+  late final _simpleSettingWithTurnOffActivePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint8 Function(
+            ffi.IntPtr,
+          )>>("__SimpleSettingWithTurnOff_active");
+
+  late final _simpleSettingWithTurnOffActive =
+      _simpleSettingWithTurnOffActivePtr.asFunction<
+          int Function(
+            int,
+          )>();
   late final _simpleSettingWithTurnOffBuilderActivePtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(
@@ -23661,30 +23707,6 @@ class Api {
   late final _simpleSettingWithTurnOffBuilderBuild =
       _simpleSettingWithTurnOffBuilderBuildPtr.asFunction<
           _SimpleSettingWithTurnOffBuilderBuildReturn Function(
-            int,
-          )>();
-  late final _tasksSettingsBuilderActivePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.IntPtr,
-            ffi.Uint8,
-          )>>("__TasksSettingsBuilder_active");
-
-  late final _tasksSettingsBuilderActive =
-      _tasksSettingsBuilderActivePtr.asFunction<
-          void Function(
-            int,
-            int,
-          )>();
-  late final _tasksSettingsBuilderBuildPtr = _lookup<
-      ffi.NativeFunction<
-          _TasksSettingsBuilderBuildReturn Function(
-            ffi.IntPtr,
-          )>>("__TasksSettingsBuilder_build");
-
-  late final _tasksSettingsBuilderBuild =
-      _tasksSettingsBuilderBuildPtr.asFunction<
-          _TasksSettingsBuilderBuildReturn Function(
             int,
           )>();
   late final _newsSettingsActivePtr = _lookup<
@@ -48498,11 +48520,102 @@ class RoomPowerLevels {
   }
 }
 
+class SimpleOnOffSetting {
+  final Api _api;
+  final _Box _box;
+
+  SimpleOnOffSetting._(this._api, this._box);
+
+  bool active() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._simpleOnOffSettingActive(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class SimpleOnOffSettingBuilder {
+  final Api _api;
+  final _Box _box;
+
+  SimpleOnOffSettingBuilder._(this._api, this._box);
+
+  void active(
+    bool active,
+  ) {
+    final tmp1 = active;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._simpleOnOffSettingBuilderActive(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  SimpleOnOffSetting build() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._simpleOnOffSettingBuilderBuild(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    final tmp7 = tmp1.arg4;
+    if (tmp3 == 0) {
+      debugAllocation("handle error", tmp4, tmp5);
+      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      final tmp3_0 =
+          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
+      if (tmp5 > 0) {
+        final ffi.Pointer<ffi.Void> tmp4_0;
+        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+        _api.__deallocate(tmp4_0, tmp6, 1);
+      }
+      throw tmp3_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_SimpleOnOffSetting");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp2 = SimpleOnOffSetting._(_api, tmp7_1);
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
 class SimpleSettingWithTurnOff {
   final Api _api;
   final _Box _box;
 
   SimpleSettingWithTurnOff._(this._api, this._box);
+
+  bool active() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._simpleSettingWithTurnOffActive(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
   void drop() {
@@ -48567,63 +48680,6 @@ class SimpleSettingWithTurnOffBuilder {
   }
 }
 
-class TasksSettingsBuilder {
-  final Api _api;
-  final _Box _box;
-
-  TasksSettingsBuilder._(this._api, this._box);
-
-  void active(
-    bool active,
-  ) {
-    final tmp1 = active;
-    var tmp0 = 0;
-    var tmp2 = 0;
-    tmp0 = _box.borrow();
-    tmp2 = tmp1 ? 1 : 0;
-    _api._tasksSettingsBuilderActive(
-      tmp0,
-      tmp2,
-    );
-    return;
-  }
-
-  TasksSettings build() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._tasksSettingsBuilderBuild(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    final tmp6 = tmp1.arg3;
-    final tmp7 = tmp1.arg4;
-    if (tmp3 == 0) {
-      debugAllocation("handle error", tmp4, tmp5);
-      final ffi.Pointer<ffi.Uint8> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-      final tmp3_0 =
-          utf8.decode(tmp4_0.asTypedList(tmp5), allowMalformed: true);
-      if (tmp5 > 0) {
-        final ffi.Pointer<ffi.Void> tmp4_0;
-        tmp4_0 = ffi.Pointer.fromAddress(tmp4);
-        _api.__deallocate(tmp4_0, tmp6, 1);
-      }
-      throw tmp3_0;
-    }
-    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
-    final tmp7_1 = _Box(_api, tmp7_0, "drop_box_TasksSettings");
-    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
-    final tmp2 = TasksSettings._(_api, tmp7_1);
-    return tmp2;
-  }
-
-  /// Manually drops the object and unregisters the FinalizableHandle.
-  void drop() {
-    _box.drop();
-  }
-}
-
 class NewsSettings {
   final Api _api;
   final _Box _box;
@@ -48679,7 +48735,7 @@ class TasksSettings {
     return tmp2;
   }
 
-  TasksSettingsBuilder updater() {
+  SimpleOnOffSettingBuilder updater() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._tasksSettingsUpdater(
@@ -48687,9 +48743,9 @@ class TasksSettings {
     );
     final tmp3 = tmp1;
     final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_TasksSettingsBuilder");
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_SimpleOnOffSettingBuilder");
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
-    final tmp2 = TasksSettingsBuilder._(_api, tmp3_1);
+    final tmp2 = SimpleOnOffSettingBuilder._(_api, tmp3_1);
     return tmp2;
   }
 
@@ -48933,7 +48989,7 @@ class ActerAppSettingsBuilder {
   }
 
   void tasks(
-    TasksSettings? tasks,
+    SimpleOnOffSetting? tasks,
   ) {
     final tmp1 = tasks;
     var tmp0 = 0;
@@ -60173,7 +60229,7 @@ class _RoomPowerLevelsTaskListsKeyReturn extends ffi.Struct {
   external int arg2;
 }
 
-class _SimpleSettingWithTurnOffBuilderBuildReturn extends ffi.Struct {
+class _SimpleOnOffSettingBuilderBuildReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.IntPtr()
@@ -60186,7 +60242,7 @@ class _SimpleSettingWithTurnOffBuilderBuildReturn extends ffi.Struct {
   external int arg4;
 }
 
-class _TasksSettingsBuilderBuildReturn extends ffi.Struct {
+class _SimpleSettingWithTurnOffBuilderBuildReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.IntPtr()


### PR DESCRIPTION
This revert the part of #2110 which applied the new defaults also to all previously submitted settings incorrectly - c004ef915187b7f24981226e41f54cf495595f8a (no need for real review of this one). Instead, we are now keeping the old behavior for all existing spaces and instead actively submit (and potentially allow the UI to configure) the new default app permissions when creating spaces - implemented in 9164448dbfb823234cb5e17de07574a6d86eddb0 .

Demonstrated in this video, where I first navigate to an existing space where app settings have never been altered showing the expected legacy behavior and then create a new subspace, where the new behavior is applied and all features are turned off (but can be activated in the settings, as well as in the actions section on the bottom of space details page):


https://github.com/user-attachments/assets/1733f445-eabd-45a1-87c2-2eaf7b209717



Fixes #2131 .