### PR TITLE
Fix push notifications forward for invites

### DIFF
--- a/.changes/2150-fix-push-for-invites.md
+++ b/.changes/2150-fix-push-for-invites.md
@@ -1,0 +1,1 @@
+- [Fix] forward to the activities screen if the push was for a room invite

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -77,20 +77,31 @@ Future<String?> forwardRedirect(
       return null;
     }
     final roomId = state.uri.queryParameters['roomId'];
-    if (await client.hasConvo(roomId!)) {
-      // this is a chat
+    if (roomId == null) {
+      _log.severe('Receivered forward without roomId failed: ${state.uri.queryParameters}.');
+      return state.namedLocation(Routes.main.name);
+    }
+
+      final room = await client.room(roomId!);
+      if (!room.isJoined()) {
+        // we haven't joined yet or have been kicked
+        // either way, we are to be shown the thing on the activities page
+        return state.namedLocation(Routes.activities.name, queryParameters: state.uri.queryParameters);
+      }
+
+      if (room.isSpace()) {
+      // final eventId = state.uri.queryParameters['eventId'];
+      // with the event ID or further information we could figure out the specific action
+        return state.namedLocation(
+          Routes.space.name,
+          pathParameters: {'spaceId': roomId},
+        );
+      }
+      // so we assume this is a chat
       return state.namedLocation(
         Routes.chatroom.name,
         pathParameters: {'roomId': roomId},
       );
-    } else {
-      // final eventId = state.uri.queryParameters['eventId'];
-      // with the event ID or further information we could figure out the specific action
-      return state.namedLocation(
-        Routes.space.name,
-        pathParameters: {'spaceId': roomId},
-      );
-    }
   } catch (e, s) {
     _log.severe('Forward fail', e, s);
     return state.namedLocation(

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -79,7 +79,8 @@ Future<String?> forwardRedirect(
     final roomId = state.uri.queryParameters['roomId'];
     if (roomId == null) {
       _log.severe(
-          'Receivered forward without roomId failed: ${state.uri.queryParameters}.');
+        'Received forward without roomId failed: ${state.uri.queryParameters}.',
+      );
       return state.namedLocation(Routes.main.name);
     }
 
@@ -87,8 +88,10 @@ Future<String?> forwardRedirect(
     if (!room.isJoined()) {
       // we haven't joined yet or have been kicked
       // either way, we are to be shown the thing on the activities page
-      return state.namedLocation(Routes.activities.name,
-          queryParameters: state.uri.queryParameters);
+      return state.namedLocation(
+        Routes.activities.name,
+        queryParameters: state.uri.queryParameters,
+      );
     }
 
     if (room.isSpace()) {

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -78,30 +78,32 @@ Future<String?> forwardRedirect(
     }
     final roomId = state.uri.queryParameters['roomId'];
     if (roomId == null) {
-      _log.severe('Receivered forward without roomId failed: ${state.uri.queryParameters}.');
+      _log.severe(
+          'Receivered forward without roomId failed: ${state.uri.queryParameters}.');
       return state.namedLocation(Routes.main.name);
     }
 
-      final room = await client.room(roomId!);
-      if (!room.isJoined()) {
-        // we haven't joined yet or have been kicked
-        // either way, we are to be shown the thing on the activities page
-        return state.namedLocation(Routes.activities.name, queryParameters: state.uri.queryParameters);
-      }
+    final room = await client.room(roomId);
+    if (!room.isJoined()) {
+      // we haven't joined yet or have been kicked
+      // either way, we are to be shown the thing on the activities page
+      return state.namedLocation(Routes.activities.name,
+          queryParameters: state.uri.queryParameters);
+    }
 
-      if (room.isSpace()) {
+    if (room.isSpace()) {
       // final eventId = state.uri.queryParameters['eventId'];
       // with the event ID or further information we could figure out the specific action
-        return state.namedLocation(
-          Routes.space.name,
-          pathParameters: {'spaceId': roomId},
-        );
-      }
-      // so we assume this is a chat
       return state.namedLocation(
-        Routes.chatroom.name,
-        pathParameters: {'roomId': roomId},
+        Routes.space.name,
+        pathParameters: {'spaceId': roomId},
       );
+    }
+    // so we assume this is a chat
+    return state.namedLocation(
+      Routes.chatroom.name,
+      pathParameters: {'roomId': roomId},
+    );
   } catch (e, s) {
     _log.severe('Forward fail', e, s);
     return state.namedLocation(

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -178,7 +178,7 @@ SPEC CHECKSUMS:
   device_info_plus: ce1b7762849d3ec103d0e0517299f2db7ad60720
   emoji_picker_flutter: 533634326b1c5de9a181ba14b9758e6dfe967a20
   fc_native_video_thumbnail: 927d4dcfd4c7e9f2cc1a20bb52dfee83de3792c2
-  file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
   Firebase: 9f574c08c2396885b5e7e100ed4293d956218af9
   firebase_core: c55630cdb8a01cf49eae741dd4bc8c93bdd546b8
   FirebaseCore: 3cf438f431f18c12cdf2aaf64434648b63f7e383
@@ -201,7 +201,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   tray_manager: 9064e219c56d75c476e46b9a21182087930baf90
-  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
   wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8


### PR DESCRIPTION
Before if we didn't know what the event was we just forwarded to the space. Which for invites meant that the user would get an error message as they can't access the room yet.

This fixes #2150 by swapping the order around: First we get the room, then check if we are in it, if not, we are forwarded to the `Activities`. If we are, we check whether it's a space or chat and forward accordingly.

See on iPhone in foreground

https://github.com/user-attachments/assets/367b0bab-cfc5-4276-b36d-8a54a032bda3

And it works for messages received while background as well:

https://github.com/user-attachments/assets/919b4daa-00c3-4464-b444-cd70fade528c



