### PR TITLE
Fix feature flags updating

### DIFF
--- a/app/lib/features/labs/providers/labs_providers.dart
+++ b/app/lib/features/labs/providers/labs_providers.dart
@@ -47,5 +47,5 @@ Future<bool> updateFeatureState(
   bool value,
 ) async {
   await ref.read(featuresProvider.notifier).setActive(f, value);
-  return ref.read(featuresProvider).isActive(f);
+  return ref.read(isActiveProvider(f));
 }

--- a/app/lib/features/labs/providers/notifiers/labs_features.dart
+++ b/app/lib/features/labs/providers/notifiers/labs_features.dart
@@ -49,12 +49,12 @@ class SharedPrefFeaturesNotifier extends StateNotifier<Features<LabsFeature>> {
   }
 
   // Let’s the UI update the state of a flag
-  Future<void> setActive(LabsFeature f, bool active) {
-    return newState(state.updateFlag(f, active));
+  Future<void> setActive(LabsFeature f, bool active) async {
+    await newState(state.updateFlag(f, active));
   }
 
   // Allow higher level to reset the features flagged
-  Future<void> resetFeatures(List<FeatureFlag<LabsFeature>> features) {
-    return newState(Features(flags: features, defaultOn: state.defaultOn));
+  Future<void> resetFeatures(List<FeatureFlag<LabsFeature>> features) async {
+    await newState(Features(flags: features, defaultOn: state.defaultOn));
   }
 }


### PR DESCRIPTION
Updating feature flags was broken due to a misuse of `.expect` on dynamic.