### PR TITLE
Bookmarked spaces first

### DIFF
--- a/.changes/2166-bookmarked-spaces-first.md
+++ b/.changes/2166-bookmarked-spaces-first.md
@@ -1,0 +1,1 @@
+- You will find your bookmarked spaces shown first in all spaces lists now, from the quick jumper, over the spaces listing to any place you have to select a spaces - making it easier and more convenient to use.

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -16,6 +16,9 @@ final spacesProvider =
   return SpaceListNotifier(ref: ref, client: client);
 });
 
+final hasSpacesProvider =
+    Provider((ref) => ref.watch(spacesProvider).isNotEmpty);
+
 final bookmarkedSpacesProvider = Provider(
   (ref) => ref.watch(spacesProvider).where((s) => s.isBookmarked()).toList(),
 );

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -160,7 +160,9 @@ final hasSpaceWithPermissionProvider =
 /// Stays up to date with underlying client info
 final _spaceIdAndNames =
     FutureProvider.autoDispose<List<_SpaceIdAndName>>((ref) async {
-  final spaces = ref.watch(spacesProvider);
+  final spaces = ref
+      .watch(bookmarkedSpacesProvider)
+      .followedBy(ref.watch(unbookmarkedSpacesProvider));
   List<_SpaceIdAndName> items = [];
   for (final space in spaces) {
     final roomId = space.getRoomIdStr();

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -20,6 +20,10 @@ final bookmarkedSpacesProvider = Provider(
   (ref) => ref.watch(spacesProvider).where((s) => s.isBookmarked()).toList(),
 );
 
+final unbookmarkedSpacesProvider = Provider(
+  (ref) => ref.watch(spacesProvider).where((s) => !s.isBookmarked()).toList(),
+);
+
 /// List of spaces other than current space and it’s parent space
 final otherSpacesForInviteMembersProvider = FutureProvider.autoDispose
     .family<List<Space>, String>((ref, spaceId) async {

--- a/app/lib/common/widgets/room/select_room_drawer.dart
+++ b/app/lib/common/widgets/room/select_room_drawer.dart
@@ -127,8 +127,11 @@ class _SelectRoomDrawerState extends ConsumerState<SelectRoomDrawer> {
 
   List<String> allRooms() {
     return switch (widget.roomType) {
-      RoomType.space =>
-        ref.watch(spacesProvider).map((space) => space.getRoomIdStr()).toList(),
+      RoomType.space => ref
+          .watch(bookmarkedSpacesProvider)
+          .followedBy(ref.watch(unbookmarkedSpacesProvider))
+          .map((space) => space.getRoomIdStr())
+          .toList(),
       RoomType.groupChat => ref
           .watch(chatsProvider.select((v) => v.where((d) => !d.isDm())))
           .map((room) => room.getRoomIdStr())

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -25,7 +25,7 @@ class Dashboard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final client = ref.watch(alwaysClientProvider);
-    final spaces = ref.watch(spacesProvider);
+    final hasSpaces = ref.watch(hasSpacesProvider);
     return InDashboard(
       child: SafeArea(
         child: Scaffold(
@@ -33,9 +33,8 @@ class Dashboard extends ConsumerWidget {
           body: Padding(
             padding: const EdgeInsets.only(top: 20, left: 20, right: 20),
             child: SingleChildScrollView(
-              child: spaces.isEmpty
-                  ? emptyState(context)
-                  : Column(
+              child: hasSpaces
+                  ? Column(
                       children: [
                         searchWidget(context),
                         featuresNav(context),
@@ -52,7 +51,8 @@ class Dashboard extends ConsumerWidget {
                         ),
                         const MySpacesSection(limit: 5),
                       ],
-                    ),
+                    )
+                  : emptyState(context),
             ),
           ),
         ),

--- a/app/lib/features/home/widgets/sidebar_widget.dart
+++ b/app/lib/features/home/widgets/sidebar_widget.dart
@@ -295,9 +295,10 @@ class SidebarWidget extends ConsumerWidget {
   }
 
   List<_SidebarItem> _spacesList(BuildContext context, WidgetRef ref) {
-    final spaces = ref.watch(spacesProvider);
+    final bookmarkedSpaces = ref.watch(bookmarkedSpacesProvider);
+    final otherSpaces = ref.watch(unbookmarkedSpacesProvider);
 
-    return spaces.map((space) {
+    return [].followedBy(bookmarkedSpaces).followedBy(otherSpaces).map((space) {
       final roomId = space.getRoomIdStr();
       final avatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
       final parentBadges =

--- a/app/lib/features/search/providers/spaces.dart
+++ b/app/lib/features/search/providers/spaces.dart
@@ -20,7 +20,10 @@ class SpaceDetails extends SearchTermDelegate {
 }
 
 List<SpaceDetails> _filterSpaces(
-    Ref ref, String searchValue, List<Space> spaces) {
+  Ref ref,
+  String searchValue,
+  List<Space> spaces,
+) {
   final List<SpaceDetails> finalSpaces = [];
 
   for (final space in spaces) {

--- a/app/lib/features/search/providers/spaces.dart
+++ b/app/lib/features/search/providers/spaces.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/search/model/search_term_delegate.dart';
 import 'package:acter/features/search/providers/search.dart';
 import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:riverpod/riverpod.dart';
 
 const fallbackSidebarIdx = 1;
@@ -18,11 +19,9 @@ class SpaceDetails extends SearchTermDelegate {
   }) : super(name: name, navigationTargetId: navigationTargetId);
 }
 
-final AutoDisposeFutureProvider<List<SpaceDetails>> spacesFoundProvider =
-    FutureProvider.autoDispose((ref) async {
-  final spaces = ref.watch(spacesProvider);
+List<SpaceDetails> _filterSpaces(
+    Ref ref, String searchValue, List<Space> spaces) {
   final List<SpaceDetails> finalSpaces = [];
-  final searchValue = ref.watch(searchValueProvider).toLowerCase();
 
   for (final space in spaces) {
     final roomId = space.getRoomIdStr();
@@ -50,4 +49,16 @@ final AutoDisposeFutureProvider<List<SpaceDetails>> spacesFoundProvider =
     return a.name.compareTo(b.name);
   });
   return finalSpaces;
+}
+
+final AutoDisposeFutureProvider<List<SpaceDetails>> spacesFoundProvider =
+    FutureProvider.autoDispose((ref) async {
+  final searchValue = ref.watch(searchValueProvider).toLowerCase();
+  // filter and sort them separately to keep the bookmarks at the beginning.
+  final allSpaces =
+      _filterSpaces(ref, searchValue, ref.watch(bookmarkedSpacesProvider));
+  allSpaces.addAll(
+    _filterSpaces(ref, searchValue, ref.watch(unbookmarkedSpacesProvider)),
+  );
+  return allSpaces;
 });

--- a/app/lib/features/search/widgets/pins_builder.dart
+++ b/app/lib/features/search/widgets/pins_builder.dart
@@ -64,6 +64,8 @@ class PinsBuilder extends ConsumerWidget {
           ],
         ),
       ),
+      skipLoadingOnRefresh: true,
+      skipLoadingOnReload: true,
     );
   }
 }

--- a/app/lib/features/search/widgets/spaces_builder.dart
+++ b/app/lib/features/search/widgets/spaces_builder.dart
@@ -36,6 +36,8 @@ class SpacesBuilder extends ConsumerWidget {
         if (spaces.isEmpty) return renderEmpty(context, ref);
         return renderItems(context, ref, spaces);
       },
+      skipLoadingOnRefresh: true,
+      skipLoadingOnReload: true,
     );
   }
 

--- a/app/lib/features/spaces/pages/spaces_page.dart
+++ b/app/lib/features/spaces/pages/spaces_page.dart
@@ -21,9 +21,6 @@ class SpacesPage extends ConsumerStatefulWidget {
 class _SpacesPageState extends ConsumerState<SpacesPage> {
   @override
   Widget build(BuildContext context) {
-    final spaces = ref.watch(spacesProvider);
-    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
-    const int minCount = 3;
     return Scaffold(
       body: CustomScrollView(
         slivers: <Widget>[
@@ -64,29 +61,42 @@ class _SpacesPageState extends ConsumerState<SpacesPage> {
             ],
             title: L10n.of(context).spaces,
           ),
-          // we have more than just the spaces screen, put them into a grid.
-          SliverGrid.builder(
-            itemCount: spaces.length,
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: max(1, min(widthCount, minCount)),
-              mainAxisExtent: 100,
-              childAspectRatio: 4,
-            ),
-            itemBuilder: (context, index) {
-              final space = spaces[index];
-              final roomId = space.getRoomIdStr();
-              return SpaceCard(
-                onTap: () => context.pushNamed(
-                  Routes.space.name,
-                  pathParameters: {'spaceId': roomId},
-                ),
-                key: Key('space-list-item-$roomId'),
-                roomId: roomId,
-              );
-            },
-          ),
+          renderSpaceList(context),
         ],
       ),
+    );
+  }
+
+  SliverGrid renderSpaceList(BuildContext context) {
+    // we have more than just the spaces screen, put them into a grid.
+    final bookmarked = ref.watch(bookmarkedSpacesProvider);
+    final others = ref.watch(unbookmarkedSpacesProvider);
+    final widthCount = (MediaQuery.of(context).size.width ~/ 300).toInt();
+    const int minCount = 3;
+
+    return SliverGrid.builder(
+      itemCount: bookmarked.length + others.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: max(1, min(widthCount, minCount)),
+        mainAxisExtent: 100,
+        childAspectRatio: 4,
+      ),
+      itemBuilder: (context, index) {
+        String roomId;
+        if (index < bookmarked.length) {
+          roomId = bookmarked[index].getRoomIdStr();
+        } else {
+          roomId = others[index - bookmarked.length].getRoomIdStr();
+        }
+        return SpaceCard(
+          onTap: () => context.pushNamed(
+            Routes.space.name,
+            pathParameters: {'spaceId': roomId},
+          ),
+          key: Key('space-list-item-$roomId'),
+          roomId: roomId,
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
.. in ...
- the all spaces list
- the sidebar
- the space selectors (e.g. for an event)
- when searching with the quick jump

see yourself:


https://github.com/user-attachments/assets/1cbd2030-bf97-47d9-ac38-d8965accf0d6


fixes #2104

To the reviewer:
It's one part per commit. Aside from ecfd3c9ececf9658d02c397c657a784766b7a6ff which contains a run-by fix to do less redraw by putting the `hasSpaces` into a provider that caches the result properly and d35106b1d86262517565575e205836a2b915641a which removes the jiggle of pins upon changing search values ...