### PR TITLE
Promoting DeviceCalendar to always-on-labs 

### DIFF
--- a/.changes/2333-calendar-device-sync.md
+++ b/.changes/2333-calendar-device-sync.md
@@ -1,0 +1,1 @@
+- [Labs] calendar events should now show up in your device calendar (unless you have rejected them) by default. This is sill under labs, if you run into trouble you can disable it from the Settings -> labs and let us know what problem you had.

--- a/app/lib/features/labs/model/labs_features.dart
+++ b/app/lib/features/labs/model/labs_features.dart
@@ -31,6 +31,7 @@ enum LabsFeature {
 
   static List<LabsFeature> get releaseDefaults => [
         LabsFeature.mobilePushNotifications,
+        LabsFeature.deviceCalendarSync,
       ];
 
   static List<LabsFeature> get nightlyDefaults => [

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -4,7 +4,6 @@ import 'package:acter/features/calendar_sync/calendar_sync.dart';
 import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
 import 'package:acter/features/settings/pages/settings_page.dart';
-import 'package:acter/features/settings/widgets/labs_notifications_settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';

--- a/app/lib/features/settings/pages/labs_page.dart
+++ b/app/lib/features/settings/pages/labs_page.dart
@@ -32,7 +32,6 @@ class SettingsLabsPage extends ConsumerWidget {
             SettingsSection(
               title: Text(lang.labsAppFeatures),
               tiles: [
-                const LabsNotificationsSettingsTile(),
                 SettingsTile.switchTile(
                   title: Text(lang.encryptionBackupKeyBackup),
                   description: Text(lang.sharedCalendarAndEvents),


### PR DESCRIPTION
ahead of the release tonight.

This seems to be stable enough for nightly for a while already. Let's try bring it onto the big stage and see what feedback we get for it.

Also removes the Notifications from the Labs-Page as we already have it as an always-on lab for a while. It is essentially stable, but can still be disabled from its own settings screen.