### PR TITLE
add labs flag for next-gen chat switch

### DIFF
--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -75,7 +75,8 @@ enum Routes {
   subSpaces('/:spaceId([!#][^/]+)/subSpaces'),
   subChats('/:spaceId([!#][^/]+)/subChats'),
   organizeCategories(
-      '/organizeCategories/:spaceId([^/]+)/:categoriesFor([^/]+)'),
+    '/organizeCategories/:spaceId([^/]+)/:categoriesFor([^/]+)',
+  ),
   spaceMembers('/:spaceId([!#][^/]+)/members'),
   spacePins('/:spaceId([!#][^/]+)/pins'),
   spaceEvents('/:spaceId([!#][^/]+)/events'),

--- a/app/lib/common/utils/routes.dart
+++ b/app/lib/common/utils/routes.dart
@@ -43,8 +43,14 @@ enum Routes {
   // show as dialog
   createChat('/chat/create'),
   chatroom('/chat/:roomId([!#][^/]+)'), // !roomId, #roomName
+
   chatProfile('/chat/:roomId([!#][^/]+)/profile'),
+
   chatSettingsVisibility('/chat/:roomId([!#][^/]+)/access'),
+  // chat-ng (room version) directs
+  chatNGRoom('/chat-ng/:roomId([!#][^/]+)'),
+  chatNGProfile('/chat-ng/:roomId([!#][^/]+)/profile'),
+  chatNGSettingsVisibility('/chat-ng/:roomId([!#][^/]+)/access'),
   chatInvite('/:roomId([!#][^/]+)/invite'),
 
   // --- tasks
@@ -68,7 +74,8 @@ enum Routes {
   space('/:spaceId([!#][^/]+)'), // !spaceId, #spaceName
   subSpaces('/:spaceId([!#][^/]+)/subSpaces'),
   subChats('/:spaceId([!#][^/]+)/subChats'),
-  organizeCategories('/organizeCategories/:spaceId([^/]+)/:categoriesFor([^/]+)'),
+  organizeCategories(
+      '/organizeCategories/:spaceId([^/]+)/:categoriesFor([^/]+)'),
   spaceMembers('/:spaceId([!#][^/]+)/members'),
   spacePins('/:spaceId([!#][^/]+)/pins'),
   spaceEvents('/:spaceId([!#][^/]+)/events'),

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -414,6 +414,7 @@ enum LabsFeature {
 
   // specific features
   chatUnread,
+  chatNG,
 
   // system features
   deviceCalendarSync,
@@ -440,6 +441,7 @@ enum LabsFeature {
         LabsFeature.encryptionBackup,
         LabsFeature.deviceCalendarSync,
         LabsFeature.mobilePushNotifications,
+        LabsFeature.chatNG,
       ];
 }
 

--- a/app/lib/features/chat/chat-ng/pages/ng_profile_page.dart
+++ b/app/lib/features/chat/chat-ng/pages/ng_profile_page.dart
@@ -1,0 +1,604 @@
+import 'package:acter/common/actions/close_room.dart';
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
+import 'package:acter/common/widgets/default_dialog.dart';
+import 'package:acter/common/widgets/edit_plain_description_sheet.dart';
+import 'package:acter/common/widgets/edit_title_sheet.dart';
+import 'package:acter/common/widgets/visibility/visibility_chip.dart';
+import 'package:acter/features/chat/widgets/member_list.dart';
+import 'package:acter/features/chat/widgets/room_avatar.dart';
+import 'package:acter/features/chat/widgets/skeletons/action_item_skeleton_widget.dart';
+import 'package:acter/features/room/widgets/notifications_settings_tile.dart';
+import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logging/logging.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+final _log = Logger('a3::chat::room_profile');
+
+class ChatNGProfilePage extends ConsumerStatefulWidget {
+  final String roomId;
+
+  const ChatNGProfilePage({
+    super.key,
+    required this.roomId,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _ChatNGProfilePageState();
+}
+
+class _ChatNGProfilePageState extends ConsumerState<ChatNGProfilePage> {
+  @override
+  Widget build(BuildContext context) {
+    final roomAvatarInfo = ref.watch(roomAvatarInfoProvider(widget.roomId));
+    final membership =
+        ref.watch(roomMembershipProvider(widget.roomId)).valueOrNull;
+    final convo = ref.watch(chatProvider(widget.roomId)).valueOrNull;
+    final isDirectChat =
+        ref.watch(isDirectChatProvider(widget.roomId)).valueOrNull ?? false;
+
+    return Column(
+      children: [
+        _buildAppBar(context, roomAvatarInfo, membership, convo, isDirectChat),
+        Expanded(
+          child: _buildBody(
+            context,
+            roomAvatarInfo,
+            membership,
+            convo,
+            isDirectChat,
+          ),
+        ),
+      ],
+    );
+  }
+
+  AppBar _buildAppBar(
+    BuildContext context,
+    AvatarInfo roomAvatarInfo,
+    Member? membership,
+    Convo? convo,
+    bool isDirectChat,
+  ) {
+    List<PopupMenuItem> menuListItems = [];
+    if (membership?.canString('CanSetName') == true) {
+      menuListItems.add(
+        PopupMenuItem(
+          onTap: () => showEditNameBottomSheet(roomAvatarInfo),
+          child: Text(L10n.of(context).editName),
+        ),
+      );
+    }
+    if (membership?.canString('CanSetTopic') == true) {
+      menuListItems.add(
+        PopupMenuItem(
+          onTap: () => showEditDescriptionBottomSheet(
+            context: context,
+            convo: convo,
+            descriptionValue: convo?.topic() ?? '',
+          ),
+          child: Text(L10n.of(context).editDescription),
+        ),
+      );
+
+      if (!isDirectChat &&
+          convo != null &&
+          membership?.canString('CanKick') == true &&
+          membership?.canString('CanUpdateJoinRule') == true) {
+        menuListItems.add(
+          PopupMenuItem(
+            onTap: () => openCloseRoomDialog(
+              context: context,
+              roomId: convo.getRoomIdStr(),
+            ),
+            child: Text(
+              L10n.of(context).closeChat,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ),
+        );
+      }
+    }
+
+    return AppBar(
+      // custom x-circle when we are in widescreen mode;
+      automaticallyImplyLeading: !context.isLargeScreen,
+      leading: context.isLargeScreen
+          ? IconButton(
+              onPressed: () => Navigator.pop(context),
+              icon: const Icon(Atlas.xmark_circle_thin),
+            )
+          : null,
+      backgroundColor: Colors.transparent,
+      elevation: 0.0,
+      actions: [
+        if (menuListItems.isNotEmpty)
+          PopupMenuButton(
+            icon: const Icon(Icons.more_vert),
+            itemBuilder: (context) => menuListItems,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBody(
+    BuildContext context,
+    AvatarInfo roomAvatarInfo,
+    Member? membership,
+    Convo? convo,
+    bool isDirectChat,
+  ) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10.0),
+        child: Column(
+          children: [
+            _header(
+              context,
+              roomAvatarInfo,
+              membership,
+              convo,
+              isDirectChat,
+            ),
+            _description(context, membership, convo),
+            _actions(
+              context,
+              convo,
+              isDirectChat,
+            ),
+            const SizedBox(height: 20),
+            _optionsBody(
+              context,
+              convo,
+              isDirectChat,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _header(
+    BuildContext context,
+    AvatarInfo roomAvatarInfo,
+    Member? membership,
+    Convo? convo,
+    bool isDirectChat,
+  ) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        InkWell(
+          onTap: () {
+            if (!isDirectChat) openAvatar(context, ref, widget.roomId);
+          },
+          child: RoomAvatar(
+            roomId: widget.roomId,
+            avatarSize: 75,
+            showParents: true,
+          ),
+        ),
+        const SizedBox(height: 10),
+        SelectionArea(
+          child: GestureDetector(
+            onTap: () {
+              if (membership?.canString('CanSetName') == true) {
+                showEditNameBottomSheet(roomAvatarInfo);
+              }
+            },
+            child: Text(
+              roomAvatarInfo.displayName ?? widget.roomId,
+              softWrap: true,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void showEditNameBottomSheet(AvatarInfo roomAvatarInfo) {
+    showEditTitleBottomSheet(
+      context: context,
+      bottomSheetTitle: L10n.of(context).editName,
+      titleValue: roomAvatarInfo.displayName ?? '',
+      onSave: (newName) => _saveName(newName),
+    );
+  }
+
+  Future<void> _saveName(String newName) async {
+    try {
+      EasyLoading.show(status: L10n.of(context).updateName);
+      final convo = await ref.read(chatProvider(widget.roomId).future);
+      if (convo == null) {
+        throw RoomNotFound();
+      }
+      await convo.setName(newName.trim());
+      EasyLoading.dismiss();
+      if (!mounted) return;
+      Navigator.pop(context);
+    } catch (e, s) {
+      _log.severe('Failed to edit chat name', e, s);
+      if (!mounted) {
+        EasyLoading.dismiss();
+        return;
+      }
+      EasyLoading.showError(
+        L10n.of(context).updateNameFailed(e),
+        duration: const Duration(seconds: 3),
+      );
+    }
+  }
+
+  Widget _description(BuildContext context, Member? membership, Convo? convo) {
+    String topic = convo?.topic() ?? '';
+    return SelectionArea(
+      child: GestureDetector(
+        onTap: () {
+          if (membership?.canString('CanSetTopic') == true) {
+            showEditDescriptionBottomSheet(
+              context: context,
+              convo: convo,
+              descriptionValue: convo?.topic() ?? '',
+            );
+          }
+        },
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: topic.isEmpty ? 0 : 16,
+            left: 16,
+            right: 16,
+          ),
+          child: Text(
+            topic,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _actions(BuildContext context, Convo? convo, bool isDirectChat) {
+    final membershipLoader = ref.watch(roomMembershipProvider(widget.roomId));
+    final isBookmarked =
+        ref.watch(isConvoBookmarked(widget.roomId)).valueOrNull ?? false;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        // Bookmark
+        _actionItem(
+          context: context,
+          iconData: isBookmarked ? Icons.bookmark : Icons.bookmark_border,
+          actionName: L10n.of(context).bookmark,
+          onTap: () async {
+            (await ref.read(chatProvider(widget.roomId).future))
+                ?.setBookmarked(!isBookmarked);
+          },
+        ),
+
+        // Invite
+        membershipLoader.when(
+          data: (membership) {
+            if (membership == null || isDirectChat) return const SizedBox();
+            return _actionItem(
+              context: context,
+              iconData: Atlas.user_plus_thin,
+              actionName: L10n.of(context).invite,
+              actionItemColor: membership.canString('CanInvite')
+                  ? null
+                  : Theme.of(context).colorScheme.onSurface,
+              onTap: () => _handleInvite(membership),
+            );
+          },
+          error: (e, s) {
+            _log.severe('Failed to load room membership', e, s);
+            return Text(L10n.of(context).errorLoadingTileDueTo(e));
+          },
+          loading: () => ActionItemSkeleton(
+            iconData: Atlas.user_plus_thin,
+            actionName: L10n.of(context).invite,
+          ),
+        ),
+
+        // Share
+        _actionItem(
+          context: context,
+          iconData: Icons.ios_share,
+          actionName: L10n.of(context).share,
+          onTap: _handleShare,
+        ),
+
+        // Leave room
+        _actionItem(
+          context: context,
+          iconData: Icons.exit_to_app,
+          actionName: L10n.of(context).leave,
+          actionItemColor: Theme.of(context).colorScheme.error,
+          onTap: showLeaveRoomDialog,
+        ),
+      ],
+    );
+  }
+
+  Widget _actionItem({
+    required BuildContext context,
+    required IconData iconData,
+    required String actionName,
+    Color? actionItemColor,
+    required VoidCallback onTap,
+  }) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 10),
+        margin: const EdgeInsets.symmetric(horizontal: 5),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: BorderRadius.circular(10.0),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          child: Column(
+            children: [
+              Icon(
+                iconData,
+                color: actionItemColor,
+              ),
+              const SizedBox(height: 10),
+              Text(
+                actionName,
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge!
+                    .copyWith(color: actionItemColor),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _optionsBody(BuildContext context, Convo? convo, bool isDirectChat) {
+    return Column(
+      children: [
+        // Notification section
+        Card(
+          margin: EdgeInsets.zero,
+          child: SettingsList(
+            physics: const NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            darkTheme: SettingsThemeData(
+              settingsListBackground: Colors.transparent,
+              dividerColor: Colors.transparent,
+              settingsSectionBackground: Colors.transparent,
+              leadingIconsColor: Theme.of(context).colorScheme.onSurface,
+            ),
+            sections: [
+              SettingsSection(
+                tiles: [
+                  NotificationsSettingsTile(roomId: widget.roomId),
+                ],
+              ),
+              SettingsSection(
+                tiles: [
+                  SettingsTile(
+                    title: Text(L10n.of(context).accessAndVisibility),
+                    description: VisibilityChip(roomId: widget.roomId),
+                    leading: const Icon(Atlas.lab_appliance_thin),
+                    onPressed: (context) => context.pushNamed(
+                      Routes.chatNGSettingsVisibility.name,
+                      pathParameters: {'roomId': widget.roomId},
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+
+        // Room members list section
+        if (!isDirectChat) _convoMembersList(),
+      ],
+    );
+  }
+
+  Widget _convoMembersList() {
+    final membersLoader = ref.watch(membersIdsProvider(widget.roomId));
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(10.0),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 10),
+          membersLoader.when(
+            data: (members) => Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              child: Text(
+                L10n.of(context).membersCount(members.length),
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
+            loading: () => Skeletonizer(
+              child: Text(L10n.of(context).membersCount(0)),
+            ),
+            error: (e, s) {
+              _log.severe('Failed to load room members', e, s);
+              return Text(L10n.of(context).errorLoadingMembersCount(e));
+            },
+          ),
+          MemberList(roomId: widget.roomId),
+        ],
+      ),
+    );
+  }
+
+  Future<void> showLeaveRoomDialog() async {
+    showAdaptiveDialog(
+      context: context,
+      useRootNavigator: false,
+      builder: (context) => DefaultDialog(
+        title: Text(
+          L10n.of(context).leaveRoom,
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        subtitle: Text(
+          L10n.of(context).areYouSureYouWantToLeaveRoom,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        actions: [
+          OutlinedButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(L10n.of(context).no),
+          ),
+          ActerPrimaryActionButton(
+            onPressed: _handleLeaveRoom,
+            child: Text(L10n.of(context).yes),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleLeaveRoom() async {
+    Navigator.pop(context);
+    EasyLoading.show(status: L10n.of(context).leavingRoom);
+    try {
+      final parentIds = await ref.read(parentIdsProvider(widget.roomId).future);
+      final convo = await ref.read(chatProvider(widget.roomId).future);
+      if (convo == null) {
+        throw RoomNotFound();
+      }
+      final res = await convo.leave();
+      if (!mounted) {
+        EasyLoading.dismiss();
+        return;
+      }
+
+      for (final parentId in parentIds) {
+        ref.invalidate(spaceRelationsProvider(parentId));
+        ref.invalidate(spaceRemoteRelationsProvider(parentId));
+      }
+      if (res) {
+        EasyLoading.dismiss();
+        context.goNamed(Routes.chat.name);
+      } else {
+        _log.severe('Failed to leave room');
+        EasyLoading.showError(
+          L10n.of(context).someErrorOccurredLeavingRoom,
+          duration: const Duration(seconds: 3),
+        );
+      }
+    } catch (e, s) {
+      _log.severe('Couldn’t leave room', e, s);
+      if (!mounted) {
+        EasyLoading.dismiss();
+        return;
+      }
+      EasyLoading.showError(
+        L10n.of(context).failedToLeaveRoom(e),
+        duration: const Duration(seconds: 3),
+      );
+    }
+  }
+
+  void _handleInvite(Member membership) {
+    if (membership.canString('CanInvite')) {
+      context.pushNamed(
+        Routes.chatInvite.name,
+        pathParameters: {'roomId': widget.roomId},
+      );
+    } else {
+      EasyLoading.showError(
+        L10n.of(context).notEnoughPowerLevelForInvites,
+        duration: const Duration(seconds: 3),
+      );
+    }
+  }
+
+  Future<void> _handleShare() async {
+    EasyLoading.show(status: L10n.of(context).sharingRoom);
+    try {
+      final convo = await ref.read(chatProvider(widget.roomId).future);
+      if (convo == null) {
+        throw RoomNotFound();
+      }
+      final roomLink = await convo.permalink();
+      if (!mounted) {
+        EasyLoading.dismiss();
+        return;
+      }
+      Share.share(
+        roomLink,
+        subject: L10n.of(context).linkToChat,
+      );
+      EasyLoading.showToast(L10n.of(context).sharedSuccessfully);
+    } catch (e, s) {
+      _log.severe('Couldn’t share this room', e, s);
+      if (!mounted) {
+        EasyLoading.dismiss();
+        return;
+      }
+      EasyLoading.showError(
+        L10n.of(context).failedToShareRoom(e),
+        duration: const Duration(seconds: 3),
+      );
+    }
+  }
+
+  void showEditDescriptionBottomSheet({
+    required BuildContext context,
+    required Convo? convo,
+    required String descriptionValue,
+  }) {
+    showEditPlainDescriptionBottomSheet(
+      context: context,
+      descriptionValue: descriptionValue,
+      onSave: (newDescription) async {
+        try {
+          EasyLoading.show(status: L10n.of(context).updateDescription);
+          await convo?.setTopic(newDescription);
+          EasyLoading.dismiss();
+          if (!context.mounted) return;
+          Navigator.pop(context);
+        } catch (e, s) {
+          _log.severe('Failed to change description', e, s);
+          if (!context.mounted) {
+            EasyLoading.dismiss();
+            return;
+          }
+          EasyLoading.showError(
+            L10n.of(context).updateDescriptionFailed(e),
+            duration: const Duration(seconds: 3),
+          );
+        }
+      },
+    );
+  }
+}

--- a/app/lib/features/chat/chat-ng/pages/room_page_ng.dart
+++ b/app/lib/features/chat/chat-ng/pages/room_page_ng.dart
@@ -1,0 +1,137 @@
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
+import 'package:acter/common/widgets/frost_effect.dart';
+import 'package:acter/features/chat/chat-ng/widgets/chat_input_ng.dart';
+import 'package:acter/features/chat/chat-ng/widgets/chat_room_ng.dart';
+import 'package:acter/features/chat/providers/chat_providers.dart';
+import 'package:acter/features/chat/widgets/room_avatar.dart';
+
+import 'package:acter/features/settings/providers/app_settings_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logging/logging.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+final _log = Logger('a3::chat::room');
+
+class ChatNGRoomPage extends ConsumerWidget {
+  static const roomPageKey = Key('chat-ng-room-page');
+  final String roomId;
+
+  const ChatNGRoomPage({
+    super.key = roomPageKey,
+    required this.roomId,
+  });
+
+  Widget appBar(BuildContext context, WidgetRef ref) {
+    final roomAvatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
+    final membersLoader = ref.watch(membersIdsProvider(roomId));
+    final isEncrypted =
+        ref.watch(isRoomEncryptedProvider(roomId)).valueOrNull ?? false;
+    return AppBar(
+      elevation: 0,
+      automaticallyImplyLeading: !context.isLargeScreen,
+      centerTitle: true,
+      toolbarHeight: 70,
+      flexibleSpace: FrostEffect(
+        child: Container(),
+      ),
+      title: GestureDetector(
+        onTap: () => context.pushNamed(
+          Routes.chatNGProfile.name,
+          pathParameters: {'roomId': roomId},
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              roomAvatarInfo.displayName ?? roomId,
+              overflow: TextOverflow.clip,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 5),
+            membersLoader.when(
+              data: (members) => Text(
+                L10n.of(context).membersCount(members.length),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              skipLoadingOnReload: false,
+              error: (e, s) {
+                _log.severe('Failed to load active members', e, s);
+                return Text(L10n.of(context).errorLoadingMembersCount(e));
+              },
+              loading: () => Skeletonizer(
+                child: Text(L10n.of(context).membersCount(100)),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        if (!isEncrypted)
+          IconButton(
+            onPressed: () =>
+                EasyLoading.showInfo(L10n.of(context).chatNotEncrypted),
+            icon: Icon(
+              PhosphorIcons.shieldWarning(),
+              color: Theme.of(context).colorScheme.error,
+            ),
+          ),
+        GestureDetector(
+          onTap: () => context.pushNamed(
+            Routes.chatNGProfile.name,
+            pathParameters: {'roomId': roomId},
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 10),
+            child: RoomAvatar(
+              roomId: roomId,
+              showParents: true,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return OrientationBuilder(
+      builder: (context, orientation) => Scaffold(
+        resizeToAvoidBottomInset: orientation == Orientation.portrait,
+        body: Column(
+          children: [
+            appBar(context, ref),
+            ChatNGRoom(roomId: roomId),
+            chatInput(context, ref),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget chatInput(BuildContext context, WidgetRef ref) {
+    final sendTypingNotice = ref.watch(
+      userAppSettingsProvider.select(
+        (settings) => settings.valueOrNull?.typingNotice() ?? false,
+      ),
+    );
+    return ChatInputNG(
+      key: Key('chat-ng-input-$roomId'),
+      roomId: roomId,
+      onTyping: (typing) async {
+        if (sendTypingNotice) {
+          final chat = await ref.read(chatProvider(roomId).future);
+          if (chat != null) await chat.typingNotice(typing);
+        }
+      },
+    );
+  }
+}

--- a/app/lib/features/chat/chat-ng/widgets/chat_input_ng.dart
+++ b/app/lib/features/chat/chat-ng/widgets/chat_input_ng.dart
@@ -1,0 +1,1008 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:acter/common/models/types.dart';
+import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/themes/app_theme.dart';
+import 'package:acter/common/widgets/emoji_picker_widget.dart';
+import 'package:acter/common/widgets/frost_effect.dart';
+import 'package:acter/features/attachments/actions/select_attachment.dart';
+import 'package:acter/features/chat/models/chat_input_state/chat_input_state.dart';
+import 'package:acter/features/chat/providers/chat_providers.dart';
+import 'package:acter/features/chat/utils.dart';
+import 'package:acter/features/chat/widgets/custom_message_builder.dart';
+import 'package:acter/features/chat/widgets/image_message_builder.dart';
+import 'package:acter/features/chat/widgets/mention_profile_builder.dart';
+import 'package:acter/features/chat/widgets/pill_builder.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' show MsgDraft;
+import 'package:acter_trigger_auto_complete/acter_trigger_autocomplete.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:atlas_icons/atlas_icons.dart';
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:flutter_matrix_html/flutter_html.dart';
+import 'package:flutter_matrix_html/text_parser.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart' show toBeginningOfSentenceCase;
+import 'package:logging/logging.dart';
+import 'package:mime/mime.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+final _log = Logger('a3::chat::custom_input');
+
+final _allowEdit = StateProvider.family.autoDispose<bool, String>(
+  (ref, roomId) => ref.watch(
+    chatInputProvider
+        .select((state) => state.sendingState == SendingState.preparing),
+  ),
+);
+
+final canSendProvider = FutureProvider.family<bool?, String>(
+  (ref, roomId) async {
+    final membership = ref.watch(roomMembershipProvider(roomId));
+    return membership.valueOrNull?.canString('CanSendChatMessages');
+  },
+);
+
+class ChatInputNG extends ConsumerWidget {
+  static const noAccessKey = Key('custom-chat-no-access');
+  static const loadingKey = Key('custom-chat-loading');
+  static const sendBtnKey = Key('custom-chat-send-button');
+
+  final String roomId;
+  final void Function(bool)? onTyping;
+
+  const ChatInputNG({
+    required this.roomId,
+    this.onTyping,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canSend = ref.watch(canSendProvider(roomId)).valueOrNull;
+    if (canSend == null) {
+      // we are still loading
+      return loadingState(context);
+    }
+    if (canSend) {
+      return _ChatInput(roomId: roomId, onTyping: onTyping);
+    }
+
+    return FrostEffect(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 15),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          child: Row(
+            children: [
+              const SizedBox(width: 1),
+              const Icon(
+                Atlas.block_prohibited_thin,
+                size: 14,
+                color: Colors.grey,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                key: noAccessKey,
+                L10n.of(context).chatMissingPermissionsToSend,
+                style: const TextStyle(color: Colors.grey, fontSize: 14),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget loadingState(BuildContext context) {
+    return Skeletonizer(
+      child: FrostEffect(
+        child: Container(
+          key: loadingKey,
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                const Padding(
+                  padding: EdgeInsets.only(right: 10),
+                  child: Icon(
+                    Atlas.paperclip_attachment_thin,
+                    size: 20,
+                  ),
+                ),
+                Flexible(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    child: TextField(
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      cursorColor: Theme.of(context).colorScheme.primary,
+                      maxLines: 6,
+                      minLines: 1,
+                      decoration: InputDecoration(
+                        isCollapsed: true,
+                        prefixIcon: Icon(
+                          Icons.shield,
+                          size: 18,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .primary
+                              .withOpacity(0.8),
+                        ),
+                        suffixIcon: const Icon(Icons.emoji_emotions),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30),
+                          borderSide: BorderSide(
+                            width: 0.5,
+                            style: BorderStyle.solid,
+                            color: Theme.of(context).colorScheme.surface,
+                          ),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30),
+                          borderSide: const BorderSide(
+                            width: 0.5,
+                            style: BorderStyle.solid,
+                          ),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30),
+                          borderSide: BorderSide(
+                            width: 0.5,
+                            style: BorderStyle.solid,
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
+                        ),
+                        hintText: L10n.of(context).newMessage,
+                        hintStyle: Theme.of(context)
+                            .textTheme
+                            .labelLarge!
+                            .copyWith(
+                              color: Theme.of(context).colorScheme.onSurface,
+                            ),
+                        contentPadding: const EdgeInsets.all(15),
+                        hintMaxLines: 1,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatInput extends ConsumerStatefulWidget {
+  final String roomId;
+  final void Function(bool)? onTyping;
+
+  const _ChatInput({
+    required this.roomId,
+    this.onTyping,
+  });
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => __ChatInputState();
+}
+
+class __ChatInputState extends ConsumerState<_ChatInput> {
+  late final ActerTriggerAutoCompleteTextController textController;
+  final FocusNode chatFocus = FocusNode();
+  final ValueNotifier<bool> _isInputEmptyNotifier = ValueNotifier(true);
+  Timer? _debounceTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _setController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      loadDraft();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _ChatInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.roomId != widget.roomId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        loadDraft();
+      });
+    }
+  }
+
+  void _setController() {
+    // putting constant colors here as context isn’t accessible in initState()
+    final triggerStyles = {
+      '@': TextStyle(
+        color: Colors.white,
+        height: 0.5,
+        background: Paint()
+          ..color = const Color(0xFF74A64D)
+          ..strokeWidth = 10
+          ..strokeJoin = StrokeJoin.round
+          ..style = PaintingStyle.stroke,
+      ),
+    };
+    textController =
+        ActerTriggerAutoCompleteTextController(triggerStyles: triggerStyles);
+    textController.addListener(_updateInputState);
+  }
+
+  // composer draft load state handler
+  Future<void> loadDraft() async {
+    final draft =
+        await ref.read(chatComposerDraftProvider(widget.roomId).future);
+
+    if (draft != null) {
+      final inputNotifier = ref.read(chatInputProvider.notifier);
+      inputNotifier.unsetSelectedMessage();
+      if (draft.eventId() != null) {
+        final eventId = draft.eventId()!;
+        final draftType = draft.draftType();
+
+        final m = ref
+            .read(chatMessagesProvider(widget.roomId))
+            .firstWhere((x) => x.id == eventId);
+        if (draftType == 'edit') {
+          inputNotifier.setEditMessage(m);
+        } else if (draftType == 'reply') {
+          inputNotifier.setReplyToMessage(m);
+        }
+      }
+      if (draft.htmlText() != null) {
+        await parseUserMentionText(
+          draft.htmlText()!,
+          widget.roomId,
+          textController,
+          ref,
+        );
+      } else {
+        textController.text = draft.plainText();
+      }
+
+      _log.info('compose draft loaded for room: ${widget.roomId}');
+    }
+  }
+
+  // listener for handling send state
+  void _updateInputState() {
+    _isInputEmptyNotifier.value = textController.text.trim().isEmpty;
+    _debounceTimer?.cancel();
+    // delay operation to avoid excessive re-writes
+    _debounceTimer = Timer(const Duration(milliseconds: 300), () async {
+      // save composing draft
+      await saveDraft(textController.text, widget.roomId, ref);
+      _log.info('compose draft saved for room: ${widget.roomId}');
+    });
+  }
+
+  void handleEmojiSelected(Category? category, Emoji emoji) {
+    String suffixText = '';
+
+    // Get the left text of cursor
+    String prefixText = '';
+    // Get cursor current position
+    var cursorPos = textController.selection.base.offset;
+    int emojiLength = emoji.emoji.length;
+
+    if (cursorPos >= 0) {
+      // can be -1 on empty and never accessed
+
+      // Right text of cursor position
+      suffixText = textController.text.substring(cursorPos);
+
+      // Get the left text of cursor
+      prefixText = textController.text.substring(0, cursorPos);
+      textController.text = prefixText + emoji.emoji + suffixText;
+    } else {
+      // no focus yet, add the emoji at the end of the content
+      cursorPos = textController.text.length;
+      textController.text += emoji.emoji;
+    }
+
+    // Add emoji at current current cursor position
+
+    // Cursor move to end of added emoji character
+    textController.selection = TextSelection(
+      baseOffset: cursorPos + emojiLength,
+      extentOffset: cursorPos + emojiLength,
+    );
+
+    // Ensure we keep the cursor up
+    // frame delay to keep focus connected with keyboard.
+    if (!chatFocus.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        chatFocus.requestFocus();
+      });
+    }
+  }
+
+  void handleBackspacePressed() {
+    if (textController.text.isEmpty) {
+      // nothing left to clear, close the emoji picker
+      ref.read(chatInputProvider.notifier).emojiPickerVisible(false);
+      return;
+    }
+    final newValue = textController.text.characters.skipLast(1).string;
+    textController.text = newValue;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedMessage = ref.watch(
+      chatInputProvider.select((value) => value.selectedMessage),
+    );
+    if (selectedMessage == null) return renderMain(context);
+    final selMsgState = ref.watch(
+      chatInputProvider.select((value) => value.selectedMessageState),
+    );
+    return switch (selMsgState) {
+      SelectedMessageState.replyTo => renderReplyView(context, selectedMessage),
+      SelectedMessageState.edit => renderEditView(context, selectedMessage),
+      SelectedMessageState.none ||
+      SelectedMessageState.actions =>
+        renderMain(context)
+    };
+  }
+
+  Widget renderMain(BuildContext context) {
+    return renderChatInputArea(context, null);
+  }
+
+  Widget renderChatInputArea(BuildContext context, Widget? child) {
+    final roomId = widget.roomId;
+    final isEncrypted =
+        ref.watch(isRoomEncryptedProvider(roomId)).valueOrNull ?? false;
+    final emojiPickerVisible = ref
+        .watch(chatInputProvider.select((value) => value.emojiPickerVisible));
+    return Column(
+      children: [
+        if (child != null) child,
+        FrostEffect(
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 15),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  Flexible(
+                    child: _TextInputWidget(
+                      roomId: roomId,
+                      controller: textController,
+                      chatFocus: chatFocus,
+                      onSendButtonPressed: () => onSendButtonPressed(ref),
+                      isEncrypted: isEncrypted,
+                      onTyping: widget.onTyping,
+                    ),
+                  ),
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _isInputEmptyNotifier,
+                    builder: (context, isEmpty, child) {
+                      return !isEmpty
+                          ? renderSendButton(context, roomId)
+                          : renderAttachmentPinButton();
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (emojiPickerVisible)
+          EmojiPickerWidget(
+            size: Size(
+              MediaQuery.of(context).size.width,
+              MediaQuery.of(context).size.height / 3,
+            ),
+            onEmojiSelected: handleEmojiSelected,
+            onBackspacePressed: handleBackspacePressed,
+            onClosePicker: () =>
+                ref.read(chatInputProvider.notifier).emojiPickerVisible(false),
+          ),
+      ],
+    );
+  }
+
+  Widget renderAttachmentPinButton() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      child: InkWell(
+        onTap: () => selectAttachment(
+          context: context,
+          onSelected: handleFileUpload,
+        ),
+        child: const Icon(
+          Atlas.paperclip_attachment_thin,
+          size: 20,
+        ),
+      ),
+    );
+  }
+
+  Widget renderSendButton(BuildContext context, String roomId) {
+    final allowEditing = ref.watch(_allowEdit(roomId));
+
+    if (allowEditing) {
+      return IconButton.filled(
+        key: ChatInputNG.sendBtnKey,
+        iconSize: 20,
+        onPressed: () => onSendButtonPressed(ref),
+        icon: const Icon(Icons.send),
+      );
+    }
+
+    return IconButton.filled(
+      iconSize: 20,
+      onPressed: () => {},
+      icon: Icon(
+        Icons.send,
+        color: Theme.of(context).colorScheme.inversePrimary,
+      ),
+    );
+  }
+
+  Widget renderReplyView(BuildContext context, Message repliedToMessage) {
+    final size = MediaQuery.of(context).size;
+    final roomId = widget.roomId;
+
+    return renderChatInputArea(
+      context,
+      FrostEffect(
+        widgetWidth: size.width,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(6.0),
+              topRight: Radius.circular(6.0),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: 12.0,
+              left: 16.0,
+              right: 16.0,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Consumer(
+                  builder: (context, ref, child) =>
+                      replyBuilder(roomId, repliedToMessage),
+                ),
+                _ReplyContentWidget(
+                  roomId: widget.roomId,
+                  msg: repliedToMessage,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget renderEditView(BuildContext context, Message editMessage) {
+    final size = MediaQuery.of(context).size;
+    return renderChatInputArea(
+      context,
+      FrostEffect(
+        widgetWidth: size.width,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(6.0),
+              topRight: Radius.circular(6.0),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 12.0,
+            ),
+            child: Consumer(builder: editMessageBuilder),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> handleFileUpload(
+    List<File> files,
+    AttachmentType attachmentType,
+  ) async {
+    final client = ref.read(alwaysClientProvider);
+    final inputState = ref.read(chatInputProvider);
+    final lang = L10n.of(context);
+    final stream = await ref.read(timelineStreamProvider(widget.roomId).future);
+
+    try {
+      for (final file in files) {
+        String? mimeType = lookupMimeType(file.path);
+        if (mimeType == null) throw lang.failedToDetectMimeType;
+        final fileLen = file.lengthSync();
+        if (mimeType.startsWith('image/') &&
+            attachmentType == AttachmentType.image) {
+          final bytes = file.readAsBytesSync();
+          final image = await decodeImageFromList(bytes);
+          final imageDraft = client
+              .imageDraft(file.path, mimeType)
+              .size(fileLen)
+              .width(image.width)
+              .height(image.height);
+          if (inputState.selectedMessageState == SelectedMessageState.replyTo) {
+            await stream.replyMessage(
+              inputState.selectedMessage!.remoteId!,
+              imageDraft,
+            );
+          } else {
+            await stream.sendMessage(imageDraft);
+          }
+        } else if (mimeType.startsWith('audio/') &&
+            attachmentType == AttachmentType.audio) {
+          final audioDraft =
+              client.audioDraft(file.path, mimeType).size(file.lengthSync());
+          if (inputState.selectedMessageState == SelectedMessageState.replyTo) {
+            await stream.replyMessage(
+              inputState.selectedMessage!.remoteId!,
+              audioDraft,
+            );
+          } else {
+            await stream.sendMessage(audioDraft);
+          }
+        } else if (mimeType.startsWith('video/') &&
+            attachmentType == AttachmentType.video) {
+          final videoDraft =
+              client.videoDraft(file.path, mimeType).size(file.lengthSync());
+
+          if (inputState.selectedMessageState == SelectedMessageState.replyTo) {
+            await stream.replyMessage(
+              inputState.selectedMessage!.remoteId!,
+              videoDraft,
+            );
+          } else {
+            await stream.sendMessage(videoDraft);
+          }
+        } else {
+          final fileDraft =
+              client.fileDraft(file.path, mimeType).size(file.lengthSync());
+
+          if (inputState.selectedMessageState == SelectedMessageState.replyTo) {
+            await stream.replyMessage(
+              inputState.selectedMessage!.remoteId!,
+              fileDraft,
+            );
+          } else {
+            await stream.sendMessage(fileDraft);
+          }
+        }
+      }
+    } catch (e, s) {
+      _log.severe('error occurred', e, s);
+    }
+
+    ref.read(chatInputProvider.notifier).unsetSelectedMessage();
+  }
+
+  Widget replyBuilder(String roomId, Message repliedToMessage) {
+    final authorId = repliedToMessage.author.id;
+    final memberAvatar =
+        ref.watch(memberAvatarInfoProvider((userId: authorId, roomId: roomId)));
+    final inputNotifier = ref.watch(chatInputProvider.notifier);
+    return Row(
+      children: [
+        const SizedBox(width: 1),
+        const Icon(
+          Icons.reply_rounded,
+          size: 12,
+          color: Colors.grey,
+        ),
+        const SizedBox(width: 4),
+        ActerAvatar(
+          options: AvatarOptions.DM(
+            memberAvatar,
+            size: 12,
+          ),
+        ),
+        const SizedBox(width: 5),
+        Text(
+          L10n.of(context).replyTo(toBeginningOfSentenceCase(authorId)),
+          style: const TextStyle(color: Colors.grey, fontSize: 12),
+        ),
+        const Spacer(),
+        GestureDetector(
+          onTap: () {
+            inputNotifier.unsetSelectedMessage();
+            chatFocus.requestFocus();
+          },
+          child: const Icon(Atlas.xmark_circle),
+        ),
+      ],
+    );
+  }
+
+  Widget editMessageBuilder(
+    BuildContext context,
+    WidgetRef ref,
+    Widget? child,
+  ) {
+    final inputNotifier = ref.watch(chatInputProvider.notifier);
+    return Row(
+      children: [
+        const SizedBox(width: 1),
+        const Icon(
+          Atlas.pencil_edit_thin,
+          size: 12,
+          color: Colors.grey,
+        ),
+        const SizedBox(width: 4),
+        Text(
+          L10n.of(context).editMessage,
+          style: const TextStyle(color: Colors.grey, fontSize: 12),
+        ),
+        const Spacer(),
+        GestureDetector(
+          onTap: () {
+            inputNotifier.unsetSelectedMessage();
+            textController.clear();
+          },
+          child: const Icon(Atlas.xmark_circle),
+        ),
+      ],
+    );
+  }
+
+  Future<void> onSendButtonPressed(WidgetRef ref) async {
+    if (textController.text.isEmpty) return;
+    final lang = L10n.of(context);
+    ref.read(chatInputProvider.notifier).startSending();
+    try {
+      // end the typing notification
+      if (widget.onTyping != null) {
+        widget.onTyping!(false);
+      }
+
+      final mentions = ref.read(chatInputProvider).mentions;
+      String markdownText = textController.text;
+      // Replace empty new lines with <br> tags
+      markdownText = markdownText.replaceAll(RegExp(r'(\n\s*\n)'), '\n<br>\n');
+      final userMentions = [];
+      mentions.forEach((key, value) {
+        userMentions.add(value);
+        markdownText = markdownText.replaceAll(
+          '@$key',
+          '[@$key](https://matrix.to/#/$value)',
+        );
+      });
+
+      // make the actual draft
+      final client = ref.read(alwaysClientProvider);
+      MsgDraft draft = client.textMarkdownDraft(markdownText);
+
+      for (final userId in userMentions) {
+        draft = draft.addMention(userId);
+      }
+
+      // actually send it out
+      final inputState = ref.read(chatInputProvider);
+      final stream = await ref.read(
+        timelineStreamProvider(widget.roomId).future,
+      );
+
+      if (inputState.selectedMessageState == SelectedMessageState.replyTo) {
+        await stream.replyMessage(inputState.selectedMessage!.remoteId!, draft);
+      } else if (inputState.selectedMessageState == SelectedMessageState.edit) {
+        await stream.editMessage(inputState.selectedMessage!.remoteId!, draft);
+      } else {
+        await stream.sendMessage(draft);
+      }
+
+      ref.read(chatInputProvider.notifier).messageSent();
+
+      textController.clear();
+      // also clear composed state
+      final convo = await ref.read(chatProvider(widget.roomId).future);
+      await convo?.saveMsgDraft(textController.text, null, 'new', null);
+    } catch (e, s) {
+      _log.severe('Sending chat message failed', e, s);
+      EasyLoading.showError(
+        lang.failedToSend(e),
+        duration: const Duration(seconds: 3),
+      );
+      ref.read(chatInputProvider.notifier).sendingFailed();
+    }
+
+    if (!chatFocus.hasFocus) {
+      chatFocus.requestFocus();
+    }
+  }
+}
+
+class _TextInputWidget extends ConsumerStatefulWidget {
+  final String roomId;
+  final ActerTriggerAutoCompleteTextController controller;
+  final FocusNode chatFocus;
+  final Function() onSendButtonPressed;
+  final bool isEncrypted;
+  final void Function(bool)? onTyping;
+
+  const _TextInputWidget({
+    required this.roomId,
+    required this.controller,
+    required this.chatFocus,
+    required this.onSendButtonPressed,
+    this.onTyping,
+    this.isEncrypted = false,
+  });
+
+  @override
+  ConsumerState<_TextInputWidget> createState() =>
+      _TextInputWidgetConsumerState();
+}
+
+class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
+  EditorState textEditorState = EditorState.blank(withInitialText: true);
+  @override
+  void initState() {
+    super.initState();
+    ref.listenManual(chatInputProvider, (prev, next) {
+      if (next.selectedMessageState == SelectedMessageState.edit &&
+          (prev?.selectedMessageState != next.selectedMessageState ||
+              next.selectedMessage != prev?.selectedMessage)) {
+        // a new message has been selected to be edited or switched from reply
+        // to edit, force refresh the inner text controller to reflect that
+        if (next.selectedMessage != null) {
+          widget.controller.text = parseEditMsg(next.selectedMessage!);
+          // frame delay to keep focus connected with keyboard.
+        }
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          widget.chatFocus.requestFocus();
+        });
+      } else if (next.selectedMessageState == SelectedMessageState.replyTo &&
+          (next.selectedMessage != prev?.selectedMessage ||
+              prev?.selectedMessageState != next.selectedMessageState)) {
+        // controller doesn’t update text so manually save draft state
+        saveDraft(widget.controller.text, widget.roomId, ref);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          widget.chatFocus.requestFocus();
+        });
+      }
+    });
+  }
+
+  void onTextTap(bool emojiPickerVisible, WidgetRef ref) {
+    final chatInputNotifier = ref.read(chatInputProvider.notifier);
+
+    ///Hide emoji picker before input field get focus if
+    ///Platform is mobile & Emoji picker is visible
+    if (!isDesktop && emojiPickerVisible) {
+      chatInputNotifier.emojiPickerVisible(false);
+    }
+  }
+
+  void onSuffixTap(
+    bool emojiPickerVisible,
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final chatInputNotifier = ref.read(chatInputProvider.notifier);
+    if (!emojiPickerVisible) {
+      //Hide soft keyboard and then show Emoji Picker
+      chatInputNotifier.emojiPickerVisible(true);
+    } else {
+      //Hide Emoji Picker
+      chatInputNotifier.emojiPickerVisible(false);
+    }
+  }
+
+  // adds new line
+  void _insertNewLine() {
+    final TextSelection selection = widget.controller.selection;
+    if (selection.isValid) {
+      final String text = widget.controller.text;
+      final int start = selection.start;
+      final newText = text.replaceRange(start, selection.end, '\n');
+      widget.controller.value = TextEditingValue(
+        text: newText,
+        selection: TextSelection.collapsed(offset: start + 1),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.enter): () {
+          widget.onSendButtonPressed();
+        },
+        LogicalKeySet(LogicalKeyboardKey.enter, LogicalKeyboardKey.shift): () {
+          _insertNewLine();
+        },
+      },
+      child: MultiTriggerAutocomplete(
+        optionsAlignment: OptionsAlignment.top,
+        textEditingController: widget.controller,
+        focusNode: widget.chatFocus,
+        autocompleteTriggers: [
+          AutocompleteTrigger(
+            trigger: '@',
+            optionsViewBuilder: (context, autocompleteQuery, ctrl) {
+              return MentionProfileBuilder(
+                context: context,
+                roomQuery: (
+                  query: autocompleteQuery.query,
+                  roomId: widget.roomId
+                ),
+              );
+            },
+          ),
+        ],
+        fieldViewBuilder: _innerTextField,
+      ),
+    );
+  }
+
+  Widget _innerTextField(
+    BuildContext context,
+    TextEditingController ctrl,
+    FocusNode chatFocus,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.2,
+      ),
+      child: TextField(
+        maxLines: 5,
+        minLines: 1,
+        onTap: () => onTextTap(
+          ref.read(chatInputProvider).emojiPickerVisible,
+          ref,
+        ),
+        controller: widget.controller,
+        focusNode: chatFocus,
+        textCapitalization: TextCapitalization.sentences,
+        enabled: ref.watch(_allowEdit(widget.roomId)),
+        onChanged: (String val) {
+          // send typing notice
+          if (widget.onTyping != null) {
+            widget.onTyping!(val.isNotEmpty);
+          }
+        },
+        onSubmitted: (_) => widget.onSendButtonPressed(),
+        style: Theme.of(context).textTheme.bodyMedium,
+        decoration: InputDecoration(
+          fillColor: Theme.of(context).unselectedWidgetColor.withOpacity(0.5),
+          contentPadding: const EdgeInsets.all(15),
+          isCollapsed: true,
+          prefixIcon: InkWell(
+            onTap: () => onSuffixTap(
+              ref.read(chatInputProvider).emojiPickerVisible,
+              context,
+              ref,
+            ),
+            child: const Icon(Icons.emoji_emotions),
+          ),
+          hintText: widget.isEncrypted
+              ? L10n.of(context).newEncryptedMessage
+              : L10n.of(context).newMessage,
+          hintMaxLines: 1,
+          focusedBorder: OutlineInputBorder(
+            borderSide: const BorderSide(width: 0.5),
+            borderRadius: BorderRadius.circular(30),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderSide: const BorderSide(width: 0.5),
+            borderRadius: BorderRadius.circular(30),
+          ),
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(30),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReplyContentWidget extends StatelessWidget {
+  final String roomId;
+  final Message msg;
+
+  const _ReplyContentWidget({
+    required this.roomId,
+    required this.msg,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (msg is ImageMessage) {
+      final imageMsg = msg as ImageMessage;
+      return Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: ImageMessageBuilder(
+          roomId: roomId,
+          message: imageMsg,
+          messageWidth: imageMsg.size.toInt(),
+          isReplyContent: true,
+        ),
+      );
+    } else if (msg is TextMessage) {
+      final textMsg = msg as TextMessage;
+      return Container(
+        constraints:
+            BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.2),
+        padding: const EdgeInsets.all(12),
+        child: Html(
+          data: textMsg.text,
+          pillBuilder: ({
+            required String identifier,
+            required String url,
+            OnPillTap? onTap,
+          }) =>
+              ActerPillBuilder(
+            identifier: identifier,
+            uri: url,
+            roomId: roomId,
+          ),
+          defaultTextStyle: Theme.of(context)
+              .textTheme
+              .bodySmall!
+              .copyWith(overflow: TextOverflow.ellipsis),
+          maxLines: 3,
+        ),
+      );
+    } else if (msg is FileMessage) {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          msg.metadata?['content'],
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      );
+    } else if (msg is CustomMessage) {
+      return CustomMessageBuilder(
+        message: msg as CustomMessage,
+        messageWidth: 100,
+      );
+    } else {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          L10n.of(context).replyPreviewUnavailable,
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall!
+              .copyWith(fontStyle: FontStyle.italic),
+        ),
+      );
+    }
+  }
+}

--- a/app/lib/features/chat/chat-ng/widgets/chat_room_ng.dart
+++ b/app/lib/features/chat/chat-ng/widgets/chat_room_ng.dart
@@ -96,7 +96,6 @@ class _ChatNGRoomConsumerState extends ConsumerState<ChatNGRoom> {
   Widget build(BuildContext context) {
     final roomId = widget.roomId;
     final messages = ref.watch(chatMessagesProvider(roomId));
-
     if (messages.isEmpty) {
       return _renderLoading(context);
     }

--- a/app/lib/features/chat/chat-ng/widgets/chat_room_ng.dart
+++ b/app/lib/features/chat/chat-ng/widgets/chat_room_ng.dart
@@ -1,173 +1,41 @@
 import 'dart:io';
 
-import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/themes/acter_theme.dart';
-import 'package:acter/common/utils/routes.dart';
-import 'package:acter/common/utils/utils.dart';
-import 'package:acter/common/widgets/frost_effect.dart';
-import 'package:acter/features/chat/chat-ng/widgets/chat_room_ng.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/avatar_builder.dart';
 import 'package:acter/features/chat/widgets/bubble_builder.dart';
-import 'package:acter/features/chat/widgets/custom_input.dart';
 import 'package:acter/features/chat/widgets/custom_message_builder.dart';
 import 'package:acter/features/chat/widgets/file_message_builder.dart';
 import 'package:acter/features/chat/widgets/image_message_builder.dart';
 import 'package:acter/features/chat/widgets/messages/encrypted_info.dart';
 import 'package:acter/features/chat/widgets/messages/invite.dart';
 import 'package:acter/features/chat/widgets/messages/topic.dart';
-import 'package:acter/features/chat/widgets/room_avatar.dart';
 import 'package:acter/features/chat/widgets/text_message_builder.dart';
 import 'package:acter/features/chat/widgets/video_message_builder.dart';
-import 'package:acter/features/settings/providers/app_settings_provider.dart';
-import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:flutter_easyloading/flutter_easyloading.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
-import 'package:logging/logging.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:skeletonizer/skeletonizer.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
 
-final _log = Logger('a3::chat::room');
-
-class RoomPage extends ConsumerWidget {
-  static const roomPageKey = Key('chat-room-page');
+class ChatNGRoom extends ConsumerStatefulWidget {
   final String roomId;
 
-  const RoomPage({
-    super.key = roomPageKey,
-    required this.roomId,
-  });
-
-  Widget appBar(BuildContext context, WidgetRef ref) {
-    final roomAvatarInfo = ref.watch(roomAvatarInfoProvider(roomId));
-    final membersLoader = ref.watch(membersIdsProvider(roomId));
-    final isEncrypted =
-        ref.watch(isRoomEncryptedProvider(roomId)).valueOrNull ?? false;
-    return AppBar(
-      elevation: 0,
-      automaticallyImplyLeading: !context.isLargeScreen,
-      centerTitle: true,
-      toolbarHeight: 70,
-      flexibleSpace: FrostEffect(
-        child: Container(),
-      ),
-      title: GestureDetector(
-        onTap: () => context.pushNamed(
-          Routes.chatProfile.name,
-          pathParameters: {'roomId': roomId},
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.max,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              roomAvatarInfo.displayName ?? roomId,
-              overflow: TextOverflow.clip,
-              style: Theme.of(context).textTheme.bodyLarge,
-            ),
-            const SizedBox(height: 5),
-            membersLoader.when(
-              data: (members) => Text(
-                L10n.of(context).membersCount(members.length),
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              skipLoadingOnReload: false,
-              error: (e, s) {
-                _log.severe('Failed to load active members', e, s);
-                return Text(L10n.of(context).errorLoadingMembersCount(e));
-              },
-              loading: () => Skeletonizer(
-                child: Text(L10n.of(context).membersCount(100)),
-              ),
-            ),
-          ],
-        ),
-      ),
-      actions: [
-        if (!isEncrypted)
-          IconButton(
-            onPressed: () =>
-                EasyLoading.showInfo(L10n.of(context).chatNotEncrypted),
-            icon: Icon(
-              PhosphorIcons.shieldWarning(),
-              color: Theme.of(context).colorScheme.error,
-            ),
-          ),
-        GestureDetector(
-          onTap: () => context.pushNamed(
-            Routes.chatProfile.name,
-            pathParameters: {'roomId': roomId},
-          ),
-          child: Padding(
-            padding: const EdgeInsets.only(right: 10),
-            child: RoomAvatar(
-              roomId: roomId,
-              showParents: true,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final isChatNG = ref.watch(isActiveProvider(LabsFeature.chatNG));
-    return OrientationBuilder(
-      builder: (context, orientation) => Scaffold(
-        resizeToAvoidBottomInset: orientation == Orientation.portrait,
-        body: Column(
-          children: [
-            appBar(context, ref),
-            isChatNG ? ChatNGRoom(roomId: roomId) : ChatRoom(roomId: roomId),
-            chatInput(context, ref),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget chatInput(BuildContext context, WidgetRef ref) {
-    final sendTypingNotice = ref.watch(
-      userAppSettingsProvider.select(
-        (settings) => settings.valueOrNull?.typingNotice() ?? false,
-      ),
-    );
-    return CustomChatInput(
-      key: Key('chat-input-$roomId'),
-      roomId: roomId,
-      onTyping: (typing) async {
-        if (sendTypingNotice) {
-          final chat = await ref.read(chatProvider(roomId).future);
-          if (chat != null) await chat.typingNotice(typing);
-        }
-      },
-    );
-  }
-}
-
-class ChatRoom extends ConsumerStatefulWidget {
-  final String roomId;
-
-  const ChatRoom({
+  const ChatNGRoom({
     super.key,
     required this.roomId,
   });
 
   @override
-  ConsumerState<ChatRoom> createState() => _ChatRoomConsumerState();
+  ConsumerState<ChatNGRoom> createState() => _ChatNGRoomConsumerState();
 }
 
-class _ChatRoomConsumerState extends ConsumerState<ChatRoom> {
+class _ChatNGRoomConsumerState extends ConsumerState<ChatNGRoom> {
   AutoScrollController scrollController = AutoScrollController();
 
   @override

--- a/app/lib/features/chat/pages/room_page.dart
+++ b/app/lib/features/chat/pages/room_page.dart
@@ -7,7 +7,6 @@ import 'package:acter/common/themes/acter_theme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/frost_effect.dart';
-import 'package:acter/features/chat/chat-ng/widgets/chat_room_ng.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/avatar_builder.dart';
 import 'package:acter/features/chat/widgets/bubble_builder.dart';
@@ -22,7 +21,6 @@ import 'package:acter/features/chat/widgets/room_avatar.dart';
 import 'package:acter/features/chat/widgets/text_message_builder.dart';
 import 'package:acter/features/chat/widgets/video_message_builder.dart';
 import 'package:acter/features/settings/providers/app_settings_provider.dart';
-import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
@@ -121,14 +119,13 @@ class RoomPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isChatNG = ref.watch(isActiveProvider(LabsFeature.chatNG));
     return OrientationBuilder(
       builder: (context, orientation) => Scaffold(
         resizeToAvoidBottomInset: orientation == Orientation.portrait,
         body: Column(
           children: [
             appBar(context, ref),
-            isChatNG ? ChatNGRoom(roomId: roomId) : ChatRoom(roomId: roomId),
+            ChatRoom(roomId: roomId),
             chatInput(context, ref),
           ],
         ),

--- a/app/lib/features/chat/widgets/chat_layout_builder.dart
+++ b/app/lib/features/chat/widgets/chat_layout_builder.dart
@@ -23,7 +23,7 @@ class ChatLayoutBuilder extends ConsumerWidget {
     final center = centerChild;
     final isChatNG = ref.watch(isActiveProvider(LabsFeature.chatNG));
     final roomRoute = isChatNG ? Routes.chatNGRoom.name : Routes.chatroom.name;
-    print('$isChatNG');
+
     if (!context.isLargeScreen) {
       // we only have space to show the deepest child:
       if (expanded != null) return expanded;

--- a/app/lib/features/chat/widgets/chat_layout_builder.dart
+++ b/app/lib/features/chat/widgets/chat_layout_builder.dart
@@ -2,10 +2,12 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/pages/chat_select_page.dart';
 import 'package:acter/features/chat/widgets/rooms_list.dart';
+import 'package:acter/features/settings/providers/settings_providers.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class ChatLayoutBuilder extends StatelessWidget {
+class ChatLayoutBuilder extends ConsumerWidget {
   final Widget? centerChild;
   final Widget? expandedChild;
 
@@ -16,19 +18,26 @@ class ChatLayoutBuilder extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final expanded = expandedChild;
     final center = centerChild;
+    final isChatNG = ref.watch(isActiveProvider(LabsFeature.chatNG));
+    final roomRoute = isChatNG ? Routes.chatNGRoom.name : Routes.chatroom.name;
+    print('$isChatNG');
     if (!context.isLargeScreen) {
       // we only have space to show the deepest child:
       if (expanded != null) return expanded;
       if (center != null) return center;
       // no children, show the room list
-      return RoomsListWidget(
-        onSelected: (String roomId) => context.pushNamed(
-          Routes.chatroom.name,
-          pathParameters: {'roomId': roomId},
-        ),
+      return Consumer(
+        builder: (context, ref, child) {
+          return RoomsListWidget(
+            onSelected: (String roomId) => context.pushNamed(
+              roomRoute,
+              pathParameters: {'roomId': roomId},
+            ),
+          );
+        },
       );
     }
 
@@ -42,12 +51,12 @@ class ChatLayoutBuilder extends StatelessWidget {
             onSelected: (String roomId) => pushReplacementRouting
                 ? context.pushReplacementNamed(
                     // we switch without "push"
-                    Routes.chatroom.name,
+                    roomRoute,
                     pathParameters: {'roomId': roomId},
                   )
                 : context.pushNamed(
                     // we switch without "push"
-                    Routes.chatroom.name,
+                    roomRoute,
                     pathParameters: {'roomId': roomId},
                   ),
           ),

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -73,8 +73,12 @@ class SettingsLabsPage extends ConsumerWidget {
                   title: Text(L10n.of(context).chatNG),
                   description: Text(L10n.of(context).chatNGExplainer),
                   initialValue: ref.watch(isActiveProvider(LabsFeature.chatNG)),
-                  onToggle: (newVal) =>
-                      updateFeatureState(ref, LabsFeature.chatNG, newVal),
+                  onToggle: (newVal) {
+                    updateFeatureState(ref, LabsFeature.chatNG, newVal);
+                    EasyLoading.showToast(
+                      'Changes will affect after app restart',
+                    );
+                  },
                 ),
               ],
             ),

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -69,6 +69,13 @@ class SettingsLabsPage extends ConsumerWidget {
                   onToggle: (newVal) =>
                       updateFeatureState(ref, LabsFeature.chatUnread, newVal),
                 ),
+                SettingsTile.switchTile(
+                  title: Text(L10n.of(context).chatNG),
+                  description: Text(L10n.of(context).chatNGExplainer),
+                  initialValue: ref.watch(isActiveProvider(LabsFeature.chatNG)),
+                  onToggle: (newVal) =>
+                      updateFeatureState(ref, LabsFeature.chatNG, newVal),
+                ),
               ],
             ),
             SettingsSection(

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -148,6 +148,8 @@
   "changeYourDisplayName": "Change your display name",
   "@changeYourDisplayName": {},
   "chat": "Chat",
+  "chatNG": "Next-Generation Chat",
+  "chatNGExplainer": "Switch to next generation Chat. Features might not be stable",
   "@chat": {},
   "chatMissingPermissionsToSend": "You don’t have permissions to sent messages here",
   "@chatMissingPermissionsToSend": {},

--- a/app/lib/router/shell_routers/chat_shell_router.dart
+++ b/app/lib/router/shell_routers/chat_shell_router.dart
@@ -1,6 +1,8 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/utils/utils.dart';
+import 'package:acter/features/chat/chat-ng/pages/ng_profile_page.dart';
+import 'package:acter/features/chat/chat-ng/pages/room_page_ng.dart';
 import 'package:acter/features/chat/pages/room_page.dart';
 import 'package:acter/features/chat/pages/room_profile_page.dart';
 import 'package:acter/features/chat/widgets/chat_layout_builder.dart';
@@ -50,7 +52,6 @@ final chatShellRoutes = [
     redirect: authGuardRedirect,
     pageBuilder: (context, state) {
       final roomId = state.pathParameters['roomId']!;
-
       rootNavKey.currentContext
           ?.read(selectedChatIdProvider.notifier)
           .select(roomId);
@@ -81,6 +82,71 @@ final chatShellRoutes = [
         key: state.pageKey,
         child: ChatLayoutBuilder(
           centerChild: RoomPage(
+            roomId: roomId,
+          ),
+          expandedChild: VisibilityAccessibilityPage(
+            roomId: roomId,
+            impliedClose: true,
+          ),
+        ),
+      );
+    },
+  ),
+  GoRoute(
+    name: Routes.chatNGRoom.name,
+    path: Routes.chatNGRoom.route,
+    redirect: authGuardRedirect,
+    pageBuilder: (context, state) {
+      final roomId = state.pathParameters['roomId']!;
+
+      rootNavKey.currentContext
+          ?.read(selectedChatIdProvider.notifier)
+          .select(roomId);
+      return NoTransitionPage(
+        key: state.pageKey,
+        child: ChatLayoutBuilder(
+          centerChild: ChatNGRoomPage(
+            roomId: roomId,
+          ),
+        ),
+      );
+    },
+  ),
+  GoRoute(
+    name: Routes.chatNGProfile.name,
+    path: Routes.chatNGProfile.route,
+    redirect: authGuardRedirect,
+    pageBuilder: (context, state) {
+      final roomId = state.pathParameters['roomId']!;
+
+      rootNavKey.currentContext
+          ?.read(selectedChatIdProvider.notifier)
+          .select(roomId);
+      return NoTransitionPage(
+        key: state.pageKey,
+        child: ChatLayoutBuilder(
+          centerChild: ChatNGRoomPage(roomId: roomId),
+          expandedChild: ChatNGProfilePage(
+            roomId: roomId,
+          ),
+        ),
+      );
+    },
+  ),
+  GoRoute(
+    name: Routes.chatNGSettingsVisibility.name,
+    path: Routes.chatNGSettingsVisibility.route,
+    redirect: authGuardRedirect,
+    pageBuilder: (context, state) {
+      final roomId = state.pathParameters['roomId']!;
+
+      rootNavKey.currentContext
+          ?.read(selectedChatIdProvider.notifier)
+          .select(roomId);
+      return NoTransitionPage(
+        key: state.pageKey,
+        child: ChatLayoutBuilder(
+          centerChild: ChatNGRoomPage(
             roomId: roomId,
           ),
           expandedChild: VisibilityAccessibilityPage(


### PR DESCRIPTION
- Adds the labs flag for switching between chat & chat-ng. Nothing is changed in terms of features, and future iteration code is copied.

### ***This is the base starting point for incremental pushes to new generational chat. Features are not meant to be stable and should be carefully considered before switching.

<img width="433" alt="Screenshot 2024-10-11 at 3 04 21 PM" src="https://github.com/user-attachments/assets/1e4dafc5-83df-4c4e-9dfd-08033189ec25">

(Mobile) ->

https://github.com/user-attachments/assets/1adecc59-8409-484b-910d-eb1c31a523b3

(Desktop)->

https://github.com/user-attachments/assets/de5f39f0-bb80-41aa-b841-c8ab689fb096

