### PR TITLE
Add update action from space view

### DIFF
--- a/.changes/2156-updates-from-spaces.md
+++ b/.changes/2156-updates-from-spaces.md
@@ -1,0 +1,1 @@
+- A new 'Create new update' action button on the bottom of each space makes it easier to activate this feature and create an update for that space

--- a/app/lib/features/home/widgets/in_dashboard.dart
+++ b/app/lib/features/home/widgets/in_dashboard.dart
@@ -1,17 +1,25 @@
+import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/news/model/keys.dart';
 import 'package:acter/features/news/widgets/news_widget.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class InDashboard extends StatelessWidget {
+class InDashboard extends ConsumerWidget {
   final Widget child;
 
   const InDashboard({super.key, required this.child});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canPostNews = ref
+            .watch(
+              hasSpaceWithPermissionProvider('CanPostNews'),
+            )
+            .valueOrNull ==
+        true;
     return LayoutBuilder(
       builder: (context, constrains) {
         if (constrains.maxWidth > 770) {
@@ -25,6 +33,7 @@ class InDashboard extends StatelessWidget {
                   children: [
                     const NewsWidget(),
                     Visibility(
+                      visible: canPostNews,
                       child: IconButton(
                         key: NewsUpdateKeys.addNewsUpdate,
                         onPressed: () =>

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -28,7 +28,8 @@ final _log = Logger('a3::news::add_page');
 const addNewsKey = Key('add-news');
 
 class AddNewsPage extends ConsumerStatefulWidget {
-  const AddNewsPage({super.key = addNewsKey});
+  final String? initialSelectedSpace;
+  const AddNewsPage({super.key = addNewsKey, this.initialSelectedSpace});
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => AddNewsState();
@@ -41,6 +42,13 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
   @override
   void initState() {
     super.initState();
+    if (widget.initialSelectedSpace != null) {
+      WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+        ref
+            .read(newsStateProvider.notifier)
+            .setSpaceId(widget.initialSelectedSpace);
+      });
+    }
     ref.listenManual(newsStateProvider, fireImmediately: true,
         (prevState, nextState) async {
       final isText = nextState.currentNewsSlide?.type == NewsSlideType.text;

--- a/app/lib/features/news/pages/news_page.dart
+++ b/app/lib/features/news/pages/news_page.dart
@@ -11,10 +11,12 @@ class NewsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final canPostLoader = ref.watch(
-      hasSpaceWithPermissionProvider('CanPostNews'),
-    );
-    final canPostNews = canPostLoader.valueOrNull ?? false;
+    final canPostNews = ref
+            .watch(
+              hasSpaceWithPermissionProvider('CanPostNews'),
+            )
+            .valueOrNull ==
+        true;
 
     return Scaffold(
       extendBodyBehindAppBar: true,

--- a/app/lib/features/news/providers/news_post_editor_providers.dart
+++ b/app/lib/features/news/providers/news_post_editor_providers.dart
@@ -40,6 +40,12 @@ class NewsStateNotifier extends StateNotifier<NewsPostState> {
     );
   }
 
+  void setSpaceId(String? spaceId) {
+    state = state.copyWith(
+      newsPostSpaceId: spaceId,
+    );
+  }
+
   Future<void> selectEventToShare(BuildContext context) async {
     final eventId = await selectEventDrawer(
       context: context,

--- a/app/lib/features/space/widgets/space_sections/space_actions_section.dart
+++ b/app/lib/features/space/widgets/space_sections/space_actions_section.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class SpaceActionsSection extends ConsumerWidget {
   static const createChatAction = Key('space-action-create-chat');
@@ -38,6 +39,7 @@ class SpaceActionsSection extends ConsumerWidget {
   Widget actionButtons(BuildContext context, WidgetRef ref) {
     final membership = ref.watch(roomMembershipProvider(spaceId)).valueOrNull;
     bool canAddPin = membership?.canString('CanPostPin') == true;
+    bool canPostUpdate = membership?.canString('CanPostNews') == true;
     bool canChangeSetting =
         membership?.canString('CanChangeAppSettings') == true;
     bool canAddEvent = membership?.canString('CanPostEvent') == true;
@@ -45,6 +47,30 @@ class SpaceActionsSection extends ConsumerWidget {
     bool canLinkSpaces = membership?.canString('CanLinkSpaces') == true;
 
     final children = [
+      if (canPostUpdate || canChangeSetting)
+        simpleActionButton(
+          context: context,
+          iconData: PhosphorIcons.newspaper(),
+          title: L10n.of(context).createNewUpdate,
+          onPressed: () async {
+            if (!canPostUpdate && canChangeSetting) {
+              if (!await offerToActivateFeature(
+                context: context,
+                ref: ref,
+                spaceId: spaceId,
+                feature: SpaceFeature.updates,
+              )) {
+                return;
+              }
+            }
+            if (context.mounted) {
+              context.pushNamed(
+                Routes.actionAddUpdate.name,
+                queryParameters: {'spaceId': spaceId},
+              );
+            }
+          },
+        ),
       if (canAddPin || canChangeSetting)
         simpleActionButton(
           context: context,

--- a/app/lib/router/general_router.dart
+++ b/app/lib/router/general_router.dart
@@ -240,7 +240,9 @@ final generalRoutes = [
     pageBuilder: (context, state) {
       return NoTransitionPage(
         key: state.pageKey,
-        child: const AddNewsPage(),
+        child: AddNewsPage(
+          initialSelectedSpace: state.uri.queryParameters['spaceId'],
+        ),
       );
     },
   ),


### PR DESCRIPTION
With the upgrade-permission and auto-selecting the space for the news.

In action:


https://github.com/user-attachments/assets/a3e742cb-fe84-44a1-96f5-d458b7c9ae33


For the reviewers:
- 8bad620cf5ee48fef35353ceed82bc635808a0b2 contains minor fixes I noticed in the other code around that to be more straight-forward and only show the `+` on the dashboard _if_ the user really has spaces they can post to
- df1ebdf64ee334aca0164df73131d65975fa039f contains the actual fix with the initial-selection addition.