### PR TITLE
Auto-updating Event Details via riverpod "utcNowProvider"

### DIFF
--- a/.changes/2299-updating-events.md
+++ b/.changes/2299-updating-events.md
@@ -1,0 +1,1 @@
+- Fix: Update event information when time progresses

--- a/app/lib/common/widgets/event/event_selector_drawer.dart
+++ b/app/lib/common/widgets/event/event_selector_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:acter/features/events/providers/event_providers.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/events/widgets/skeletons/event_list_skeleton_widget.dart';
 import 'package:atlas_icons/atlas_icons.dart';
@@ -62,6 +63,8 @@ Future<String?> selectEventDrawer({
                         itemBuilder: (context, index) => EventItem(
                           event: calEvents[index],
                           isShowRsvp: false,
+                          eventType:
+                              ref.read(eventTypeProvider(calEvents[index])),
                           onTapEventItem: (event) {
                             Navigator.pop(context, event);
                           },

--- a/app/lib/features/calendar_sync/providers/events_to_sync_provider.dart
+++ b/app/lib/features/calendar_sync/providers/events_to_sync_provider.dart
@@ -1,5 +1,5 @@
 //ALL UPCOMING EVENTS
-import 'package:acter/features/events/actions/get_event_type.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,7 +10,7 @@ final eventsToSyncProvider = FutureProvider.autoDispose((ref) async {
   // fetch all from all spaces
   final allEventList = await ref.watch(allEventListProvider(null).future);
   final upcomingAndOngoing = allEventList.where((event) {
-    final eventType = getEventType(event);
+    final eventType = ref.watch(eventTypeProvider(event));
     return eventType == EventFilters.upcoming ||
         eventType == EventFilters.ongoing;
   });

--- a/app/lib/features/datetime/providers/notifiers/now_notifier.dart
+++ b/app/lib/features/datetime/providers/notifiers/now_notifier.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UtcNowNotifier extends StateNotifier<DateTime> {
+  late Timer _timer;
+  UtcNowNotifier() : super(DateTime.now().toUtc()) {
+    _timer = Timer.periodic(const Duration(seconds: 59), (t) {
+      state = DateTime.now().toUtc();
+    });
+  }
+
+  @override
+  void dispose() {
+    // TODO: implement dispose
+    super.dispose();
+    _timer.cancel();
+  }
+}

--- a/app/lib/features/datetime/providers/utc_now_provider.dart
+++ b/app/lib/features/datetime/providers/utc_now_provider.dart
@@ -1,0 +1,7 @@
+import 'package:acter/features/datetime/providers/notifiers/now_notifier.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the "current" UTC datetime, automatically updating at least
+/// once a minute
+final utcNowProvider =
+    StateNotifierProvider<UtcNowNotifier, DateTime>((ref) => UtcNowNotifier());

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -14,7 +14,7 @@ import 'package:acter/features/attachments/widgets/attachment_section.dart';
 import 'package:acter/features/bookmarks/types.dart';
 import 'package:acter/features/bookmarks/widgets/bookmark_action.dart';
 import 'package:acter/features/comments/widgets/comments_section.dart';
-import 'package:acter/features/events/actions/get_event_type.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/model/keys.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/events/utils/events_utils.dart';
@@ -127,7 +127,8 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
     final canRedact = ref.watch(canRedactProvider(event));
     final membership = ref.watch(roomMembershipProvider(spaceId)).valueOrNull;
     final canPostEvent = membership?.canString('CanPostEvent') == true;
-    final canChangeDate = getEventType(event) == EventFilters.upcoming;
+    final canChangeDate =
+        ref.watch(eventTypeProvider(event)) == EventFilters.upcoming;
 
     //Create event actions
     List<PopupMenuEntry> actions = [];
@@ -292,12 +293,13 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
     final spaceId = calendarEvent.roomIdStr();
     final membership = ref.watch(roomMembershipProvider(spaceId)).valueOrNull;
     final canPostEvent = membership?.canString('CanPostEvent') == true;
+    final eventType = ref.watch(eventTypeProvider(calendarEvent));
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // Date and Month
-        EventDateWidget(calendarEvent: calendarEvent),
+        EventDateWidget(calendarEvent: calendarEvent, eventType: eventType),
         // Title, Space, User counts, comments counts and like counts
         Expanded(
           child: Column(
@@ -476,7 +478,8 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
     required Color rsvpStatusColor,
     bool isSelected = false,
   }) {
-    final canRSVPUpdate = getEventType(calendarEvent) != EventFilters.past;
+    final canRSVPUpdate =
+        ref.watch(eventTypeProvider(calendarEvent)) != EventFilters.past;
     return Expanded(
       child: InkWell(
         key: key,
@@ -518,14 +521,15 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
             .fromNow();
 
     String eventDateTime = '${formatDate(ev)} (${formatTime(ev)})';
+    final eventType = ref.watch(eventTypeProvider(ev));
 
-    String eventTimingTitle = switch (getEventType(ev)) {
+    String eventTimingTitle = switch (eventType) {
       EventFilters.ongoing => '${lang.eventStarted} $agoTime',
       EventFilters.upcoming => '${lang.eventStarts} $agoTime',
       EventFilters.past => '${lang.eventEnded} $agoTime',
       _ => '',
     };
-    final canChangeDate = getEventType(ev) == EventFilters.upcoming;
+    final canChangeDate = eventType == EventFilters.upcoming;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 10.0),

--- a/app/lib/features/events/pages/event_list_page.dart
+++ b/app/lib/features/events/pages/event_list_page.dart
@@ -10,6 +10,7 @@ import 'package:acter/common/widgets/add_button_with_can_permission.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
 import 'package:acter/common/widgets/space_name_widget.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/events/widgets/skeletons/event_list_skeleton_widget.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -191,6 +192,7 @@ class _EventListPageState extends ConsumerState<EventListPage> {
             EventItem(
               event: event,
               isShowSpaceName: widget.spaceId == null,
+              eventType: ref.watch(eventTypeProvider(event)),
             ),
         ],
       ),

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -1,6 +1,6 @@
 import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
 import 'package:acter/features/bookmarks/types.dart';
-import 'package:acter/features/events/actions/get_event_type.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/actions/sort_event_list.dart';
 import 'package:acter/features/events/providers/notifiers/event_notifiers.dart';
 import 'package:acter/features/events/providers/notifiers/rsvp_notifier.dart';
@@ -43,7 +43,9 @@ final allOngoingEventListProvider = FutureProvider.autoDispose
     .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
   final allEventList = await ref.watch(allEventListProvider(spaceId).future);
   List<ffi.CalendarEvent> allOngoingEventList = allEventList
-      .where((event) => getEventType(event) == EventFilters.ongoing)
+      .where(
+        (event) => ref.watch(eventTypeProvider(event)) == EventFilters.ongoing,
+      )
       .toList();
   return sortEventListAscTime(allOngoingEventList);
 });
@@ -69,7 +71,9 @@ final allUpcomingEventListProvider = FutureProvider.autoDispose
     .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
   final allEventList = await ref.watch(allEventListProvider(spaceId).future);
   List<ffi.CalendarEvent> allUpcomingEventList = allEventList
-      .where((event) => getEventType(event) == EventFilters.upcoming)
+      .where(
+        (event) => ref.watch(eventTypeProvider(event)) == EventFilters.upcoming,
+      )
       .toList();
   return sortEventListAscTime(allUpcomingEventList);
 });
