### PR TITLE
Fix editing unmodifiable map problem

### DIFF
--- a/app/lib/features/bug_report/actions/open_bug_report.dart
+++ b/app/lib/features/bug_report/actions/open_bug_report.dart
@@ -12,11 +12,12 @@ bool _bugReportOpen = false;
 
 Future<void> openBugReport(
   BuildContext context, {
-  Map<String, String> queryParams = const {},
+  Map<String, String>? queryParams,
 }) async {
   if (_bugReportOpen) {
     return;
   }
+  queryParams = queryParams ?? {};
   final cacheDir = await appCacheDir();
   // rage shake disallows dot in filename
   final timestamp = DateTime.now().timestamp;


### PR DESCRIPTION
Fixes #2126 .

Before


https://github.com/user-attachments/assets/8b27dd0b-4293-4963-8598-57476b98a7f3


And we are seeing an error in the console: 
```
flutter: [a3::home::client_notifier][SEVERE]: 2024-09-03 11:05:40.943138: platform dispatch error
[2024-09-03][11:05:40.943496][a3::home::client_notifier][ERROR] platform dispatch error Unsupported operation: Cannot modify unmodifiable map null #0      _UnmodifiableMapMixin.[]= (dart:collection/maps.dart:272:5)
#1      openBugReport (package:acter/features/bug_report/actions/open_bug_report.dart:28:16)
open_bug_report.dart:28
<asynchronous suspension>

```

After:

https://github.com/user-attachments/assets/a7e552e4-4fee-4894-b404-320bfbd0884f

