### PR TITLE
Fix bug in type casting of nullable variable

### DIFF
--- a/app/lib/features/chat/widgets/emoji/emoji_container.dart
+++ b/app/lib/features/chat/widgets/emoji/emoji_container.dart
@@ -46,8 +46,7 @@ class _EmojiContainerState extends State<EmojiContainer>
     Map<String, dynamic>? reactions = widget.message.metadata?['reactions'];
     if (reactions == null) return const SizedBox();
     final children = reactions.keys.map((key) {
-      final records = reactions[key].expect('reactions of $key not available')
-          as List<ReactionRecord>;
+      final records = reactions[key] as List<ReactionRecord>;
       final sentByMe = records.any((x) => x.sentByMe());
       final emoji = Text(key, style: EmojiConfig.emojiTextStyle);
       final moreThanOne = records.length > 1;


### PR DESCRIPTION
Will fix [this issue](https://acter.sentry.io/issues/10589073/events/21017ba097f8405d93d63af95353f486/?project=4507612337012816).
This bug seems to be occurred because `.expect()` was called about `Map<String, dynamic>`.