### PR TITLE
Fix badge counter

### DIFF
--- a/.changes/disable-badge-counter.md
+++ b/.changes/disable-badge-counter.md
@@ -1,0 +1,1 @@
+- Fix: don't show badge counter until the user can also clear that counter

--- a/packages/acter_notifify/lib/util.dart
+++ b/packages/acter_notifify/lib/util.dart
@@ -33,7 +33,8 @@ Future<void> removeNotificationsForRoom(String roomId) async {
 
 Future<void> updateBadgeCount(int newCount) async {
   if (await AppBadgePlus.isSupported()) {
-    await AppBadgePlus.updateBadge(newCount);
+    await AppBadgePlus.updateBadge(0);
+    // await AppBadgePlus.updateBadge(newCount);
   }
 }
 


### PR DESCRIPTION
We have had reports that the app Badge counter wasn't properly updating (especially on iOS and Mac). Looks like we are updating it but based on the still "active" notifications count, which might not be what the user expects. And as they can't really clear that listing (as it is with the system) for now, the number annoys quite some people. To resolve that, I've added a temporary fix removing the badge counter entirely (setting it to `0` regardless of current known number of notifications) until we have the activity center in a way that can allow for them to be cleared.