### PR TITLE
Remove id from category

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2044,7 +2044,6 @@ object ActerAppSettingsBuilder {
 
 
 object Category {
-    fn id() -> string;
     fn title() -> string;
     fn entries() -> string;
     fn display() -> Option<Display>;

--- a/native/acter/src/api/categories.rs
+++ b/native/acter/src/api/categories.rs
@@ -34,13 +34,7 @@ impl CategoriesBuilder {
         self.entries.clear();
     }
     pub fn add(&mut self, cat: Box<Category>) {
-        let id = cat.id();
-        let idx = self.entries.iter().position(|p| p.id == id);
         self.entries.push(*cat);
-        if let Some(index) = idx {
-            // remove the existing entry and replace it with the freshly added one
-            self.entries.swap_remove(index);
-        }
     }
     pub(crate) fn build(self) -> CategoriesStateEventContent {
         CategoriesStateEventContent {

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -753,7 +753,6 @@ pub fn new_link_ref_builder(title: String, uri: String) -> Result<RefDetailsBuil
     Ok(builder)
 }
 
-#[allow(clippy::boxed_local)]
 pub fn new_obj_ref_builder(
     position: Option<String>,
     reference: Box<RefDetails>,

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -293,7 +293,6 @@ impl NewsSlideDraft {
         }
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn color(&mut self, colors: Box<ColorizeBuilder>) {
         self.colorize_builder = *colors;
     }
@@ -320,7 +319,6 @@ impl NewsSlideDraft {
             .build()?)
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn add_reference(&mut self, reference: Box<ObjRef>) -> &Self {
         self.references.push(*reference);
         self

--- a/native/acter/src/api/pins.rs
+++ b/native/acter/src/api/pins.rs
@@ -363,7 +363,6 @@ impl PinDraft {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(*display));
         self
@@ -456,7 +455,6 @@ impl PinUpdateBuilder {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(Some(*display)));
         self

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -261,7 +261,6 @@ impl TaskListDraft {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(*display));
         self
@@ -853,7 +852,6 @@ impl TaskDraft {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(*display));
         self
@@ -935,7 +933,6 @@ impl TaskUpdateBuilder {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(Some(*display)));
         self
@@ -1166,7 +1163,6 @@ impl TaskListUpdateBuilder {
         self
     }
 
-    #[allow(clippy::boxed_local)]
     pub fn display(&mut self, display: Box<Display>) -> &mut Self {
         self.content.display(Some(Some(*display)));
         self

--- a/native/acter/src/lib.rs
+++ b/native/acter/src/lib.rs
@@ -3,7 +3,12 @@
 #![feature(vec_into_raw_parts)]
 #![feature(async_closure)]
 #![feature(box_into_inner)]
-#![allow(unused, dead_code, clippy::transmutes_expressible_as_ptr_casts)]
+#![allow(
+    unused,
+    dead_code,
+    clippy::boxed_local,
+    clippy::transmutes_expressible_as_ptr_casts
+)]
 
 #[rustfmt::skip]
 #[cfg(feature = "uniffi")]

--- a/native/core/src/events/common/categories.rs
+++ b/native/core/src/events/common/categories.rs
@@ -11,7 +11,6 @@ pub struct CategoriesStateEventContent {
 
 #[derive(Debug, Clone, Serialize, Eq, PartialEq, Deserialize, Builder)]
 pub struct Category {
-    pub id: String,
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(name = "display_typed"))]
@@ -22,9 +21,6 @@ pub struct Category {
 }
 
 impl Category {
-    pub fn id(&self) -> String {
-        self.id.clone()
-    }
     pub fn title(&self) -> String {
         self.title.clone()
     }
@@ -38,7 +34,6 @@ impl Category {
     pub fn update_builder(&self) -> CategoryBuilder {
         CategoryBuilder::default()
             .entries(self.entries())
-            .id(self.id.clone())
             .title(self.title.clone())
             .display_typed(self.display.clone())
             .to_owned()

--- a/native/test/src/tests/categories.rs
+++ b/native/test/src/tests/categories.rs
@@ -36,7 +36,6 @@ async fn categories_e2e() -> Result<()> {
     new_cat_builder.add_entry("a".to_owned());
     new_cat_builder.add_entry("b".to_owned());
     new_cat_builder.add_entry("c".to_owned());
-    new_cat_builder.id("campaigns".to_owned());
     new_cat_builder.title("Campaigns".to_owned());
     let new_cat = new_cat_builder.build()?;
 
@@ -78,6 +77,7 @@ async fn categories_e2e() -> Result<()> {
     let updated = updater.build()?;
 
     let mut space_cat_updater = new_space_categories.update_builder();
+    space_cat_updater.clear();
     space_cat_updater.add(Box::new(updated.clone()));
 
     // and we add a second now.
@@ -85,7 +85,6 @@ async fn categories_e2e() -> Result<()> {
     new_cat_builder.add_entry("c".to_owned());
     new_cat_builder.add_entry("b".to_owned());
     new_cat_builder.add_entry("a".to_owned());
-    new_cat_builder.id("new-campaign".to_owned());
     new_cat_builder.title("Campaigns".to_owned());
     let new_cat = new_cat_builder.build()?;
     space_cat_updater.add(Box::new(new_cat.clone()));

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -23919,16 +23919,6 @@ class Api {
             int,
             int,
           )>();
-  late final _categoryIdPtr = _lookup<
-      ffi.NativeFunction<
-          _CategoryIdReturn Function(
-            ffi.IntPtr,
-          )>>("__Category_id");
-
-  late final _categoryId = _categoryIdPtr.asFunction<
-      _CategoryIdReturn Function(
-        int,
-      )>();
   late final _categoryTitlePtr = _lookup<
       ffi.NativeFunction<
           _CategoryTitleReturn Function(
@@ -49093,35 +49083,6 @@ class Category {
 
   Category._(this._api, this._box);
 
-  String id() {
-    var tmp0 = 0;
-    tmp0 = _box.borrow();
-    final tmp1 = _api._categoryId(
-      tmp0,
-    );
-    final tmp3 = tmp1.arg0;
-    final tmp4 = tmp1.arg1;
-    final tmp5 = tmp1.arg2;
-    if (tmp4 == 0) {
-      print("returning empty string");
-      return "";
-    }
-    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
-    List<int> tmp3_buf = [];
-    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
-    for (int i = 0; i < tmp4; i++) {
-      int char = tmp3_precast.elementAt(i).value;
-      tmp3_buf.add(char);
-    }
-    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
-    if (tmp5 > 0) {
-      final ffi.Pointer<ffi.Void> tmp3_0;
-      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
-      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
-    }
-    return tmp2;
-  }
-
   String title() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
@@ -60340,15 +60301,6 @@ class _SimpleSettingWithTurnOffBuilderBuildReturn extends ffi.Struct {
   external int arg3;
   @ffi.IntPtr()
   external int arg4;
-}
-
-class _CategoryIdReturn extends ffi.Struct {
-  @ffi.IntPtr()
-  external int arg0;
-  @ffi.UintPtr()
-  external int arg1;
-  @ffi.UintPtr()
-  external int arg2;
 }
 
 class _CategoryTitleReturn extends ffi.Struct {


### PR DESCRIPTION
It is not needed, not useful and in the way -> f4d13e253f81dfb483606f78f2441d047bf09c1c .

ac107a77c3aab3937984fd83a49f1c3fc651c4ca Also adds a minor commit to add `boxed_local` for the entire rust crate so we don't have to put that in every local occurrence...

Replaces #2162 .