### PR TITLE
Fix double redaction bug

### DIFF
--- a/native/core/src/executor.rs
+++ b/native/core/src/executor.rs
@@ -123,7 +123,12 @@ impl Executor {
         reason: UnsignedRoomRedactionEvent,
     ) -> Result<()> {
         trace!(event_id=?event_meta.event_id, ?model_type, "asked to redact");
-        match self.store.get(event_meta.event_id.as_str()).await {
+        let event_id = event_meta.event_id.to_string();
+
+        match self.store.get(&event_id).await {
+            Ok(AnyActerModel::RedactedActerModel(_)) => {
+                info!(?event_id, "live redacted: Already redacted");
+            }
             Ok(model) => {
                 trace!("previous model found. overwriting");
                 let redacted = RedactedActerModel::new(
@@ -165,9 +170,14 @@ impl Executor {
             return Ok(());
         };
 
-        match self.store.get(meta.event_id.as_str()).await {
+        let event_id = meta.event_id.to_string();
+
+        match self.store.get(&event_id).await {
+            Ok(AnyActerModel::RedactedActerModel(_)) => {
+                info!(?event_id, "live redacted: Already redacted");
+            }
             Ok(model) => {
-                trace!("redacting model live");
+                trace!("live redacted: model found");
                 let redacted = RedactedActerModel::new(
                     model.model_type().to_owned(),
                     model.indizes(self.store.user_id()),
@@ -175,19 +185,12 @@ impl Executor {
                     event.into(),
                 );
                 let keys = model.redact(&self.store, redacted).await?;
-                info!(
-                    "******************** found model live redacted: {:?}",
-                    keys.clone()
-                );
+                info!(?event_id, "live redacted: {:?}", keys.clone());
                 self.notify(keys);
             }
             Err(Error::ModelNotFound(_)) => {
-                trace!("no model found");
-                info!(
-                    "******************** not found live redacted: {:?}",
-                    meta.event_id.clone()
-                );
-                self.notify(vec![meta.event_id.to_string()]);
+                info!(?event_id, "live redaction: not found");
+                self.notify(vec![event_id]);
             }
             Err(error) => return Err(error),
         }
@@ -197,6 +200,7 @@ impl Executor {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::{
         events::{comments::CommentEventContent, BelongsTo},
@@ -209,6 +213,7 @@ mod tests {
         },
         store::{MemoryStore, StoreConfig},
     };
+    use serde_json::{from_value, json};
 
     async fn fresh_executor() -> Result<Executor> {
         let config = StoreConfig::default().state_store(MemoryStore::new());
@@ -232,7 +237,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_simle_model() -> Result<()> {
+    async fn subscribe_simple_model() -> Result<()> {
         let _ = env_logger::try_init();
         let executor = fresh_executor().await?;
         let model = TestModelBuilder::default().simple().build().unwrap();
@@ -351,6 +356,67 @@ mod tests {
         };
 
         assert_eq!(inner_model, model);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn double_redact_model() -> Result<()> {
+        let _ = env_logger::try_init();
+        let executor = fresh_executor().await?;
+        let model = TestModelBuilder::default().simple().build().unwrap();
+        let model_id = model.event_id().to_string();
+        // nothing in the store
+        assert!(executor.store().get(&model_id).await.is_err());
+
+        let waiter = executor.wait_for(model_id.clone());
+        executor.handle(model.clone().into()).await?;
+
+        let new_model = waiter.await?;
+
+        let AnyActerModel::TestModel(inner_model) = new_model else {
+            panic!("Not a test model");
+        };
+
+        assert_eq!(inner_model, model);
+
+        // now let's redact this model;
+
+        let redaction: UnsignedRoomRedactionEvent = from_value(json!({
+            "event_id" : format!("{model_id}:redacted"),
+            "sender": "@someone:example.org",
+            "origin_server_ts": 123456,
+            "content": { "redacts" : model_id, },
+        }))?;
+
+        executor
+            .redact("test_model".to_owned(), model.event_meta(), redaction)
+            .await?;
+
+        let AnyActerModel::RedactedActerModel(redaction) = executor.store().get(&model_id).await?
+        else {
+            panic!("Model was not redacten :(");
+        };
+        assert_eq!(redaction.origin_type(), "test_model");
+
+        // redacting again
+
+        let redaction: UnsignedRoomRedactionEvent = from_value(json!({
+            "event_id" : format!("{model_id}:redacted2"),
+            "sender": "@someone:example.org",
+            "origin_server_ts": 123456,
+            "content": { "redacts" : model_id, },
+        }))?;
+
+        executor
+            .redact("test_model".to_owned(), model.event_meta(), redaction)
+            .await?;
+
+        let AnyActerModel::RedactedActerModel(redaction) = executor.store().get(&model_id).await?
+        else {
+            panic!("Model was not redacten :(");
+        };
+        assert_eq!(redaction.origin_type(), "test_model"); // we stay with the existing redaction
+
         Ok(())
     }
 }

--- a/native/core/src/models.rs
+++ b/native/core/src/models.rs
@@ -218,6 +218,12 @@ pub struct RedactedActerModel {
 }
 
 impl RedactedActerModel {
+    pub fn origin_type(&self) -> &str {
+        &self.orig_type
+    }
+}
+
+impl RedactedActerModel {
     pub fn new(
         orig_type: String,
         orig_indizes: Vec<String>,

--- a/native/core/src/models/test.rs
+++ b/native/core/src/models/test.rs
@@ -51,6 +51,18 @@ impl TestModelBuilder {
     }
 }
 
+impl TestModel {
+    pub fn event_meta(&self) -> EventMeta {
+        EventMeta {
+            event_id: self.event_id.clone(),
+            sender: user_id!("@test:example.org").to_owned(),
+            origin_server_ts: MilliSecondsSinceUnixEpoch(123567890u32.into()),
+            room_id: self.room_id.clone(),
+            redacted: None,
+        }
+    }
+}
+
 impl ActerModel for TestModel {
     fn event_id(&self) -> &EventId {
         &self.event_id


### PR DESCRIPTION
When we received a redaction on a model that was already redacted, we'd still apply it again leading to a wrapping-of-wrapping-of-wrapping-issue. This adds a test for this and fixes the bug. 