### PR TITLE
Fix NDK 27 x84_64 target

### DIFF
--- a/native/acter/build.rs
+++ b/native/acter/build.rs
@@ -92,13 +92,17 @@ fn setup_x86_64_android_workaround() {
                 "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
             ),
         };
-        const DEFAULT_CLANG_VERSION: &str = "14.0.7";
+        const DEFAULT_CLANG_VERSION: &str = "18";
         let clang_version =
             std::env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
         let linux_x86_64_lib_dir = format!(
-            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib/clang/{clang_version}/lib/linux/"
         );
-        println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
+        let full_path = format!("{android_ndk_home}/{linux_x86_64_lib_dir}");
+        if !std::fs::exists(&full_path).unwrap() {
+            panic!("`clang_rt.builtins-x86_64-android` includes not found. `{full_path}` doesn't exist. Please adjust `$ANDROID_NDK_HOME` and/or `$NDK_CLANG_VERSION` to fix.")
+        }
+        println!("cargo:rustc-link-search={full_path}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }
 }


### PR DESCRIPTION
if NDK_HOME wasn't set to the version r25 anymore. Add clang 18 as default since we are on NDK 27 now. Show error messages with info to user if not to help with fixing it.

## Developer Upgrade notes:

Your ANDROID_NDK_HOME must point to an NDK version of 27 or higher. If you have troubles building with `cargo make android-dev`, adjust the environment variables stated in the error message as necessary.