### PR TITLE
Only Activate the ShakeDetector bugReporter while the app is in Foregroun

### DIFF
--- a/.changes/2359-background-shake.md
+++ b/.changes/2359-background-shake.md
@@ -1,0 +1,1 @@
+- Fix: ignore rageshake while the app is backgrounded to avoid starting up with a bug report screen opened

--- a/app/lib/config/app_shell.dart
+++ b/app/lib/config/app_shell.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/providers/app_state_provider.dart';
 import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart';
 import 'package:acter/common/utils/constants.dart';
@@ -71,7 +72,9 @@ class AppShellState extends ConsumerState<AppShell> {
       detector = ShakeDetector.autoStart(
         shakeThresholdGravity: 30.0,
         onShake: () {
-          openBugReport(context);
+          if (ref.read(isAppInForeground)) {
+            openBugReport(context);
+          }
         },
       );
     }


### PR DESCRIPTION
fixes the rage shake dialog appearing on picking up the device, because it was shaken while the app wasn't running.