### PR TITLE
Minor joining fixes

### DIFF
--- a/app/lib/features/activities/widgets/invitation_card.dart
+++ b/app/lib/features/activities/widgets/invitation_card.dart
@@ -224,6 +224,7 @@ class _InvitationCardState extends ConsumerState<InvitationCard> {
     EasyLoading.show(status: L10n.of(context).rejecting);
     try {
       bool res = await widget.invitation.reject();
+      ref.invalidate(invitationListProvider);
       if (!context.mounted) {
         EasyLoading.dismiss();
         return;

--- a/app/lib/features/activities/widgets/invitation_card.dart
+++ b/app/lib/features/activities/widgets/invitation_card.dart
@@ -13,7 +13,7 @@ import 'package:logging/logging.dart';
 
 final _log = Logger('a3::activities::invitation_card');
 
-class InvitationCard extends ConsumerWidget {
+class InvitationCard extends ConsumerStatefulWidget {
   final Invitation invitation;
 
   const InvitationCard({
@@ -22,13 +22,33 @@ class InvitationCard extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() => _InvitationCardState();
+}
+
+class _InvitationCardState extends ConsumerState<InvitationCard> {
+  String? roomTitle;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchTitle();
+  }
+
+  void _fetchTitle() async {
+    final title = await widget.invitation.room().displayName();
+    setState(() {
+      roomTitle = title.text();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          renderTile(context, ref),
+          renderTile(context),
           const Divider(indent: 5),
           Padding(
             padding: const EdgeInsets.all(8.0),
@@ -43,7 +63,7 @@ class InvitationCard extends ConsumerWidget {
                 const SizedBox(width: 15),
                 // Accept Invitation Button
                 ActerPrimaryActionButton(
-                  onPressed: () => _onTapAcceptInvite(context, ref),
+                  onPressed: () => _onTapAcceptInvite(context),
                   child: Text(L10n.of(context).accept),
                 ),
               ],
@@ -54,20 +74,20 @@ class InvitationCard extends ConsumerWidget {
     );
   }
 
-  ListTile renderTile(BuildContext context, WidgetRef ref) {
-    final isDM = invitation.isDm();
+  ListTile renderTile(BuildContext context) {
+    final isDM = widget.invitation.isDm();
     if (isDM) {
-      return renderDmChatTile(context, ref);
+      return renderDmChatTile(context);
     }
-    final room = invitation.room();
+    final room = widget.invitation.room();
     if (room.isSpace()) {
-      return renderSpaceTile(context, ref);
+      return renderSpaceTile(context);
     }
-    return renderGroupChatTile(context, ref);
+    return renderGroupChatTile(context);
   }
 
-  ListTile renderSpaceTile(BuildContext context, WidgetRef ref) {
-    final roomId = invitation.roomIdStr();
+  ListTile renderSpaceTile(BuildContext context) {
+    final roomId = widget.invitation.roomIdStr();
     final roomAvatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
     return ListTile(
       leading: ActerAvatar(
@@ -80,17 +100,14 @@ class InvitationCard extends ConsumerWidget {
       subtitle: Wrap(
         children: [
           Text(L10n.of(context).invitationToSpace),
-          inviter(
-            context,
-            ref,
-          ),
+          inviter(context),
         ],
       ),
     );
   }
 
-  ListTile renderGroupChatTile(BuildContext context, WidgetRef ref) {
-    final roomId = invitation.roomIdStr();
+  ListTile renderGroupChatTile(BuildContext context) {
+    final roomId = widget.invitation.roomIdStr();
     final roomAvatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
     return ListTile(
       leading: ActerAvatar(
@@ -99,23 +116,24 @@ class InvitationCard extends ConsumerWidget {
           size: 48,
         ),
       ),
+      title: Text(
+        roomTitle ?? roomId,
+        overflow: TextOverflow.ellipsis,
+      ),
       subtitle: Wrap(
         children: [
           Text(L10n.of(context).invitationToChat),
-          inviter(
-            context,
-            ref,
-          ),
+          inviter(context),
         ],
       ),
     );
   }
 
-  ListTile renderDmChatTile(BuildContext context, WidgetRef ref) {
+  ListTile renderDmChatTile(BuildContext context) {
     final profile =
-        ref.watch(invitationUserProfileProvider(invitation)).valueOrNull;
-    final senderId = invitation.senderIdStr();
-    final roomId = invitation.roomIdStr();
+        ref.watch(invitationUserProfileProvider(widget.invitation)).valueOrNull;
+    final senderId = widget.invitation.senderIdStr();
+    final roomId = widget.invitation.roomIdStr();
     return ListTile(
       leading: ActerAvatar(
         options: AvatarOptions.DM(
@@ -134,10 +152,10 @@ class InvitationCard extends ConsumerWidget {
     );
   }
 
-  Chip inviter(BuildContext context, WidgetRef ref) {
+  Chip inviter(BuildContext context) {
     final profile =
-        ref.watch(invitationUserProfileProvider(invitation)).valueOrNull;
-    final userId = invitation.senderIdStr();
+        ref.watch(invitationUserProfileProvider(widget.invitation)).valueOrNull;
+    final userId = widget.invitation.senderIdStr();
 
     return Chip(
       visualDensity: VisualDensity.compact,
@@ -156,14 +174,14 @@ class InvitationCard extends ConsumerWidget {
   }
 
   // method for post-process invitation accept
-  void _onTapAcceptInvite(BuildContext context, WidgetRef ref) async {
+  void _onTapAcceptInvite(BuildContext context) async {
     EasyLoading.show(status: L10n.of(context).joining);
     final client = ref.read(alwaysClientProvider);
-    final roomId = invitation.roomIdStr();
-    final isSpace = invitation.room().isSpace();
+    final roomId = widget.invitation.roomIdStr();
+    final isSpace = widget.invitation.room().isSpace();
     final lang = L10n.of(context);
     try {
-      await invitation.accept();
+      await widget.invitation.accept();
     } catch (e, s) {
       _log.severe('Failure accepting invite', e, s);
       if (!context.mounted) {
@@ -205,7 +223,7 @@ class InvitationCard extends ConsumerWidget {
   void _onTapDeclineInvite(BuildContext context) async {
     EasyLoading.show(status: L10n.of(context).rejecting);
     try {
-      bool res = await invitation.reject();
+      bool res = await widget.invitation.reject();
       if (!context.mounted) {
         EasyLoading.dismiss();
         return;

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -147,7 +147,10 @@ impl Client {
         let parsed = RoomOrAliasId::parse(room_id_or_alias)?;
         let server_names = match server_name {
             Some(inner) => vec![OwnedServerName::try_from(inner)?],
-            None => vec![],
+            None => parsed
+                .server_name()
+                .map(|i| vec![i.to_owned()])
+                .unwrap_or_default(),
         };
 
         self.join_room_typed(parsed, server_names).await


### PR DESCRIPTION
- f7122e93e1d92ea7b42bfa62dfe6485cdac46578 so that we see the room name when we are invited
- a798aed5d690ab406433748f9782b9beca93878f so that the invite list refreshes upon rejecting an invite
- be97be6d249ac79c5d95d45b4e2fdf36a03ddde1 uses the room id server as a fallback for public rooms that are linked into a space that don't have any particular `via`-parameter set