### PR TITLE
Don't block on notification initialization. 

### DIFF
--- a/app/lib/config/notifications/init.dart
+++ b/app/lib/config/notifications/init.dart
@@ -10,6 +10,7 @@ import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:acter/router/router.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_notifify/acter_notifify.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
@@ -21,7 +22,7 @@ const pushServer = Env.pushServer;
 const ntfyServer = Env.ntfyServer;
 
 Future<String?> initializeNotifications() async {
-  return await initializeNotifify(
+  final initialLocationFromNotification = await initializeNotifify(
     androidFirebaseOptions: DefaultFirebaseOptions.android,
     handleMessageTap: _handleMessageTap,
     isEnabledCheck: _isEnabled,
@@ -34,6 +35,14 @@ Future<String?> initializeNotifications() async {
         Env.windowsApplicationId.isNotEmpty ? Env.windowsApplicationId : null,
     currentClientsGen: _genCurrentClients,
   );
+
+  if (initialLocationFromNotification != null) {
+    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
+      // push after the next render to ensure we still have the "initial" location
+      goRouter.push(initialLocationFromNotification);
+    });
+  }
+  return initialLocationFromNotification;
 }
 
 Future<bool> setupPushNotifications(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:acter/common/tutorial_dialogs/space_overview_tutorials/create_or
 import 'package:acter/common/tutorial_dialogs/space_overview_tutorials/space_overview_tutorials.dart';
 import 'package:acter/common/utils/logging.dart';
 import 'package:acter/common/utils/main.dart';
-import 'package:acter/common/utils/utils.dart';
 import 'package:acter/config/desktop.dart';
 import 'package:acter/config/env.g.dart';
 import 'package:acter/config/notifications/init.dart';
@@ -60,18 +59,15 @@ Future<void> _startAppInner(Widget app, bool withSentry) async {
     linux: true,
   );
   await initLogging();
-  final initialLocationFromNotification = await initializeNotifications();
+
+  // Note: do await on this or we might be awaiting for an interaction
+  //       on macos desktop without showing anything. This can happen in
+  //       background.
+  initializeNotifications();
 
   if (isDesktop) {
     app = DesktopSupport(child: app);
   }
-
-  initialLocationFromNotification.let((p0) {
-    WidgetsBinding.instance.addPostFrameCallback((Duration duration) {
-      // push after the next render to ensure we still have the "initial" location
-      goRouter.push(p0);
-    });
-  });
 
   if (withSentry) {
     await SentryFlutter.init(


### PR DESCRIPTION
The problem of #2218 occurs because on the very first start on a fresh system, the user is informed about the notifications happening. As we are awaiting this call (to allow to redirect there properly), the screen stays blank until the user agreed. This is confusing.

The fix is to not wait for that to return. We can still do the routing fixes at a later point.

fixes #2218