### PR TITLE
Event: Copy to new

### DIFF
--- a/.changes/2167-copy-event-as-new.md
+++ b/.changes/2167-copy-event-as-new.md
@@ -1,0 +1,1 @@
+- You can now take any Event you see and use it as a template to create any other similar event. Clicking Actions -> `Copy as New` will open the create event dialog with all fields filled in with the content from the current event for you to edit and submit.

--- a/app/lib/features/events/pages/create_event_page.dart
+++ b/app/lib/features/events/pages/create_event_page.dart
@@ -7,6 +7,8 @@ import 'package:acter/common/widgets/spaces/select_space_form_field.dart';
 import 'package:acter/features/events/model/keys.dart';
 import 'package:acter/features/events/utils/events_utils.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:dart_date/dart_date.dart';
 import 'package:flutter/material.dart';
@@ -22,10 +24,12 @@ const createEditEventKey = Key('create-edit-event');
 
 class CreateEventPage extends ConsumerStatefulWidget {
   final String? initialSelectedSpace;
+  final CalendarEvent? templateEvent;
 
   const CreateEventPage({
     super.key = createEditEventKey,
     this.initialSelectedSpace,
+    this.templateEvent,
   });
 
   @override
@@ -46,17 +50,67 @@ class CreateEventPageConsumerState extends ConsumerState<CreateEventPage> {
   TimeOfDay _selectedEndTime = TimeOfDay.now();
   EditorState textEditorState = EditorState.blank();
 
+  void _setFromTemplate() {
+    if (widget.templateEvent == null) {
+      return;
+    }
+    final event = widget.templateEvent!;
+    // title
+    _eventNameController.text = event.title();
+    // description
+    final desc = event.description();
+    if (desc != null) {
+      final formatted = desc.formatted();
+      if (formatted != null) {
+        textEditorState =
+            EditorState(document: ActerDocumentHelpers.fromHtml(formatted));
+      } else {
+        textEditorState = EditorState(
+          document: ActerDocumentHelpers.fromMarkdown(
+            desc.body(),
+          ),
+        );
+      }
+    }
+
+    // Getting start and end date time
+    final dartStartTime = toDartDatetime(event.utcStart());
+    final dartEndTime = toDartDatetime(event.utcEnd());
+
+    // Setting data to variables for start date
+    _selectedStartDate = dartStartTime.toLocal();
+    _selectedStartTime = TimeOfDay.fromDateTime(_selectedStartDate);
+    _startDateController.text = eventDateFormat(_selectedStartDate);
+    _startTimeController.text = _selectedStartTime.format(context);
+
+    // Setting data to variables for end date
+    _selectedEndDate = dartEndTime.toLocal();
+    _selectedEndTime = TimeOfDay.fromDateTime(_selectedEndDate);
+    _endDateController.text = eventDateFormat(_selectedEndDate);
+    _endTimeController.text = _selectedEndTime.format(context);
+    _setSpaceId(event.roomIdStr());
+    setState(() {});
+  }
+
+  void _setSpaceId(String spaceId) {
+    ref.read(selectedSpaceIdProvider.notifier).state = spaceId;
+  }
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
-      // if calendarId is null that means Create Event
-      if (widget.initialSelectedSpace != null &&
-          widget.initialSelectedSpace!.isNotEmpty) {
-        final parentNotifier = ref.read(selectedSpaceIdProvider.notifier);
-        parentNotifier.state = widget.initialSelectedSpace;
-      }
-    });
+    if (widget.templateEvent != null) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (Duration duration) => _setFromTemplate(),
+      );
+    } else if (widget.initialSelectedSpace != null &&
+        widget.initialSelectedSpace!.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (Duration duration) => widget.initialSelectedSpace != null
+            ? _setSpaceId(widget.initialSelectedSpace!)
+            : null,
+      );
+    }
   }
 
   @override

--- a/app/lib/features/events/pages/create_event_page.dart
+++ b/app/lib/features/events/pages/create_event_page.dart
@@ -310,10 +310,16 @@ class CreateEventPageConsumerState extends ConsumerState<CreateEventPage> {
 
   // Selecting date
   Future<void> _selectDate({required bool isStartDate}) async {
+    DateTime initialDate = isStartDate ? _selectedStartDate : _selectedEndDate;
+    DateTime firstDate = DateTime.now();
+    if (initialDate < firstDate) {
+      initialDate = firstDate;
+    }
+
     final date = await showDatePicker(
       context: context,
-      initialDate: isStartDate ? _selectedStartDate : _selectedEndDate,
-      firstDate: DateTime.now(),
+      initialDate: initialDate,
+      firstDate: firstDate,
       lastDate: DateTime.now().addYears(1),
     );
     if (date == null || !mounted) return;

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/actions/report_content.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/toolkit/errors/error_page.dart';
+import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/edit_html_description_sheet.dart';
 import 'package:acter/common/widgets/edit_title_sheet.dart';
@@ -33,6 +34,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' show join;
@@ -176,6 +178,22 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
             ),
           );
         }
+
+        // Copy as New
+        actions.add(
+          PopupMenuItem(
+            onTap: () {
+              context.pushNamed(Routes.createEvent.name, extra: event);
+            },
+            child: Row(
+              children: <Widget>[
+                Icon(PhosphorIcons.calendarPlus()),
+                const SizedBox(width: 10),
+                Text(L10n.of(context).createAcopy),
+              ],
+            ),
+          ),
+        );
       }
     }
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -295,6 +295,8 @@
   "@createTaskList": {},
   "createNewUpdate": "Create New Update",
   "@createNewUpdate": {},
+  "createAcopy": "Copy as new",
+  "@createAcopy": {},
   "creatingCalendarEvent": "Creating Calendar Event",
   "@creatingCalendarEvent": {},
   "creatingChat": "Creating Chat",

--- a/app/lib/router/shell_routers/home_shell_router.dart
+++ b/app/lib/router/shell_routers/home_shell_router.dart
@@ -41,6 +41,7 @@ import 'package:acter/features/tasks/pages/task_item_detail_page.dart';
 import 'package:acter/features/tasks/pages/task_list_details_page.dart';
 import 'package:acter/features/tasks/pages/tasks_list_page.dart';
 import 'package:acter/router/router.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:go_router/go_router.dart';
 
 final homeShellRoutes = [
@@ -460,10 +461,16 @@ final homeShellRoutes = [
     name: Routes.createEvent.name,
     path: Routes.createEvent.route,
     pageBuilder: (context, state) {
+      final extra = state.extra;
+      CalendarEvent? templateEvent;
+      if (extra != null && extra is CalendarEvent) {
+        templateEvent = extra;
+      }
       return NoTransitionPage(
         key: state.pageKey,
         child: CreateEventPage(
           initialSelectedSpace: state.uri.queryParameters['spaceId'],
+          templateEvent: templateEvent,
         ),
       );
     },


### PR DESCRIPTION
First step towards the idea of an event-series: one-click action to create another event exactly like the one you are looking at:


https://github.com/user-attachments/assets/22ad0078-c299-4e1d-9d2d-b94589aca39b


To the reviewer:
- This is achieved by passing the `CalendarEvent` via `extra` and the event-creator taking all the values and setting its local state, hence the slight delay you see in it rendering. 1897be4a46354c7569c20ee918bd1108aa2d88b9
- [7d17138](https://github.com/acterglobal/a3/pull/2167/commits/7d17138732f6294da625c1f44924c0bbc93cf7bd) then contains a fix when you tried to open the time picker on a datetime that is lower than today, which is valid now, as we might have used a long-passed event as the template ...
