### PR TITLE
Detect debug mode in platform code of desktop

### DIFF
--- a/app/linux/main.cc
+++ b/app/linux/main.cc
@@ -1,6 +1,12 @@
 #include "my_application.h"
 
 int main(int argc, char** argv) {
+#ifndef NDEBUG
+  printf("This app works in debug mode\n");
+#else
+  printf("This app works in release mode\n");
+#endif
+
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -23,6 +23,11 @@ class AppDelegate: FlutterAppDelegate {
   public override func application(_ application: NSApplication,
                                   continue userActivity: NSUserActivity,
                                   restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void) -> Bool {
+#if DEBUG
+    print("This app works in debug mode")
+#else
+    print("This app works in release mode")
+#endif
 
     guard let url = AppLinks.shared.getUniversalLink(userActivity) else {
       return false

--- a/app/windows/runner/main.cpp
+++ b/app/windows/runner/main.cpp
@@ -8,6 +8,11 @@
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
+#ifdef _DEBUG
+  println("This app works in debug mode");
+#else
+  println("This app works in release mode");
+#endif
 
   HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Acter");
   if (hwnd != NULL) {


### PR DESCRIPTION
Flutter provides `kDebugMode` constant to detect debug mode in dart level.
But we don't know how to detect debug mode in cpp level.
We should be able to detect debug mode in cpp level for windows/linux/macos etc.