### PR TITLE
Ensure bug reporter only open once

### DIFF
--- a/app/lib/features/bug_report/actions/open_bug_report.dart
+++ b/app/lib/features/bug_report/actions/open_bug_report.dart
@@ -17,25 +17,29 @@ Future<void> openBugReport(
   if (_bugReportOpen) {
     return;
   }
-  queryParams = queryParams ?? {};
-  final cacheDir = await appCacheDir();
-  // rage shake disallows dot in filename
-  final timestamp = DateTime.now().timestamp;
-  final imagePath = await screenshotController.captureAndSave(
-    cacheDir,
-    fileName: 'screenshot_$timestamp.png',
-  );
-  if (imagePath != null) {
-    queryParams['screenshot'] = imagePath;
-  }
-  if (!context.mounted) {
-    _log.warning('Trying to open the bugreport without being mounted');
-    return;
-  }
   _bugReportOpen = true;
-  await context.pushNamed(
-    Routes.bugReport.name,
-    queryParameters: queryParams,
-  );
-  _bugReportOpen = false;
+  try {
+    queryParams = queryParams ?? {};
+    final cacheDir = await appCacheDir();
+    // rage shake disallows dot in filename
+    final timestamp = DateTime.now().timestamp;
+    final imagePath = await screenshotController.captureAndSave(
+      cacheDir,
+      fileName: 'screenshot_$timestamp.png',
+    );
+    if (imagePath != null) {
+      queryParams['screenshot'] = imagePath;
+    }
+    if (!context.mounted) {
+      _log.warning('Trying to open the bugreport without being mounted');
+      return;
+    }
+    _bugReportOpen = true;
+    await context.pushNamed(
+      Routes.bugReport.name,
+      queryParameters: queryParams,
+    );
+  } finally {
+    _bugReportOpen = false;
+  }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2658,10 +2658,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   volume_controller:
     dependency: transitive
     description:


### PR DESCRIPTION
Minor bugfix that meant if were not properly awaiting for the bug reporter action, it could open more than once. This could happen if you'd call it in background for example.

This fix changes the behavior to _immediately_ set the local state to prevent any further opening and reset it within a `finally` to ensure it is unset after. This means we are doing this before the first await yield point and thus prevent any further call from opening it.