### PR TITLE
fix convo card trailing

### DIFF
--- a/app/lib/features/chat/widgets/convo_card.dart
+++ b/app/lib/features/chat/widgets/convo_card.dart
@@ -84,7 +84,9 @@ class ConvoCard extends ConsumerWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                 subtitle: buildSubtitle(context, constraints),
-                trailing: constraints.maxWidth < 300 ? null : trailing,
+                trailing: constraints.maxWidth < 300
+                    ? null
+                    : trailing ?? _TrailingWidget(roomId: roomId),
               ),
             ),
           ],


### PR DESCRIPTION
Fixes #2231. Bug fix include adding fallback ```trailing``` widget renderer as ```trailing``` param isn't passed in any call. That's why the message timestamp was missing from chat list.