### PR TITLE
Content-hashed external URI parsing support

### DIFF
--- a/app/lib/features/deep_linking/actions/handle_deep_link_uri.dart
+++ b/app/lib/features/deep_linking/actions/handle_deep_link_uri.dart
@@ -1,5 +1,5 @@
 import 'package:acter/features/deep_linking/types.dart';
-import 'package:acter/features/deep_linking/utils.dart';
+import 'package:acter/features/deep_linking/parse_acter_uri.dart';
 import 'package:acter/features/super_invites/dialogs/redeem_dialog.dart';
 import 'package:acter/features/users/actions/show_global_user_dialog.dart';
 import 'package:flutter/material.dart';
@@ -14,7 +14,7 @@ Future<void> handleDeepLinkUri({
 }) async {
   final lang = L10n.of(context);
   try {
-    final result = parseUri(uri);
+    final result = parseActerUri(uri);
     final _ = switch (result.type) {
       LinkType.userId => context.mounted
           ? await showUserInfoDrawer(context: context, userId: result.target)

--- a/app/lib/features/deep_linking/parse_acter_uri.dart
+++ b/app/lib/features/deep_linking/parse_acter_uri.dart
@@ -20,7 +20,7 @@ class ObjectNotSupported extends UriParseError {
 class ParsingFailed extends UriParseError {}
 class IncorrectHashError extends ParsingFailed {}
 class MissingUserError extends ParsingFailed {
-  final UriParseError result;
+  final UriParseResult result;
   MissingUserError({required this.result});
 }
 
@@ -59,7 +59,11 @@ UriParseResult _parseHttpsUri(Uri uri) {
 
   // put the query as the path
   final extractableUri = strippedUri.replace(path: strippedUri.fragment, fragment: null);
-  return _parseActerUri(extractableUri);
+  final result = _parseActerUri(extractableUri);
+  if (result.preview.userId == null || result.preview.userId?.isEmpty == true) {
+    throw MissingUserError(result: result);
+  }
+  return result;
 }
 
 UriParseResult _parseSuperInvite(Uri uri) {

--- a/app/lib/features/deep_linking/parse_acter_uri.dart
+++ b/app/lib/features/deep_linking/parse_acter_uri.dart
@@ -19,15 +19,19 @@ class ObjectNotSupported extends UriParseError {
 
 class ParsingFailed extends UriParseError {}
 class IncorrectHashError extends ParsingFailed {}
+class MissingUserError extends ParsingFailed {
+  final UriParseError result;
+  MissingUserError({required this.result});
+}
 
-UriParseResult parseUri(Uri uri) => switch (uri.scheme) {
-      'acter' => _parseUri(uri),
+UriParseResult parseActerUri(Uri uri) => switch (uri.scheme) {
+      'acter' => _parseActerUri(uri),
       'matrix' => _parseMatrixUri(uri),
       'https' || 'http' => _parseHttpsUri(uri),
       _ => throw SchemeNotSupported(scheme: uri.scheme),
     };
 
-UriParseResult _parseUri(Uri uri) {
+UriParseResult _parseActerUri(Uri uri) {
   final path = uri.pathSegments.first;
   return switch (path) {
     'o' => _parseActerEvent(uri),
@@ -55,7 +59,7 @@ UriParseResult _parseHttpsUri(Uri uri) {
 
   // put the query as the path
   final extractableUri = strippedUri.replace(path: strippedUri.fragment, fragment: null);
-  return _parseUri(extractableUri);
+  return _parseActerUri(extractableUri);
 }
 
 UriParseResult _parseSuperInvite(Uri uri) {

--- a/app/lib/features/deep_linking/utils.dart
+++ b/app/lib/features/deep_linking/utils.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:acter/features/deep_linking/types.dart';
+import 'package:crypto/crypto.dart';
 
 class UriParseError extends Error {}
 
@@ -15,15 +18,16 @@ class ObjectNotSupported extends UriParseError {
 }
 
 class ParsingFailed extends UriParseError {}
+class IncorrectHashError extends ParsingFailed {}
 
 UriParseResult parseUri(Uri uri) => switch (uri.scheme) {
-      'acter' => _parseActerUri(uri),
+      'acter' => _parseUri(uri),
       'matrix' => _parseMatrixUri(uri),
-      'https' || 'http' => _parseMatrixHttpsUri(uri),
+      'https' || 'http' => _parseHttpsUri(uri),
       _ => throw SchemeNotSupported(scheme: uri.scheme),
     };
 
-UriParseResult _parseActerUri(Uri uri) {
+UriParseResult _parseUri(Uri uri) {
   final path = uri.pathSegments.first;
   return switch (path) {
     'o' => _parseActerEvent(uri),
@@ -32,14 +36,37 @@ UriParseResult _parseActerUri(Uri uri) {
   };
 }
 
+UriParseResult _parseHttpsUri(Uri uri) {
+  if (uri.host == 'matrix.to') {
+    return _parseMatrixHttpsUri(uri);
+  }
+  final hash = uri.pathSegments.lastOrNull;
+  if (hash == null || hash.isEmpty) {
+    throw IncorrectHashError();
+  }
+
+  final pathWithoutHash = uri.path.substring(0, uri.path.length - hash.length -1);
+  final strippedUri = uri.replace(path: pathWithoutHash);
+  final hashableUri = strippedUri.toString();
+  final calculatedHash = sha1.convert(utf8.encode(hashableUri)).toString();
+  if (calculatedHash != hash) {
+    throw IncorrectHashError();
+  }
+
+  // put the query as the path
+  final extractableUri = strippedUri.replace(path: strippedUri.fragment, fragment: null);
+  return _parseUri(extractableUri);
+}
+
 UriParseResult _parseSuperInvite(Uri uri) {
   final path = uri.pathSegments;
-  if (path.length < 2) {
+  if (path.length < 3) {
     throw ParsingFailed();
   }
-  final superInviteId = path[1];
+  final server = path[1];
+  final superInviteId = path[2];
   final via = uri.queryParametersAll['via'] ?? [];
-  via.add(uri.host);
+  via.add(server);
 
   return UriParseResult(
     type: LinkType.superInvite,

--- a/app/lib/features/invite_members/pages/share_invite_code.dart
+++ b/app/lib/features/invite_members/pages/share_invite_code.dart
@@ -126,7 +126,7 @@ class ShareInviteCode extends ConsumerWidget {
             if (context.mounted) {
               showQrCode(
                 context,
-                'acter://acter.global/i/$inviteCode?roomDisplayName=$displayName&userId=$userId&userDisplayName=$userName',
+                'acter:i/acter.global/$inviteCode?roomDisplayName=$displayName&userId=$userId&userDisplayName=$userName',
                 title: Text(lang.shareInviteWithCode(inviteCode)),
               );
             }

--- a/app/test/features/deep_linking/parsing_test.dart
+++ b/app/test/features/deep_linking/parsing_test.dart
@@ -2,42 +2,202 @@ import 'package:acter/features/deep_linking/types.dart';
 import 'package:acter/features/deep_linking/utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void main() {
-  group('Testing matrix://-links', () {
-    test('roomAlias', () async {
-      final result = parseUri(Uri.parse('matrix:r/somewhere:example.org'));
-      expect(result.type, LinkType.roomAlias);
-      expect(result.target, '#somewhere:example.org');
-      expect(result.via, []);
-    });
-    test('roomId', () async {
-      final sourceUri =
-          Uri.parse('matrix:roomid/room:acter.global?via=elsewhere.ca');
-      final result = parseUri(sourceUri);
-      expect(result.type, LinkType.roomId);
-      expect(result.target, '!room:acter.global');
-      expect(result.via, ['elsewhere.ca']);
-    });
-    test('userId', () async {
-      final result =
-          parseUri(Uri.parse('matrix:u/alice:acter.global?action=chat'));
-      expect(result.type, LinkType.userId);
-      expect(result.target, '@alice:acter.global');
-    });
-    test('eventId', () async {
-      final result = parseUri(
-        Uri.parse(
-          'matrix:roomid/room:acter.global/e/someEvent?via=acter.global&via=example.org',
-        ),
-      );
-      expect(result.type, LinkType.chatEvent);
-      expect(result.target, '\$someEvent');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-    });
+typedef UriMaker = Uri Function(String);
+
+// re-usable test cases
+
+void acterObjectLinksTests(UriMaker makeUri) {
+  test('calendarEvent', () async {
+    final result = parseUri(
+      makeUri('o/somewhere:example.org/calendarEvent/spaceObjectId'),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.calendarEvent);
+    expect(result.target, '\$spaceObjectId');
+    expect(result.roomId, '!somewhere:example.org');
+    expect(result.via, []);
+  });
+  test('pin', () async {
+    final sourceUri =
+        makeUri('o/room:acter.global/pin/pinId?via=elsewhere.ca');
+    final result = parseUri(sourceUri);
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.pin);
+    expect(result.target, '\$pinId');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['elsewhere.ca']);
+  });
+  test('boost', () async {
+    final result =
+        parseUri(makeUri('o/another:acter.global/boost/boostId'));
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.boost);
+    expect(result.target, '\$boostId');
+    expect(result.roomId, '!another:acter.global');
+    expect(result.via, []);
+  });
+  test('taskList', () async {
+    final result = parseUri(
+      makeUri(
+        'o/room:acter.global/taskList/someEvent?via=acter.global&via=example.org',
+      ),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.taskList);
+    expect(result.target, '\$someEvent');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['acter.global', 'example.org']);
   });
 
-  group('Testing https://matrix.to/-links', () {
+  test('task', () async {
+    final result = parseUri(
+      makeUri(
+        'o/room:acter.global/taskList/listId/task/taskId?via=acter.global&via=example.org',
+      ),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.taskList);
+    expect(result.objectPath!.objectId, '\$listId');
+    expect(result.objectPath!.child!.objectType, ObjectType.task);
+    expect(result.objectPath!.child!.objectId, '\$taskId');
+    expect(result.objectPath!.child!.child, null);
+    expect(result.target, '\$listId');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['acter.global', 'example.org']);
+  });
+
+  test('comment on task', () async {
+    final result = parseUri(
+      makeUri('o/room:acter.global/taskList/someEvent/task/taskId/comment/commentId?via=acter.global&via=example.org',
+      ),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.taskList);
+    expect(result.objectPath!.objectId, '\$someEvent');
+    expect(result.objectPath!.child!.objectType, ObjectType.task);
+    expect(result.objectPath!.child!.objectId, '\$taskId');
+    expect(result.objectPath!.child!.child!.objectType, ObjectType.comment);
+    expect(result.objectPath!.child!.child!.objectId, '\$commentId');
+    expect(result.target, '\$someEvent');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['acter.global', 'example.org']);
+  });
+}
+
+
+void acterInviteLinkTests(UriMaker makeUri) {
+  test('simple invite', () async {
+    final result = parseUri(
+      makeUri('acter.global/i/inviteCode'),
+    );
+    expect(result.type, LinkType.superInvite);
+    expect(result.target, 'inviteCode');
+    expect(result.roomId, null);
+    expect(result.via, ['acter.global']);
+    expect(result.preview.roomDisplayName, null);
+  });
+  test('with preview', () async {
+    final result = parseUri(
+      makeUri(
+        'acter.global/i/inviteCode?roomDisplayName=Room+Name&userId=ben:acter.global&userDisplayName=Ben+From+Acter',
+      ),
+    );
+    expect(result.type, LinkType.superInvite);
+    expect(result.target, 'inviteCode');
+    expect(result.roomId, null);
+    expect(result.via, ['acter.global']);
+    expect(result.preview.roomDisplayName, 'Room Name');
+    expect(result.preview.userDisplayName, 'Ben From Acter');
+    expect(result.preview.userId, '@ben:acter.global');
+  });
+}
+
+
+void acterObjectPreviewTests(UriMaker makeUri) {
+  test('calendarEvent', () async {
+    final result = parseUri(
+      makeUri('o/somewhere:example.org/calendarEvent/spaceObjectId?title=Our+Awesome+Event&startUtc=12334567&participants=3',
+      ),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.calendarEvent);
+    expect(result.target, '\$spaceObjectId');
+    expect(result.roomId, '!somewhere:example.org');
+    expect(result.preview.title, 'Our Awesome Event');
+    expect(result.preview.extra['startUtc']?.firstOrNull, '12334567');
+    expect(result.preview.extra['participants']?.firstOrNull, '3');
+    expect(result.via, []);
+  });
+
+  test('comment on task', () async {
+    final result = parseUri(
+      makeUri('o/room:acter.global/taskList/someEvent/task/taskId/comment/commentId?via=acter.global&via=example.org&roomDisplayName=someRoom+Name',
+      ),
+    );
+    expect(result.type, LinkType.spaceObject);
+    expect(result.objectPath!.objectType, ObjectType.taskList);
+    expect(result.objectPath!.objectId, '\$someEvent');
+    expect(result.objectPath!.child!.objectType, ObjectType.task);
+    expect(result.objectPath!.child!.objectId, '\$taskId');
+    expect(result.objectPath!.child!.child!.objectType, ObjectType.comment);
+    expect(result.objectPath!.child!.child!.objectId, '\$commentId');
+    expect(result.target, '\$someEvent');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['acter.global', 'example.org']);
+    expect(result.preview.roomDisplayName, 'someRoom Name');
+  });
+}
+
+void newSpecLinksTests(UriMaker makeUri) {
+  test('roomAlias', () async {
+    final result = parseUri(makeUri('r/somewhere:example.org'));
+    expect(result.type, LinkType.roomAlias);
+    expect(result.target, '#somewhere:example.org');
+    expect(result.via, []);
+  });
+  test('roomId', () async {
+    final sourceUri =
+        makeUri('roomid/room:acter.global?via=elsewhere.ca');
+    final result = parseUri(sourceUri);
+    expect(result.type, LinkType.roomId);
+    expect(result.target, '!room:acter.global');
+    expect(result.via, ['elsewhere.ca']);
+  });
+  test('userId', () async {
+    final result =
+        parseUri(makeUri('u/alice:acter.global?action=chat'));
+    expect(result.type, LinkType.userId);
+    expect(result.target, '@alice:acter.global');
+  });
+  test('eventId', () async {
+    final result = parseUri(
+      makeUri(
+      'roomid/room:acter.global/e/someEvent?via=acter.global&via=example.org',
+      ),
+    );
+    expect(result.type, LinkType.chatEvent);
+    expect(result.target, '\$someEvent');
+    expect(result.roomId, '!room:acter.global');
+    expect(result.via, ['acter.global', 'example.org']);
+  });
+}
+
+// --- Actual tests start
+
+void main() {
+  group('Testing matrix:-links', () => newSpecLinksTests((u) => Uri.parse('matrix:$u')));
+
+  group('Testing fallback acter:-links', () => newSpecLinksTests((u) => Uri.parse('acter:$u')));
+
+  group('Testing acter: object-links', () => acterObjectLinksTests((u) => Uri.parse('acter:$u')));
+
+  group('Testing acter:// invite-links',  () => acterInviteLinkTests((u) => Uri.parse('acter://$u')));
+
+  group('Testing acter: preview data', () => acterObjectPreviewTests((u) => Uri.parse('acter:$u')));
+
+
+  // legacy matrix.to-links (we are not creating anymore but can still read)
+  group('Testing legacy https://matrix.to/-links', () {
     test('roomAlias', () async {
       final result =
           parseUri(Uri.parse('https://matrix.to/#/%23somewhere%3Aexample.org'));
@@ -70,182 +230,6 @@ void main() {
       expect(result.target, '\$someEvent:example.org');
       expect(result.roomId, '!room:acter.global');
       expect(result.via, ['acter.global', 'example.org']);
-    });
-  });
-  group('Testing fallback acter://-links', () {
-    test('roomAlias', () async {
-      final result = parseUri(Uri.parse('acter:r/somewhere:example.org'));
-      expect(result.type, LinkType.roomAlias);
-      expect(result.target, '#somewhere:example.org');
-      expect(result.via, []);
-    });
-    test('roomId', () async {
-      final sourceUri =
-          Uri.parse('acter:roomid/room:acter.global?via=elsewhere.ca');
-      final result = parseUri(sourceUri);
-      expect(result.type, LinkType.roomId);
-      expect(result.target, '!room:acter.global');
-      expect(result.via, ['elsewhere.ca']);
-    });
-    test('userId', () async {
-      final result =
-          parseUri(Uri.parse('acter:u/alice:acter.global?action=chat'));
-      expect(result.type, LinkType.userId);
-      expect(result.target, '@alice:acter.global');
-    });
-    test('eventId', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:roomid/room:acter.global/e/someEvent?via=acter.global&via=example.org',
-        ),
-      );
-      expect(result.type, LinkType.chatEvent);
-      expect(result.target, '\$someEvent');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-    });
-  });
-
-  group('Testing acter:// object-links', () {
-    test('calendarEvent', () async {
-      final result = parseUri(
-        Uri.parse('acter:o/somewhere:example.org/calendarEvent/spaceObjectId'),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.calendarEvent);
-      expect(result.target, '\$spaceObjectId');
-      expect(result.roomId, '!somewhere:example.org');
-      expect(result.via, []);
-    });
-    test('pin', () async {
-      final sourceUri =
-          Uri.parse('acter:o/room:acter.global/pin/pinId?via=elsewhere.ca');
-      final result = parseUri(sourceUri);
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.pin);
-      expect(result.target, '\$pinId');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['elsewhere.ca']);
-    });
-    test('boost', () async {
-      final result =
-          parseUri(Uri.parse('acter:o/another:acter.global/boost/boostId'));
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.boost);
-      expect(result.target, '\$boostId');
-      expect(result.roomId, '!another:acter.global');
-      expect(result.via, []);
-    });
-    test('taskList', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:o/room:acter.global/taskList/someEvent?via=acter.global&via=example.org',
-        ),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.taskList);
-      expect(result.target, '\$someEvent');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-    });
-
-    test('task', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:o/room:acter.global/taskList/listId/task/taskId?via=acter.global&via=example.org',
-        ),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.taskList);
-      expect(result.objectPath!.objectId, '\$listId');
-      expect(result.objectPath!.child!.objectType, ObjectType.task);
-      expect(result.objectPath!.child!.objectId, '\$taskId');
-      expect(result.objectPath!.child!.child, null);
-      expect(result.target, '\$listId');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-    });
-
-    test('comment on task', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:o/room:acter.global/taskList/someEvent/task/taskId/comment/commentId?via=acter.global&via=example.org',
-        ),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.taskList);
-      expect(result.objectPath!.objectId, '\$someEvent');
-      expect(result.objectPath!.child!.objectType, ObjectType.task);
-      expect(result.objectPath!.child!.objectId, '\$taskId');
-      expect(result.objectPath!.child!.child!.objectType, ObjectType.comment);
-      expect(result.objectPath!.child!.child!.objectId, '\$commentId');
-      expect(result.target, '\$someEvent');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-    });
-  });
-
-  group('Testing acter:// invite-links', () {
-    test('simple invite', () async {
-      final result = parseUri(
-        Uri.parse('acter://acter.global/i/inviteCode'),
-      );
-      expect(result.type, LinkType.superInvite);
-      expect(result.target, 'inviteCode');
-      expect(result.roomId, null);
-      expect(result.via, ['acter.global']);
-      expect(result.preview.roomDisplayName, null);
-    });
-    test('with preview', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter://acter.global/i/inviteCode?roomDisplayName=Room+Name&userId=ben:acter.global&userDisplayName=Ben+From+Acter',
-        ),
-      );
-      expect(result.type, LinkType.superInvite);
-      expect(result.target, 'inviteCode');
-      expect(result.roomId, null);
-      expect(result.via, ['acter.global']);
-      expect(result.preview.roomDisplayName, 'Room Name');
-      expect(result.preview.userDisplayName, 'Ben From Acter');
-      expect(result.preview.userId, '@ben:acter.global');
-    });
-  });
-
-  group('Testing acter:// preview data', () {
-    test('calendarEvent', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:o/somewhere:example.org/calendarEvent/spaceObjectId?title=Our+Awesome+Event&startUtc=12334567&participants=3',
-        ),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.calendarEvent);
-      expect(result.target, '\$spaceObjectId');
-      expect(result.roomId, '!somewhere:example.org');
-      expect(result.preview.title, 'Our Awesome Event');
-      expect(result.preview.extra['startUtc']?.firstOrNull, '12334567');
-      expect(result.preview.extra['participants']?.firstOrNull, '3');
-      expect(result.via, []);
-    });
-
-    test('comment on task', () async {
-      final result = parseUri(
-        Uri.parse(
-          'acter:o/room:acter.global/taskList/someEvent/task/taskId/comment/commentId?via=acter.global&via=example.org&roomDisplayName=someRoom+Name',
-        ),
-      );
-      expect(result.type, LinkType.spaceObject);
-      expect(result.objectPath!.objectType, ObjectType.taskList);
-      expect(result.objectPath!.objectId, '\$someEvent');
-      expect(result.objectPath!.child!.objectType, ObjectType.task);
-      expect(result.objectPath!.child!.objectId, '\$taskId');
-      expect(result.objectPath!.child!.child!.objectType, ObjectType.comment);
-      expect(result.objectPath!.child!.child!.objectId, '\$commentId');
-      expect(result.target, '\$someEvent');
-      expect(result.roomId, '!room:acter.global');
-      expect(result.via, ['acter.global', 'example.org']);
-      expect(result.preview.roomDisplayName, 'someRoom Name');
     });
   });
 }