@@ -95,7 +99,9 @@ final allPastEventListProvider = FutureProvider.autoDispose
     .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
   final allEventList = await ref.watch(allEventListProvider(spaceId).future);
   List<ffi.CalendarEvent> allPastEventList = allEventList
-      .where((event) => getEventType(event) == EventFilters.past)
+      .where(
+        (event) => ref.watch(eventTypeProvider(event)) == EventFilters.past,
+      )
       .toList();
   return sortEventListDscTime(allPastEventList);
 });

--- a/app/lib/features/events/providers/event_type_provider.dart
+++ b/app/lib/features/events/providers/event_type_provider.dart
@@ -1,13 +1,14 @@
+import 'package:acter/features/datetime/providers/utc_now_provider.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
-import 'package:dart_date/dart_date.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-
-EventFilters getEventType(ffi.CalendarEvent event) {
+final eventTypeProvider =
+    Provider.autoDispose.family<EventFilters, ffi.CalendarEvent>((ref, event) {
   DateTime eventStartDateTime = toDartDatetime(event.utcStart());
   DateTime eventEndDateTime = toDartDatetime(event.utcEnd());
-  DateTime currentDateTime = DateTime.now().toUTC;
+  DateTime currentDateTime = ref.read(utcNowProvider);
 
   //Check for event type
   if (eventStartDateTime.isBefore(currentDateTime) &&
@@ -19,4 +20,4 @@ EventFilters getEventType(ffi.CalendarEvent event) {
     return EventFilters.past;
   }
   return EventFilters.all;
-}
+});

--- a/app/lib/features/events/widgets/event_date_widget.dart
+++ b/app/lib/features/events/widgets/event_date_widget.dart
@@ -1,4 +1,3 @@
-import 'package:acter/features/events/actions/get_event_type.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/events/utils/events_utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -6,8 +5,10 @@ import 'package:flutter/material.dart';
 
 class EventDateWidget extends StatelessWidget {
   final CalendarEvent calendarEvent;
+  final EventFilters eventType;
 
-  const EventDateWidget({super.key, required this.calendarEvent});
+  const EventDateWidget(
+      {super.key, required this.calendarEvent, required this.eventType,});
 
   @override
   Widget build(BuildContext context) {
@@ -40,11 +41,8 @@ class EventDateWidget extends StatelessWidget {
     );
   }
 
-  Color getColorBasedOnEventType(BuildContext context) {
-    if (getEventType(calendarEvent) == EventFilters.past) {
-      return Colors.grey.shade800;
-    } else {
-      return Theme.of(context).primaryColor;
-    }
-  }
+  Color getColorBasedOnEventType(BuildContext context) => switch (eventType) {
+        EventFilters.past => Colors.grey.shade800,
+        _ => Theme.of(context).primaryColor
+      };
 }

--- a/app/lib/features/events/widgets/event_item.dart
+++ b/app/lib/features/events/widgets/event_item.dart
@@ -2,7 +2,6 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/blinking_text.dart';
-import 'package:acter/features/events/actions/get_event_type.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/events/utils/events_utils.dart';
 import 'package:acter/features/events/widgets/event_date_widget.dart';
@@ -22,6 +21,7 @@ class EventItem extends StatelessWidget {
   final Function(String)? onTapEventItem;
   final bool isShowRsvp;
   final bool isShowSpaceName;
+  final EventFilters eventType;
 
   const EventItem({
     super.key,
@@ -30,6 +30,7 @@ class EventItem extends StatelessWidget {
     this.onTapEventItem,
     this.isShowRsvp = true,
     this.isShowSpaceName = false,
+    required this.eventType,
   });
 
   @override
@@ -53,7 +54,10 @@ class EventItem extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                EventDateWidget(calendarEvent: event),
+                EventDateWidget(
+                  calendarEvent: event,
+                  eventType: eventType,
+                ),
                 Expanded(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -66,7 +70,7 @@ class EventItem extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 10),
-                if (getEventType(event) == EventFilters.ongoing)
+                if (eventType == EventFilters.ongoing)
                   _buildHappeningIndication(context),
                 const SizedBox(width: 10),
                 if (isShowRsvp) _buildRsvpStatus(context),

--- a/app/lib/features/home/widgets/my_events.dart
+++ b/app/lib/features/home/widgets/my_events.dart
@@ -75,7 +75,10 @@ class MyEventsSection extends ConsumerWidget {
   }
 
   Widget eventListUI(
-      BuildContext context, WidgetRef ref, List<CalendarEvent> events) {
+    BuildContext context,
+    WidgetRef ref,
+    List<CalendarEvent> events,
+  ) {
     final count = limit.map((val) => min(val, events.length)) ?? events.length;
     return ListView.builder(
       shrinkWrap: true,

--- a/app/lib/features/home/widgets/my_events.dart
+++ b/app/lib/features/home/widgets/my_events.dart
@@ -4,6 +4,7 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/events/widgets/skeletons/event_list_skeleton_widget.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -45,7 +46,7 @@ class MyEventsSection extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             sectionHeader(context, sectionTitle),
-            eventListUI(context, calEvents),
+            eventListUI(context, ref, calEvents),
           ],
         );
       },
@@ -73,7 +74,8 @@ class MyEventsSection extends ConsumerWidget {
     );
   }
 
-  Widget eventListUI(BuildContext context, List<CalendarEvent> events) {
+  Widget eventListUI(
+      BuildContext context, WidgetRef ref, List<CalendarEvent> events) {
     final count = limit.map((val) => min(val, events.length)) ?? events.length;
     return ListView.builder(
       shrinkWrap: true,
@@ -83,6 +85,7 @@ class MyEventsSection extends ConsumerWidget {
         isShowSpaceName: true,
         margin: const EdgeInsets.only(bottom: 14),
         event: events[index],
+        eventType: ref.watch(eventTypeProvider(events[index])),
       ),
     );
   }

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -4,6 +4,7 @@ import 'package:acter/common/toolkit/buttons/danger_action_button.dart';
 import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/common/widgets/html_editor.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/events/widgets/skeletons/event_item_skeleton_widget.dart';
@@ -281,6 +282,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
                           final notifier = ref.read(newsStateProvider.notifier);
                           await notifier.selectEventToShare(context);
                         },
+                        eventType: ref.watch(eventTypeProvider(calendarEvent)),
                       ),
                     );
                   },

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/actions/open_link.dart';
 import 'package:acter/common/toolkit/errors/error_dialog.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/events/widgets/skeletons/event_item_skeleton_widget.dart';
 import 'package:acter/features/news/model/news_references_model.dart';
