### PR TITLE
Switching from rootNavKey.currentContext! to ProviderContainer

### DIFF
--- a/app/integration_test/support/util.dart
+++ b/app/integration_test/support/util.dart
@@ -1,14 +1,13 @@
 import 'dart:io';
 
-import 'package:acter/common/extensions/acter_build_context.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/widgets/spaces/select_space_form_field.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/features/home/data/keys.dart';
 import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
 import 'package:acter/features/search/model/keys.dart';
 import 'package:acter/features/settings/widgets/settings_menu.dart';
-import 'package:acter/router/router.dart';
 import 'package:convenient_test_dev/convenient_test_dev.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter/material.dart';
@@ -62,7 +61,7 @@ extension ActerUtil on ConvenientTest {
   }
 
   Future<void> ensureLabEnabled(LabsFeature feat) async {
-    if (!rootNavKey.currentContext!.read(isActiveProvider(feat))) {
+    if (!mainProviderContainer.read(isActiveProvider(feat))) {
       // ensure we do actually have access to the main nav.
       await find.byKey(Keys.mainNav).should(findsOneWidget);
       final quickJumpKey = find.byKey(MainNavKeys.quickJump);
@@ -80,7 +79,7 @@ extension ActerUtil on ConvenientTest {
       final confirmKey = find.byKey(Key('labs-${feat.name}'));
       await confirmKey.should(findsOneWidget);
       // let's read again
-      if (!rootNavKey.currentContext!.read(isActiveProvider(feat))) {
+      if (!mainProviderContainer.read(isActiveProvider(feat))) {
         await confirmKey.tap();
       }
 
@@ -88,7 +87,7 @@ extension ActerUtil on ConvenientTest {
 
       // ensure we are active
       assert(
-        rootNavKey.currentContext!.read(isActiveProvider(feat)),
+        mainProviderContainer.read(isActiveProvider(feat)),
         'Could not activate $feat',
       );
     }

--- a/app/lib/config/notifications/util.dart
+++ b/app/lib/config/notifications/util.dart
@@ -1,6 +1,5 @@
-import 'package:acter/common/extensions/acter_build_context.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/router/providers/router_providers.dart';
-import 'package:acter/router/router.dart';
 import 'package:acter/router/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -18,7 +17,7 @@ Future<void> setRejected(String deviceId, bool value) async {
 }
 
 bool isCurrentRoute(String uri) {
-  final currentUri = rootNavKey.currentContext!.read(currentRoutingLocation);
+  final currentUri = mainProviderContainer.read(currentRoutingLocation);
   return currentUri == uri;
 }
 
@@ -27,7 +26,7 @@ bool shouldReplaceCurrentRoute(String uri) {
     return false;
   }
 
-  final currentUri = rootNavKey.currentContext!.read(currentRoutingLocation);
+  final currentUri = mainProviderContainer.read(currentRoutingLocation);
   return currentUri.startsWith(chatRoomUriMatcher);
 }
 

--- a/app/lib/config/setup.dart
+++ b/app/lib/config/setup.dart
@@ -2,11 +2,14 @@ import 'dart:io';
 
 import 'package:acter/config/env.g.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const userAgent = '${Env.rageshakeAppName}/${Env.rageshakeAppName}';
 final defaultLogSetting = Platform.environment.containsKey(rustLogKey)
     ? Platform.environment[rustLogKey] as String
     : Env.defaultRustLog;
+
+final mainProviderContainer = ProviderContainer();
 
 void configSetup() {
   // Pass the configuration to the SDK plugin

--- a/app/lib/features/calendar_sync/calendar_sync.dart
+++ b/app/lib/features/calendar_sync/calendar_sync.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:acter/common/extensions/acter_build_context.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/features/calendar_sync/providers/events_to_sync_provider.dart';
 import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
-import 'package:acter/router/router.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:device_calendar/device_calendar.dart';
@@ -32,7 +31,7 @@ ProviderSubscription<AsyncValue<List<EventAndRsvp>>>? _subscription;
 
 Future<bool> _isEnabled() async {
   try {
-    return (await rootNavKey.currentContext!
+    return (await mainProviderContainer
         .read(asyncIsActiveProvider(LabsFeature.deviceCalendarSync).future));
   } catch (e, s) {
     _log.severe('Reading current context failed', e, s);
@@ -87,9 +86,7 @@ Future<void> initCalendarSync({bool ignoreRejection = false}) async {
   // clear if it existed before
   _subscription?.close();
   // start listening
-  _subscription =
-      ProviderScope.containerOf(rootNavKey.currentContext!, listen: true)
-          .listen(
+  _subscription = mainProviderContainer.listen(
     eventsToSyncProvider,
     (prev, next) async {
       final events = next.valueOrNull;

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -69,6 +69,10 @@ Future<void> _startAppInner(Widget app, bool withSentry) async {
     app = DesktopSupport(child: app);
   }
 
+  // use the globally defined ProviderContainer
+  final wrappedApp =
+      UncontrolledProviderScope(container: mainProviderContainer, child: app);
+
   if (withSentry) {
     await SentryFlutter.init(
       (options) {
@@ -81,10 +85,10 @@ Future<void> _startAppInner(Widget app, bool withSentry) async {
         // and prevent reporting otherwise.
         options.beforeSend = sentryBeforeSend;
       },
-      appRunner: () => runApp(app),
+      appRunner: () => runApp(wrappedApp),
     );
   } else {
-    runApp(app);
+    runApp(wrappedApp);
   }
 }
 

--- a/app/lib/router/shell_routers/chat_shell_router.dart
+++ b/app/lib/router/shell_routers/chat_shell_router.dart
@@ -1,7 +1,7 @@
-import 'package:acter/common/extensions/acter_build_context.dart';
 import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/features/chat/pages/room_page.dart';
 import 'package:acter/features/chat/pages/room_profile_page.dart';
 import 'package:acter/features/chat/widgets/chat_layout_builder.dart';
@@ -19,8 +19,7 @@ import 'package:go_router/go_router.dart';
 /// the chat-ng feature.
 Widget _chatLayoutBuilder({Widget? centerChild, Widget? expandedChild}) {
   final isChatNg =
-      rootNavKey.currentContext?.read(isActiveProvider(LabsFeature.chatNG)) ==
-          true;
+      mainProviderContainer.read(isActiveProvider(LabsFeature.chatNG)) == true;
   return isChatNg
       ? ChatLayoutBuilder(
           roomListWidgetBuilder: (s) => RoomsListNGWidget(onSelected: s),
@@ -39,9 +38,7 @@ final chatShellRoutes = [
     path: Routes.chat.route,
     redirect: authGuardRedirect,
     pageBuilder: (context, state) {
-      rootNavKey.currentContext
-          ?.read(selectedChatIdProvider.notifier)
-          .select(null);
+      mainProviderContainer.read(selectedChatIdProvider.notifier).select(null);
       return NoTransitionPage(
         key: state.pageKey,
         child: _chatLayoutBuilder(),
@@ -53,13 +50,13 @@ final chatShellRoutes = [
     path: Routes.chatroom.route,
     redirect: authGuardRedirect,
     pageBuilder: (context, state) {
-      final isChatNg = rootNavKey.currentContext
-              ?.read(isActiveProvider(LabsFeature.chatNG)) ==
-          true;
+      final isChatNg =
+          mainProviderContainer.read(isActiveProvider(LabsFeature.chatNG)) ==
+              true;
       final roomId = state.pathParameters['roomId']!;
 
-      rootNavKey.currentContext
-          ?.read(selectedChatIdProvider.notifier)
+      mainProviderContainer
+          .read(selectedChatIdProvider.notifier)
           .select(roomId);
       return NoTransitionPage(
         key: state.pageKey,
@@ -82,8 +79,8 @@ final chatShellRoutes = [
     pageBuilder: (context, state) {
       final roomId = state.pathParameters['roomId']
           .expect('chatProfile route needs roomId as path param');
-      rootNavKey.currentContext
-          ?.read(selectedChatIdProvider.notifier)
+      mainProviderContainer
+          .read(selectedChatIdProvider.notifier)
           .select(roomId);
       return NoTransitionPage(
         key: state.pageKey,
@@ -101,8 +98,8 @@ final chatShellRoutes = [
     pageBuilder: (context, state) {
       final roomId = state.pathParameters['roomId']
           .expect('chatSettingsVisibility route needs roomId as path param');
-      rootNavKey.currentContext
-          ?.read(selectedChatIdProvider.notifier)
+      mainProviderContainer
+          .read(selectedChatIdProvider.notifier)
           .select(roomId);
       return NoTransitionPage(
         key: state.pageKey,

--- a/app/lib/router/utils.dart
+++ b/app/lib/router/utils.dart
@@ -1,7 +1,7 @@
-import 'package:acter/common/extensions/acter_build_context.dart';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/config/app_shell.dart';
+import 'package:acter/config/setup.dart';
 import 'package:acter/router/providers/router_providers.dart';
 import 'package:acter/router/router.dart';
 import 'package:flutter/material.dart';
@@ -54,8 +54,7 @@ final chatRoomUriMatcher = RegExp('/chat/.+');
 
 /// helper to figure out how to route to the specific chat room
 void goToChat(BuildContext localContext, String roomId) {
-  final context = rootNavKey.currentContext!;
-  final currentUri = context.read(currentRoutingLocation);
+  final currentUri = mainProviderContainer.read(currentRoutingLocation);
   if (!currentUri.startsWith(chatRoomUriMatcher)) {
     // we are not in a chat room. just a regular push routing
     // will do
@@ -69,13 +68,13 @@ void goToChat(BuildContext localContext, String roomId) {
   }
 
   // we are in a chat page
-  if (roomId == rootNavKey.currentContext!.read(selectedChatIdProvider)) {
+  if (roomId == mainProviderContainer.read(selectedChatIdProvider)) {
     // we are on the same page, nothing to be done
     return;
   }
 
   // we are on a different chat page. Push replace the current screen
-  context.pushReplacementNamed(
+  (rootNavKey.currentContext ?? localContext).pushReplacementNamed(
     Routes.chatroom.name,
     pathParameters: {'roomId': roomId},
   );

--- a/packages/acter_notifify/lib/acter_notifify.dart
+++ b/packages/acter_notifify/lib/acter_notifify.dart
@@ -11,6 +11,7 @@ import 'package:acter_notifify/util.dart';
 import 'package:acter_notifify/platform/windows.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:logging/logging.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 final _log = Logger('a3::notifify::acter');
 
@@ -87,6 +88,7 @@ Future<String?> initializeNotifify({
         );
       } catch (error, stack) {
         final deviceId = client.deviceId().toString();
+        Sentry.captureException(error, stackTrace: stack);
         _log.severe('Failed to setup ntfy for $deviceId', error, stack);
       }
     }

--- a/packages/acter_notifify/lib/matrix.dart
+++ b/packages/acter_notifify/lib/matrix.dart
@@ -14,6 +14,7 @@ import 'package:acter_notifify/platform/windows.dart';
 import 'package:convert/convert.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:logging/logging.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 final _log = Logger('a3::notifify::matrix');
 int id = 0;
@@ -47,6 +48,7 @@ Future<bool> handleMatrixMessage(
     return true;
   } catch (e, s) {
     _log.severe('Parsing Notification failed: $message', e, s);
+    Sentry.captureException(e, stackTrace: s);
   }
   return false;
 }

--- a/packages/acter_notifify/lib/ntfy.dart
+++ b/packages/acter_notifify/lib/ntfy.dart
@@ -6,6 +6,7 @@ import 'package:acter_notifify/acter_notifify.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_notifify/matrix.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:dio/dio.dart';
 import 'package:logging/logging.dart';
 
@@ -58,6 +59,7 @@ Future<bool?> setupNtfyNotificationsForDevice(
   );
   if (rs.data == null) {
     _log.severe('Connecting to ntfy server failed: $rs');
+    Sentry.captureMessage('Connecting to ntfy server failed: $rs');
     return false;
   }
   _subscriptions[token] = rs.data!.stream
@@ -83,6 +85,7 @@ Future<bool?> setupNtfyNotificationsForDevice(
       );
     } catch (error, stack) {
       _log.severe('Failed to show push notification $event', error, stack);
+      Sentry.captureException(error, stackTrace: stack);
     }
   });
   return true;

--- a/packages/acter_notifify/lib/platform/android.dart
+++ b/packages/acter_notifify/lib/platform/android.dart
@@ -5,6 +5,7 @@ import 'package:acter_notifify/local.dart';
 import 'package:acter_notifify/matrix.dart';
 import 'package:acter_notifify/util.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:logging/logging.dart';
 
 final _log = Logger('a3::notifify::android');
@@ -24,6 +25,7 @@ Future<ByteArrayAndroidBitmap?> _fetchImage(
       return ByteArrayAndroidBitmap(image.asTypedList());
     } catch (e, s) {
       _log.severe('fetching image data failed', e, s);
+      Sentry.captureException(e, stackTrace: s);
     }
   }
   return null;
@@ -41,6 +43,7 @@ Future<Person> _makeSenderPerson(NotificationItem notification) async {
       );
     } catch (e, s) {
       _log.severe('fetching image data failed', e, s);
+      Sentry.captureException(e, stackTrace: s);
     }
   }
   return Person(key: sender.userId(), name: sender.displayName());
@@ -56,6 +59,7 @@ Future<ByteArrayAndroidBitmap?> _fetchRoomAvatar(
       return ByteArrayAndroidBitmap(image.asTypedList());
     } catch (e, s) {
       _log.severe('fetching room avatar failed', e, s);
+      Sentry.captureException(e, stackTrace: s);
     }
   }
   return null;

--- a/packages/acter_notifify/lib/push.dart
+++ b/packages/acter_notifify/lib/push.dart
@@ -6,6 +6,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_notifify/acter_notifify.dart';
 import 'package:acter_notifify/matrix.dart';
 import 'package:logging/logging.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:push/push.dart';
 
 final _log = Logger('a3::notifify::push');
@@ -77,12 +78,14 @@ Future<void> initializePush({
               pushServerUrl: pushServerUrl);
         } catch (error, st) {
           _log.severe('Setting token for $deviceId failed', error, st);
+          Sentry.captureException(error, stackTrace: st);
         }
       }
     });
   } catch (e, s) {
     // this fails on hot-reload and in integration tests... if so, ignore for now
     _log.severe('Push initialization error', e, s);
+    Sentry.captureException(e, stackTrace: s);
   }
 }
 

--- a/packages/acter_notifify/pubspec.yaml
+++ b/packages/acter_notifify/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   dio: ^5.5.0+1
   windows_notification: ^1.2.0
   app_badge_plus: ^1.1.5
+  sentry: any
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This replaces the `rootNavKey.currentContext!` spread throughout our code base with the riverpod provided `ProviderContainer`.

## Why?
The `rootNavKey.currentContext!` requires a context to be present. There are several cases however, when that isn't necessary the case - most notably when we start up or are supposed to handle notifications. As `!` is a failing action, this means those activities can and do fail, as [shown in these logs](https://rageshake.acter.global/api/listing/2024-10-28/225229-WCYFZ7IT/app_2024-10-28_20-29-33.026675261.log.gz) (limited access):

```
[2024-10-28][20:29:36.274547][a3::notifify::matrix][ERROR] Parsing Notification failed: {content_algorithm: m.megolm.v1.aes-sha2, sender_display_name: XXXXX, room_name: YY/Emil/Jo/Ben, sender: @asdaea:acter.global, unread: 4, content_ciphertext: AwgFEpABTgNPP/5gs+zP227dPnd/3qZde5f9GcAhuMc9YzlHk0edAtRzcgABeMv4h/yo3hKpujVbk8aJETUl9k4zuV+FzS0fE+iWD+Dq66KARCVxd9YzKPEcfl7n3OqV0g0x29tcneYoCEDq/GRLBsmEIb3MTTRVWk06lEMHoLHeNqdkCea6xWl32DwBwasdae27gAg8Mj+rNg/3pLVd+5Qyb1SJ9bRC9nREMF8+XYf5cg+ts1HKQZy0FCKUpXkl3w01OMZISVPEUJ, missed_calls: None, prio: high, type: m.room.encrypted, device_id: LBYZFYUHPL, event_id: $pj24lTJda47DtCZ4b9SfEg8u94tE0uHh65rKMHeXudo, content_sender_key: okHn2hBGamjVtMasdafdsnncPHEnVLyn9WrI7teNelo, room_id: !adfasdfasdfasf:acter.global, content_session_id: 1wJKmjgDEuf94xds2Wp95KCTVVU+l1ae5+V7CIm61sc, content_device_id: FECRXDAHMN} Null check operator used on a null value null *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
``` 

We are using `ref.read` in our code base to find out about a huge amount of states and configurations. The main reason we use `rootNavKey.currentContext!` is to get access to `ref.read`. But that isn't reliable, especially outside the widget context.

## What

[Taken from this article](https://codewithandrea.com/articles/riverpod-initialize-listener-app-startup/#conclusion), this PR replaces that `currentContext!.read`-mechanism with a `ProviderContainer` we initialize globally and then hand to the app-widget at startup. This allows us to have a global provider we can `ref.read` with that can be used from anywhere and is independent of any specific context or whether the app is visible at all.


### In Details

 - https://github.com/acterglobal/a3/pull/2331/commits/f8a9844f99bc022512fce6e960565260e9343ea6 switches from rootNavKey to ProviderContainer
 - https://github.com/acterglobal/a3/pull/2331/commits/05c046b862cde9c543452aa38d7e8c015a8b92da is an additional commit to add sentry logging for our notification exceptions, so we get more insights about those going forward.