### PR DESCRIPTION
This PR brings support for providing non matrix-to https links with content hashing support for additional security. These work analogous to the previous `acter:`-style-links but with that entire path put into the `#`-fragment (query stays the same, but the order might change) and replacing the path with a final hash of the entire URI in this style _without_ that hash as the final parameter). This allows any server to provide that feature under any domain + path as long as the last path-item is the hash itself.

Example: `acter:roomid/room:acter.global/e/someEvent?via=acter.global&via=example.org` becomes `https://app.acter.global/p/$HASH?via=acter.global&via=example.org#roomid/room:acter.global/e/someEvent` (where `$HASH = SHA1.of(https://app.acter.global/p/?via=acter.global&via=example.org#roomid/room:acter.global/e/someEvent`)

This ensures that we can a) still parse most information from the URI itself without querying the server and b) ensure that the data wasn't messed with in transit or by any third party compared to the data that the server would be showing under that hash.

To the reviewer:
1. I renamed the files and functions for better lookup
2. I have refactored the code to be reusable for both tests of the `acter:` and new https-links, that's why the test file looks different
3. I decided to update the super-invite-uris to use the same pattern (rather than a host-url-one) to make it easier to reuse the code (which required updating our current qr-code generator)
4. links with a hash are checked for containing a user-id - if not the result is thrown in a particular error (allowing the UI to still use it, but make clear that this isn't the usual way it is meant to be) 