### PR TITLE
Show Sidebar from mediumLargeAndUp, not only from large (which is larger)

### DIFF
--- a/app/lib/config/app_shell.dart
+++ b/app/lib/config/app_shell.dart
@@ -171,7 +171,7 @@ class AppShellState extends ConsumerState<AppShell> {
   SlotLayout primaryNavigationLayout() {
     return SlotLayout(
       config: <Breakpoint, SlotLayoutConfig?>{
-        Breakpoints.large: SlotLayout.from(
+        Breakpoints.mediumLargeAndUp: SlotLayout.from(
           key: const Key('primaryNavigation'),
           builder: (BuildContext context) => SidebarWidget(
             navigationShell: widget.navigationShell,


### PR DESCRIPTION
Didn't know but there is a `mediumLarge` that is more than `medium` and smaller than `large` ... the more you know.

Now it works as expected, showing a navigation in all size of window:

https://github.com/user-attachments/assets/f0a14906-fa5c-4399-b3f7-8868482240a8


