### PR TITLE
Space group creation fixes

### DIFF
--- a/app/lib/features/chat/pages/sub_chats_page.dart
+++ b/app/lib/features/chat/pages/sub_chats_page.dart
@@ -82,7 +82,8 @@ class SubChatsPage extends ConsumerWidget {
           key: SubChatsPage.createSubChatKey,
           onTap: () => context.pushNamed(
             Routes.createChat.name,
-            queryParameters: {'parentSpaceId': spaceId},
+            queryParameters: {'spaceId': spaceId},
+            extra: 1,
           ),
           child: Row(
             children: <Widget>[


### PR DESCRIPTION
fixes, https://github.com/acterglobal/a3-meta/issues/603

### Space group chat creation Flow with issues:
- Opening create DMs instead of Create Group
- Parent space not auto selected

https://github.com/user-attachments/assets/63efc66a-d7d2-4ef9-8376-d71c8d83b318

### Space group chat creation Flow after fixes:
- Directly open Create Group Chat
- Parent space now auto selected

https://github.com/user-attachments/assets/32890828-72a5-4432-8450-96e58403f471


