### PR TITLE
Fixing 404 on room join

### DIFF
--- a/packages/acter_notifify/lib/util.dart
+++ b/packages/acter_notifify/lib/util.dart
@@ -32,6 +32,7 @@ Future<void> removeNotificationsForRoom(String roomId) async {
 }
 
 Future<void> updateBadgeCount(int newCount) async {
+  if (Platform.isLinux) return; // not supported
   if (await AppBadgePlus.isSupported()) {
     await AppBadgePlus.updateBadge(0);
     // await AppBadgePlus.updateBadge(newCount);


### PR DESCRIPTION
Two minor fixes:

- 144bad6ab0eaa72a691c64a467ee7da268bec80e checks for the specific higher level type before forwarding to make sure that will be able to show the proper type -- not just that the room generally is available
- 6d3c5fdaa5cd5e32e80aa91e2967ab37b29e54e5 disabled broken badges on linux