### PR TITLE
Windows path separator is different from other platform's one

### DIFF
--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -178,19 +178,19 @@ String getHumanReadableFileSize(int bytes) {
 
 String documentTypeFromFileExtension(String fileExtension) {
   switch (fileExtension) {
-    case 'png':
-    case 'jpg':
-    case 'jpeg':
+    case '.png':
+    case '.jpg':
+    case '.jpeg':
       return 'Image';
-    case 'mov':
-    case 'mp4':
+    case '.mov':
+    case '.mp4':
       return 'Video';
-    case 'mp3':
-    case 'wav':
+    case '.mp3':
+    case '.wav':
       return 'Audio';
-    case 'pdf':
+    case '.pdf':
       return 'PDF';
-    case 'txt':
+    case '.txt':
       return 'Text File';
     default:
       return '';

--- a/app/lib/features/attachments/actions/handle_selected_attachments.dart
+++ b/app/lib/features/attachments/actions/handle_selected_attachments.dart
@@ -11,6 +11,7 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
 
 final _log = Logger('a3::attachments::actions::handle_selected');
 
@@ -31,10 +32,9 @@ Future<void> handleAttachmentSelected({
   final client = ref.read(alwaysClientProvider);
   List<AttachmentDraft> drafts = [];
   try {
-    for (var selected in attachments) {
-      final file = selected;
+    for (var file in attachments) {
       final mimeType = lookupMimeType(file.path);
-      String fileName = file.path.split('/').last;
+      String fileName = p.basename(file.path);
       if (mimeType == null) throw lang.failedToDetectMimeType;
       if (attachmentType == AttachmentType.camera ||
           attachmentType == AttachmentType.image) {

--- a/app/lib/features/attachments/widgets/attachment_item.dart
+++ b/app/lib/features/attachments/widgets/attachment_item.dart
@@ -11,6 +11,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' show Attachment;
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
 
 // Attachment item UI
 class AttachmentItem extends ConsumerWidget {
@@ -104,9 +105,8 @@ class AttachmentItem extends ConsumerWidget {
   Widget title(BuildContext context, AttachmentType attachmentType) {
     final msgContent = attachment.msgContent();
     final fileName = msgContent.body();
-    final fileNameSplit = fileName.split('.');
     final title = attachment.name() ?? fileName;
-    final fileExtension = fileNameSplit.last;
+    final fileExtension = p.extension(fileName);
     String fileSize = getHumanReadableFileSize(msgContent.size() ?? 0);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/features/attachments/widgets/attachment_selection_options.dart
+++ b/app/lib/features/attachments/widgets/attachment_selection_options.dart
@@ -12,6 +12,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
 
 // Attachments Selection Media Type Widget (Mobile)
 class AttachmentSelectionOptions extends StatelessWidget {
@@ -297,7 +298,7 @@ class _FileWidget extends StatelessWidget {
   }
 
   Widget _filePreview(BuildContext context, File file) {
-    final fileName = file.path.split('/').last;
+    final fileName = p.basename(file.path);
     if (type == AttachmentType.camera || type == AttachmentType.image) {
       return AttachmentContainer(
         name: fileName,

--- a/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
+++ b/app/lib/features/chat/providers/notifiers/media_chat_notifier.dart
@@ -118,7 +118,7 @@ class MediaChatNotifier extends StateNotifier<MediaChatState> {
   static Future<File?> getThumbnailData(String mediaPath) async {
     try {
       final tempDir = await getTemporaryDirectory();
-      final videoName = mediaPath.split('/').last.split('.').first;
+      final videoName = p.basenameWithoutExtension(mediaPath);
       final destPath = p.join(tempDir.path, '$videoName.jpg');
       final destFile = File(destPath);
 

--- a/app/lib/features/chat/widgets/file_message_builder.dart
+++ b/app/lib/features/chat/widgets/file_message_builder.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
 
 class FileMessageBuilder extends ConsumerWidget {
   final types.FileMessage message;
@@ -57,28 +58,28 @@ class FileMessageBuilder extends ConsumerWidget {
   }
 
   Widget getFileIcon(BuildContext context) {
-    final extension = message.name.split('.').last;
+    final extension = p.extension(message.name);
     IconData iconData;
     switch (extension) {
-      case 'png':
-      case 'jpg':
-      case 'jpeg':
+      case '.png':
+      case '.jpg':
+      case '.jpeg':
         iconData = Atlas.file_image;
         break;
-      case 'pdf':
+      case '.pdf':
         iconData = Icons.picture_as_pdf;
         break;
-      case 'doc':
+      case '.doc':
         iconData = Atlas.file;
         break;
-      case 'mp4':
+      case '.mp4':
         iconData = Atlas.file_video;
         break;
-      case 'mp3':
+      case '.mp3':
         iconData = Atlas.music_file;
         break;
-      case 'rtf':
-      case 'txt':
+      case '.rtf':
+      case '.txt':
       default:
         iconData = Atlas.lines_file;
         break;

--- a/app/lib/features/news/news_utils/news_utils.dart
+++ b/app/lib/features/news/news_utils/news_utils.dart
@@ -17,7 +17,7 @@ class NewsUtils {
   static Future<File?> getThumbnailData(XFile videoFile) async {
     try {
       final tempDir = await getTemporaryDirectory();
-      final videoName = videoFile.name.split('.').first;
+      final videoName = p.basenameWithoutExtension(videoFile.path);
       final destPath = p.join(tempDir.path, '$videoName.jpg');
       final destFile = File(destPath);
 

--- a/app/lib/features/pins/actions/select_pin_attachments.dart
+++ b/app/lib/features/pins/actions/select_pin_attachments.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:acter/common/models/types.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/pins/models/create_pin_state/pin_attachment_model.dart';
@@ -7,6 +8,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 final _log = Logger('a3::pins::select::attachment');
 
@@ -32,9 +34,8 @@ Future<void> selectAttachment(
     if (result != null && result.files.isNotEmpty) {
       final file = result.files.first;
       String fileSize = getHumanReadableFileSize(file.size);
-      final fileNameSplit = file.name.split('.');
-      final title = fileNameSplit.first;
-      final fileExtension = fileNameSplit.last;
+      final title = p.basenameWithoutExtension(file.name);
+      final fileExtension = p.extension(file.name);
       final attachment = PinAttachment(
         attachmentType: attachmentType,
         title: title,


### PR DESCRIPTION
Will use `path` package to parse path.
Will not split path into filename and extension manually using `/`.