### PR TITLE
preserve empty lines in controller text

### DIFF
--- a/.changes/2180-fix-empty-lines.md
+++ b/.changes/2180-fix-empty-lines.md
@@ -1,0 +1,1 @@
+- Empty lines are now preserved and rendered in chats when composing room message text.

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -689,6 +689,8 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
 
       final mentions = ref.read(chatInputProvider).mentions;
       String markdownText = textController.text;
+      // Replace empty new lines with <br> tags
+      markdownText = markdownText.replaceAll(RegExp(r'(\n\s*\n)'), '\n<br>\n');
       final userMentions = [];
       mentions.forEach((key, value) {
         userMentions.add(value);

--- a/app/lib/features/chat/widgets/text_message_builder.dart
+++ b/app/lib/features/chat/widgets/text_message_builder.dart
@@ -137,6 +137,7 @@ class _TextWidget extends ConsumerWidget {
                   onLinkTap: (url) => onMessageLinkTap(url, context),
                   backgroundColor: Colors.transparent,
                   data: message.text,
+                  renderNewlines: true,
                   pillBuilder: ({
                     required String identifier,
                     required String url,


### PR DESCRIPTION
Fixes #2049: Preserve empty spaces in text controller by replacing them with `<br>` tags.

Preview:

https://github.com/user-attachments/assets/631b4b56-56df-4f98-9802-f64cfe7fdad6