@@ -45,7 +46,10 @@ class NewsSlideActions extends ConsumerWidget {
     final lang = L10n.of(context);
     final calEventLoader = ref.watch(calendarEventProvider(eventId));
     return calEventLoader.when(
-      data: (calEvent) => EventItem(event: calEvent),
+      data: (calEvent) => EventItem(
+        event: calEvent,
+        eventType: ref.watch(eventTypeProvider(calEvent)),
+      ),
       loading: () => const EventItemSkeleton(),
       error: (e, s) {
         _log.severe('Failed to load cal event', e, s);

--- a/app/lib/features/space/widgets/space_sections/events_section.dart
+++ b/app/lib/features/space/widgets/space_sections/events_section.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
+import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -28,7 +29,7 @@ class EventsSection extends ConsumerWidget {
       eventListSearchFilterProvider((spaceId: spaceId, searchText: '')),
     );
     return calEventsLoader.when(
-      data: (calEvents) => buildEventsSectionUI(context, calEvents),
+      data: (calEvents) => buildEventsSectionUI(context, ref, calEvents),
       error: (e, s) {
         _log.severe('Failed to search cal events in space', e, s);
         return Center(
@@ -43,6 +44,7 @@ class EventsSection extends ConsumerWidget {
 
   Widget buildEventsSectionUI(
     BuildContext context,
+    WidgetRef ref,
     List<CalendarEvent> events,
   ) {
     final hasMore = events.length > limit;
@@ -59,18 +61,21 @@ class EventsSection extends ConsumerWidget {
             pathParameters: {'spaceId': spaceId},
           ),
         ),
-        eventsListUI(events, count),
+        eventsListUI(ref, events, count),
       ],
     );
   }
 
-  Widget eventsListUI(List<CalendarEvent> events, int count) {
+  Widget eventsListUI(WidgetRef ref, List<CalendarEvent> events, int count) {
     return ListView.builder(
       shrinkWrap: true,
       itemCount: count,
       padding: EdgeInsets.zero,
       physics: const NeverScrollableScrollPhysics(),
-      itemBuilder: (context, index) => EventItem(event: events[index]),
+      itemBuilder: (context, index) => EventItem(
+        event: events[index],
+        eventType: ref.watch(eventTypeProvider(events[index])),
+      ),
     );
   }
 }


### PR DESCRIPTION
Leveraging the riverpod system to have a cached now-utc-time that is updated once a minute and thus refreshes the data to the current time. 

Fixes #2256 .