### PR TITLE
Fix iOS building for ```cargo-make```

### DIFF
--- a/native/acter/src/api/uniffi_api.rs
+++ b/native/acter/src/api/uniffi_api.rs
@@ -1,6 +1,3 @@
-use matrix_sdk_base::ruma::{
-    room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
-};
 use matrix_sdk_ui::notification_client::{
     NotificationEvent, NotificationItem as SdkNotificationItem,
 };


### PR DESCRIPTION
Currently, the error comes up while building `iOS-sim` and `iOS` variants with ```cargo-make```:
```
Compiling matrix-sdk-sqlite v0.7.1 (https://github.com/matrix-org/matrix-rust-sdk#9df1c480)
   Compiling matrix-sdk-store-file-event-cache v0.1.3+dev (/Users/gtalhaa/Work/flutter-projects/a3/native/file-event-cache)
   Compiling acter-core v0.1.0 (/Users/gtalhaa/Work/flutter-projects/a3/native/core)
   Compiling matrix-sdk-ui v0.7.0 (https://github.com/matrix-org/matrix-rust-sdk#9df1c480)
error[E0432]: unresolved imports `matrix_sdk_base::ruma::room::message`, `matrix_sdk_base::ruma::AnySyncMessageLikeEvent`, `matrix_sdk_base::ruma::AnySyncTimelineEvent`, `matrix_sdk_base::ruma::SyncMessageLikeEvent`
 --> native/acter/src/api/uniffi_api.rs:2:11
  |
2 |     room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
  |           ^^^^^^^               ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^ no `SyncMessageLikeEvent` in the root
  |           |                     |                        |
  |           |                     |                        no `AnySyncTimelineEvent` in the root
  |           |                     no `AnySyncMessageLikeEvent` in the root
  |           could not find `message` in `room`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `acter` (lib) due to 1 previous error
[cargo-make][1] ERROR - Error while executing command, exit code: 101
[cargo-make][1] WARN - Build Failed.
[cargo-make] ERROR - Error while running duckscript: Source: Unknown Line: 5 - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```
In ```uniffi_api.rs```, the undefined imports have been removed in order to make it successful.