### PR TITLE
Show proper info of subspaces and space chats, hide unaccessible entries.

### DIFF
--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -115,7 +115,6 @@ class SpaceItem {
 
 class SpaceRelationsOverview {
   bool hasMore;
-  SpaceRelations rel;
   List<String> knownSubspaces;
   List<String> knownChats;
   List<String> suggestedIds;
@@ -124,7 +123,6 @@ class SpaceRelationsOverview {
   List<Space> otherRelations;
 
   SpaceRelationsOverview({
-    required this.rel,
     required this.knownSubspaces,
     required this.knownChats,
     required this.suggestedIds,
@@ -280,7 +278,6 @@ final spaceRelationsOverviewProvider =
     }
   }
   return SpaceRelationsOverview(
-    rel: relatedSpaces,
     parents: parents,
     knownChats: knownChats,
     knownSubspaces: knownSubspaces,

--- a/app/lib/features/categories/model/CategoryModelLocal.dart
+++ b/app/lib/features/categories/model/CategoryModelLocal.dart
@@ -6,11 +6,13 @@ class CategoryModelLocal {
   final Color? color;
   final ActerIcon? icon;
   final List<String> entries;
+  final bool isUncategorized;
 
   const CategoryModelLocal({
     required this.title,
     this.color,
     this.icon,
     required this.entries,
+    this.isUncategorized = false,
   });
 }

--- a/app/lib/features/categories/utils/category_utils.dart
+++ b/app/lib/features/categories/utils/category_utils.dart
@@ -25,19 +25,6 @@ class CategoryUtils {
     return category.color != null && category.icon != null;
   }
 
-  ///GET LIST OF LOCAL CATEGORY WHICH EXCLUDE ITEM WITH EMPTY ENTRIES
-  List<CategoryModelLocal> getCategorisedListWithoutEmptyEntries(
-    List<CategoryModelLocal> categoryList,
-  ) {
-    List<CategoryModelLocal> categoryListLocalWithoutEmptyEntries = [];
-    for (var categoryListLocal in categoryList) {
-      if (categoryListLocal.entries.isNotEmpty) {
-        categoryListLocalWithoutEmptyEntries.add(categoryListLocal);
-      }
-    }
-    return categoryListLocalWithoutEmptyEntries;
-  }
-
   ///GET CATEGORIES LOCAL LIST BASED ON ITEM ENTRIES
   List<CategoryModelLocal> getCategorisedList(
     List<Category> categoryList,

--- a/app/lib/features/categories/utils/category_utils.dart
+++ b/app/lib/features/categories/utils/category_utils.dart
@@ -66,7 +66,8 @@ class CategoryUtils {
     //ADD UN-CATEGORIES ITEM to LAST POSITION
     CategoryModelLocal unCategorized = CategoryModelLocal(
       entries: unCategoriesEntriesList,
-      title: 'Un-categorized',
+      title: '',
+      isUncategorized: true,
     );
     categoryListLocal.add(unCategorized);
 

--- a/app/lib/features/chat/pages/sub_chats_page.dart
+++ b/app/lib/features/chat/pages/sub_chats_page.dart
@@ -201,9 +201,14 @@ class SubChatsPage extends ConsumerWidget {
       child: ExpansionTile(
         tilePadding: const EdgeInsets.only(right: 16),
         initiallyExpanded: true,
+        showTrailingIcon: !categoryModelLocal.isUncategorized,
+        enabled: !categoryModelLocal.isUncategorized,
+        minTileHeight: categoryModelLocal.isUncategorized ? 0 : null,
         shape: const Border(),
         collapsedBackgroundColor: Colors.transparent,
-        title: CategoryHeaderView(categoryModelLocal: categoryModelLocal),
+        title: categoryModelLocal.isUncategorized
+            ? const SizedBox.shrink()
+            : CategoryHeaderView(categoryModelLocal: categoryModelLocal),
         children: List<Widget>.generate(entries.length, (index) {
           final roomEntry = entries[index];
           final roomInfo = roomEntry.$1;

--- a/app/lib/features/spaces/pages/sub_spaces_page.dart
+++ b/app/lib/features/spaces/pages/sub_spaces_page.dart
@@ -3,12 +3,15 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/skeletons/general_list_skeleton_widget.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/room/room_card.dart';
+import 'package:acter/common/widgets/room/room_hierarchy_card.dart';
+import 'package:acter/common/widgets/room/room_hierarchy_join_button.dart';
 import 'package:acter/common/widgets/room/room_hierarchy_options_menu.dart';
 import 'package:acter/features/categories/model/CategoryModelLocal.dart';
 import 'package:acter/features/categories/providers/categories_providers.dart';
 import 'package:acter/features/categories/utils/category_utils.dart';
 import 'package:acter/features/categories/widgets/category_header_view.dart';
 import 'package:acter/features/spaces/providers/space_list_provider.dart';
+import 'package:acter/router/utils.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -169,7 +172,36 @@ class SubSpacesPage extends ConsumerWidget {
     WidgetRef ref,
     CategoryModelLocal categoryModelLocal,
   ) {
-    final entries = categoryModelLocal.entries;
+    final knownSubspaces = ref
+            .watch(spaceRelationsOverviewProvider(spaceId))
+            .valueOrNull
+            ?.knownSubspaces ??
+        [];
+    final remoteSubSpaces =
+        ref.watch(remoteSubspaceRelationsProvider(spaceId)).valueOrNull ?? [];
+    final entries = [];
+
+    for (final subSpaceId in categoryModelLocal.entries) {
+      if (knownSubspaces.contains(subSpaceId)) {
+        // user already knows this one
+        entries.add((null, subSpaceId));
+      } else {
+        for (final r in remoteSubSpaces) {
+          if (r.roomIdStr() == subSpaceId) {
+            if (r.joinRuleStr().toLowerCase() != 'private') {
+              // we ignore private cases
+              entries.add((r, subSpaceId));
+            }
+
+            break; // room was found but ignored
+          }
+        }
+      }
+    }
+    if (entries.isEmpty) {
+      // nothing to show, hide category
+      return const SizedBox.shrink();
+    }
 
     final suggestedSpaces =
         ref.watch(suggestedSpacesProvider(spaceId)).valueOrNull;
@@ -188,7 +220,40 @@ class SubSpacesPage extends ConsumerWidget {
         collapsedBackgroundColor: Colors.transparent,
         title: CategoryHeaderView(categoryModelLocal: categoryModelLocal),
         children: List<Widget>.generate(entries.length, (index) {
-          final roomId = entries[index];
+          final roomEntry = entries[index];
+          final roomInfo = roomEntry.$1;
+          final roomId = roomEntry.$2;
+          if (roomInfo != null) {
+            // we don't have this room yet, need to show via room hierarchy
+            final parentId = spaceId;
+            return RoomHierarchyCard(
+              key: Key('subspace-list-item-$roomId'),
+              roomInfo: roomInfo,
+              parentId: parentId,
+              indicateIfSuggested: true,
+              trailing: Wrap(
+                children: [
+                  RoomHierarchyJoinButton(
+                    joinRule: roomInfo.joinRuleStr().toLowerCase(),
+                    roomId: roomId,
+                    roomName: roomInfo.name() ?? roomId,
+                    viaServerName: roomInfo.viaServerName(),
+                    forward: (spaceId) {
+                      goToSpace(context, spaceId);
+                      ref.invalidate(spaceRelationsProvider(parentId));
+                      ref.invalidate(spaceRemoteRelationsProvider(parentId));
+                    },
+                  ),
+                  RoomHierarchyOptionsMenu(
+                    isSuggested: roomInfo.suggested(),
+                    childId: roomId,
+                    parentId: parentId,
+                  ),
+                ],
+              ),
+            );
+          }
+
           final isSuggested = suggestedSpaceIds.contains(roomId);
           return RoomCard(
             roomId: roomId,

--- a/app/lib/features/spaces/pages/sub_spaces_page.dart
+++ b/app/lib/features/spaces/pages/sub_spaces_page.dart
@@ -215,10 +215,14 @@ class SubSpacesPage extends ConsumerWidget {
     return Card(
       child: ExpansionTile(
         tilePadding: const EdgeInsets.only(right: 16),
-        initiallyExpanded: true,
+        showTrailingIcon: !categoryModelLocal.isUncategorized,
+        enabled: !categoryModelLocal.isUncategorized,
+        minTileHeight: categoryModelLocal.isUncategorized ? 0 : null,
         shape: const Border(),
         collapsedBackgroundColor: Colors.transparent,
-        title: CategoryHeaderView(categoryModelLocal: categoryModelLocal),
+        title: categoryModelLocal.isUncategorized
+            ? const SizedBox.shrink()
+            : CategoryHeaderView(categoryModelLocal: categoryModelLocal),
         children: List<Widget>.generate(entries.length, (index) {
           final roomEntry = entries[index];
           final roomInfo = roomEntry.$1;

--- a/app/lib/features/spaces/pages/sub_spaces_page.dart
+++ b/app/lib/features/spaces/pages/sub_spaces_page.dart
@@ -8,7 +8,6 @@ import 'package:acter/common/widgets/room/room_hierarchy_join_button.dart';
 import 'package:acter/common/widgets/room/room_hierarchy_options_menu.dart';
 import 'package:acter/features/categories/model/CategoryModelLocal.dart';
 import 'package:acter/features/categories/providers/categories_providers.dart';
-import 'package:acter/features/categories/utils/category_utils.dart';
 import 'package:acter/features/categories/widgets/category_header_view.dart';
 import 'package:acter/features/spaces/providers/space_list_provider.dart';
 import 'package:acter/router/utils.dart';
@@ -147,18 +146,13 @@ class SubSpacesPage extends ConsumerWidget {
     );
 
     return localCategoryList.when(
-      data: (localCategoryListData) {
-        final categoryList = CategoryUtils()
-            .getCategorisedListWithoutEmptyEntries(localCategoryListData);
-        return ListView.builder(
-          scrollDirection: Axis.vertical,
-          shrinkWrap: true,
-          itemCount: categoryList.length,
-          itemBuilder: (BuildContext context, int index) {
-            return _buildCategoriesList(context, ref, categoryList[index]);
-          },
-        );
-      },
+      data: (categoryList) => ListView.builder(
+        scrollDirection: Axis.vertical,
+        shrinkWrap: true,
+        itemCount: categoryList.length,
+        itemBuilder: (BuildContext context, int index) =>
+            _buildCategoriesList(context, ref, categoryList[index]),
+      ),
       error: (e, s) {
         _log.severe('Failed to load the sub-spaces', e, s);
         return Center(child: Text(L10n.of(context).loadingFailed(e)));
@@ -219,6 +213,7 @@ class SubSpacesPage extends ConsumerWidget {
         enabled: !categoryModelLocal.isUncategorized,
         minTileHeight: categoryModelLocal.isUncategorized ? 0 : null,
         shape: const Border(),
+        initiallyExpanded: true,
         collapsedBackgroundColor: Colors.transparent,
         title: categoryModelLocal.isUncategorized
             ? const SizedBox.shrink()

--- a/app/test/features/spaces/spacechats_test.dart
+++ b/app/test/features/spaces/spacechats_test.dart
@@ -1,0 +1,263 @@
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/widgets/room/room_card.dart';
+import 'package:acter/common/widgets/room/room_hierarchy_card.dart';
+import 'package:acter/features/categories/providers/categories_providers.dart';
+import 'package:acter/features/categories/utils/category_utils.dart';
+import 'package:acter/features/chat/pages/sub_chats_page.dart';
+import 'package:acter/features/space/widgets/space_info.dart';
+import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:acter/features/space/providers/suggested_provider.dart';
+import 'package:acter/features/space/widgets/space_sections/chats_section.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/mock_room_providers.dart';
+import '../../helpers/mock_space_providers.dart';
+import '../../helpers/test_util.dart';
+
+void main() {
+  List<Override> spaceOverrides() => [
+        // mocking so we can display the page in general
+        roomVisibilityProvider.overrideWith((a, b) => null),
+        roomDisplayNameProvider.overrideWith((a, b) => null),
+        parentAvatarInfosProvider.overrideWith((a, b) => []),
+        roomAvatarProvider.overrideWith((a, b) => null),
+        membersIdsProvider.overrideWith((a, b) => []),
+        roomAvatarInfoProvider.overrideWith(() => MockRoomAvatarInfoNotifier()),
+        roomMembershipProvider.overrideWith((a, b) => null),
+        isBookmarkedProvider.overrideWith((a, b) => false),
+        spaceInvitedMembersProvider.overrideWith((a, b) => []),
+        shouldShowSuggestedProvider.overrideWith((a, b) => false),
+        isActerSpaceForSpace.overrideWith((a, b) => false),
+        suggestedSpacesProvider.overrideWith((a, b) async {
+          return (List<String>.empty(), List<SpaceHierarchyRoomInfo>.empty());
+        }),
+      ];
+
+  group('Spacechats Page unaccessible items', () {
+    testWidgets('Known show only', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRemoteRelationsProvider.overrideWith((a, b) => []),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: ['b', 'c'], // those are known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubChatsPage(spaceId: '!spaceId'),
+      );
+
+      // a doesn't show, b and c do because they are known
+      expect(find.byType(RoomCard), findsExactly(2));
+    });
+
+    testWidgets('Unaccessible not shown', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRelationsProvider.overrideWith((a, b) => null), // no remote
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: [], // those aren't known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubChatsPage(spaceId: '!spaceId'),
+      );
+
+      // None of the items are accessible, do not show
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.byType(RoomHierarchyCard), findsNothing);
+    });
+
+    testWidgets('Remote is shown, too', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          maybeRoomProvider.overrideWith(() => MockAsyncMaybeRoomNotifier()),
+          suggestedSpacesProvider.overrideWith((a, b) async {
+            return (List<String>.empty(), List<SpaceHierarchyRoomInfo>.empty());
+          }),
+          roomHierarchyAvatarProvider.overrideWith((a, b) => null),
+          remoteChatRelationsProvider.overrideWith(
+            (a, b) => [
+              MockSpaceHierarchyRoomInfo(roomId: 'c', joinRule: 'Public'),
+            ],
+          ),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: [
+                'b',
+              ], // those are known, 'c' is a known remote one
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubChatsPage(spaceId: '!spaceId'),
+      );
+
+      // a doesn't show, b and c do
+      expect(find.byType(RoomCard), findsExactly(1));
+      expect(find.byType(RoomHierarchyCard), findsExactly(1));
+    });
+  });
+
+  group('Space Chat Overview Section unaccessible items', () {
+    testWidgets('Known show only', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRemoteRelationsProvider.overrideWith((a, b) => []),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: ['b', 'c'],
+              knownSubspaces: [], // those are known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const ChatsSection(spaceId: '!spaceId', limit: 3),
+      );
+
+      // a doesn't show, b and c do because they are known
+      expect(find.byType(RoomCard), findsExactly(2));
+    });
+
+    testWidgets('Unaccessible not shown', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRelationsProvider.overrideWith((a, b) => null), // no remote
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: [], // those aren't known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const ChatsSection(spaceId: '!spaceId', limit: 3),
+      );
+
+      // None of the items are accessible, do not show
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.byType(RoomHierarchyCard), findsNothing);
+    });
+
+    testWidgets('Remote is shown, too', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          maybeRoomProvider.overrideWith(() => MockAsyncMaybeRoomNotifier()),
+          suggestedSpacesProvider.overrideWith((a, b) async {
+            return (List<String>.empty(), List<SpaceHierarchyRoomInfo>.empty());
+          }),
+          roomHierarchyAvatarProvider.overrideWith((a, b) => null),
+          remoteChatRelationsProvider.overrideWith(
+            (a, b) => [
+              MockSpaceHierarchyRoomInfo(roomId: 'c', joinRule: 'Public'),
+            ],
+          ),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: ['b'],
+              knownSubspaces: [], // those are known, 'c' is a known remote one
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const ChatsSection(spaceId: '!spaceId', limit: 3),
+      );
+
+      // a doesn't show, b and c do
+      expect(find.byType(RoomCard), findsExactly(1));
+      expect(find.byType(RoomHierarchyCard), findsExactly(1));
+    });
+  });
+}

--- a/app/test/features/spaces/spacechats_test.dart
+++ b/app/test/features/spaces/spacechats_test.dart
@@ -44,8 +44,8 @@ void main() {
           spaceRelationsOverviewProvider.overrideWith(
             (a, b) => SpaceRelationsOverview(
               parents: [],
-              knownChats: [],
-              knownSubspaces: ['b', 'c'], // those are known
+              knownChats: ['b', 'c'],
+              knownSubspaces: [], // those are known
               otherRelations: [],
               mainParent: null,
               hasMore: false,
@@ -120,10 +120,8 @@ void main() {
           spaceRelationsOverviewProvider.overrideWith(
             (a, b) => SpaceRelationsOverview(
               parents: [],
-              knownChats: [],
-              knownSubspaces: [
-                'b',
-              ], // those are known, 'c' is a known remote one
+              knownChats: ['b'],
+              knownSubspaces: [], // those are known, 'c' is a known remote one
               otherRelations: [],
               mainParent: null,
               hasMore: false,

--- a/app/test/features/spaces/subspaces_test.dart
+++ b/app/test/features/spaces/subspaces_test.dart
@@ -1,0 +1,150 @@
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/widgets/room/room_card.dart';
+import 'package:acter/common/widgets/room/room_hierarchy_card.dart';
+import 'package:acter/features/categories/providers/categories_providers.dart';
+import 'package:acter/features/categories/utils/category_utils.dart';
+import 'package:acter/features/space/widgets/space_info.dart';
+import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
+import 'package:acter/features/space/providers/suggested_provider.dart';
+import 'package:acter/features/spaces/pages/sub_spaces_page.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/mock_room_providers.dart';
+import '../../helpers/mock_space_providers.dart';
+import '../../helpers/test_util.dart';
+
+void main() {
+  List<Override> spaceOverrides() => [
+        // mocking so we can display the page in general
+        roomVisibilityProvider.overrideWith((a, b) => null),
+        roomDisplayNameProvider.overrideWith((a, b) => null),
+        parentAvatarInfosProvider.overrideWith((a, b) => []),
+        roomAvatarProvider.overrideWith((a, b) => null),
+        membersIdsProvider.overrideWith((a, b) => []),
+        roomAvatarInfoProvider.overrideWith(() => MockRoomAvatarInfoNotifier()),
+        roomMembershipProvider.overrideWith((a, b) => null),
+        isBookmarkedProvider.overrideWith((a, b) => false),
+        spaceInvitedMembersProvider.overrideWith((a, b) => []),
+        shouldShowSuggestedProvider.overrideWith((a, b) => false),
+        isActerSpaceForSpace.overrideWith((a, b) => false),
+        suggestedSpacesProvider.overrideWith((a, b) async {
+          return (List<String>.empty(), List<SpaceHierarchyRoomInfo>.empty());
+        }),
+      ];
+
+  group('Subspaces Page unaccessible items', () {
+    testWidgets('Known show only', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRemoteRelationsProvider.overrideWith((a, b) => []),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: ['b', 'c'], // those are known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubSpacesPage(spaceId: '!spaceId'),
+      );
+
+      // a doesn't show, b and c do because they are known
+      expect(find.byType(RoomCard), findsExactly(2));
+    });
+
+    testWidgets('Unaccessible not shown', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          spaceRelationsProvider.overrideWith((a, b) => null), // no remote
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: [], // those aren't known
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubSpacesPage(spaceId: '!spaceId'),
+      );
+
+      // None of the items are accessible, do not show
+      expect(find.byType(RoomCard), findsNothing);
+      expect(find.byType(RoomHierarchyCard), findsNothing);
+    });
+
+    testWidgets('Remote is shown, too', (tester) async {
+      await tester.pumpProviderWidget(
+        overrides: [
+          ...spaceOverrides(),
+          maybeRoomProvider.overrideWith(() => MockAsyncMaybeRoomNotifier()),
+          suggestedSpacesProvider.overrideWith((a, b) async {
+            return (List<String>.empty(), List<SpaceHierarchyRoomInfo>.empty());
+          }),
+          roomHierarchyAvatarProvider.overrideWith((a, b) => null),
+          remoteSubspaceRelationsProvider.overrideWith(
+            (a, b) => [
+              MockSpaceHierarchyRoomInfo(roomId: 'c', joinRule: 'Public'),
+            ],
+          ),
+          spaceRelationsOverviewProvider.overrideWith(
+            (a, b) => SpaceRelationsOverview(
+              parents: [],
+              knownChats: [],
+              knownSubspaces: [
+                'b',
+              ], // those are known, 'c' is a known remote one
+              otherRelations: [],
+              mainParent: null,
+              hasMore: false,
+              suggestedIds: [],
+            ),
+          ),
+          localCategoryListProvider.overrideWith(
+            (a, b) => CategoryUtils().getCategorisedList(
+              [],
+              ['a', 'b', 'c'], // uncategorized subspaces
+            ),
+          ),
+
+          // the actual failing ones
+          spaceProvider.overrideWith((a, b) => MockSpace()),
+        ],
+        child: const SubSpacesPage(spaceId: '!spaceId'),
+      );
+
+      // a doesn't show, b and c do
+      expect(find.byType(RoomCard), findsExactly(1));
+      expect(find.byType(RoomHierarchyCard), findsExactly(1));
+    });
+  });
+}

--- a/app/test/helpers/mock_room_providers.dart
+++ b/app/test/helpers/mock_room_providers.dart
@@ -1,0 +1,13 @@
+import 'package:acter/common/providers/notifiers/room_notifiers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:mockito/mockito.dart';
+
+class MockAsyncMaybeRoomNotifier extends FamilyAsyncNotifier<Room?, String>
+    with Mock
+    implements AsyncMaybeRoomNotifier {
+  @override
+  Future<Room?> build(arg) async {
+    return null;
+  }
+}

--- a/app/test/helpers/mock_space_providers.dart
+++ b/app/test/helpers/mock_space_providers.dart
@@ -29,3 +29,35 @@ class RetryMockAsyncSpaceNotifier extends FamilyAsyncNotifier<Space?, String>
 }
 
 class MockSpace extends Fake implements Space {}
+
+class MockSpaceHierarchyRoomInfo extends Fake
+    implements SpaceHierarchyRoomInfo {
+  final String roomId;
+  final String? roomName;
+  final String joinRule;
+  final String serverName;
+  final bool isSuggested;
+
+  MockSpaceHierarchyRoomInfo({
+    required this.roomId,
+    this.roomName,
+    this.joinRule = 'Private',
+    this.isSuggested = false,
+    this.serverName = '',
+  });
+
+  @override
+  String roomIdStr() => roomId;
+
+  @override
+  String? name() => roomName;
+
+  @override
+  String joinRuleStr() => joinRule;
+
+  @override
+  String viaServerName() => serverName;
+
+  @override
+  bool suggested() => isSuggested;
+}


### PR DESCRIPTION
Fixes #2234 .

Contains new flutter widget tests to "proof" its true and remains true. Tests and fixes also applied to the chats.

While on it, d0f1fec07c881563e44e3e0c1e4d187aac1ae3e5 contains an update to make the "uncategorized" entry cleaner: no icons, no title, no ability to toggle -- none of them are necessary on that last thing.

This is what that looks like now:
![Bildschirmfoto_2024-10-09_17-38-05](https://github.com/user-attachments/assets/d626c795-cde0-4af2-8d39-1b21cd991f41)
