### PR TITLE
When the task item can't be accessed: Don't show the error

### DIFF
--- a/app/lib/features/tasks/widgets/task_item.dart
+++ b/app/lib/features/tasks/widgets/task_item.dart
@@ -66,9 +66,11 @@ class TaskItem extends ConsumerWidget {
       ),
       error: (e, s) {
         _log.severe('Failed to load task', e, s);
-        return ListTile(
-          title: Text(lang.loadingFailed(e)),
-        );
+        // FIXME: don't show broken task list items on main screen;
+        return const SizedBox.shrink();
+        // // return ListTile(
+        // //   title: Text(lang.loadingFailed(e)),
+        // );
       },
       loading: () => ListTile(
         title: Text(lang.loading),


### PR DESCRIPTION
The root cause isn't clear but it is a bad look on @emilvincentz 's demo device's dashboard screen.