### PR TITLE
Keep the extension of the original file when none was given

### DIFF
--- a/.changes/2420-keep-file-extension.md
+++ b/.changes/2420-keep-file-extension.md
@@ -1,0 +1,1 @@
+- Fix: when downloading as file, keep the extension even if the user removed it to ensure they can open the resulting file.

--- a/app/lib/features/files/actions/download_file.dart
+++ b/app/lib/features/files/actions/download_file.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -8,7 +8,8 @@ import 'package:flutter_easyloading/flutter_easyloading.dart';
 
 Future<bool> downloadFile(BuildContext context, File file) async {
   final lang = L10n.of(context);
-  final filename = basename(file.path);
+  final filename = p.basename(file.path);
+  final extension = p.extension(filename);
   String? outputFile = await FilePicker.platform.saveFile(
     dialogTitle: lang.downloadFileDialogTitle,
     fileName: filename,
@@ -16,6 +17,11 @@ Future<bool> downloadFile(BuildContext context, File file) async {
 
   if (outputFile == null) {
     return false;
+  }
+
+  if (p.extension(outputFile).isEmpty) {
+    // the new file doesn't have an extension, we add the previous one again
+    outputFile = '$outputFile$extension';
   }
 
   await file.copy(outputFile);


### PR DESCRIPTION
Fixes #2415 by making files downloaded always have extensions - if none was given, we use the original one.

See it in action. Notice that I removed the extension but it is saved with it.


https://github.com/user-attachments/assets/3eef1d76-50c4-4926-aaf7-13895be41f0a

