### PR TITLE
Fixing range-error when closing room with parents

### DIFF
--- a/.changes/2432-range-error-in-closing-rooms.md
+++ b/.changes/2432-range-error-in-closing-rooms.md
@@ -1,0 +1,1 @@
+- Fix "Range Error" when closing rooms with parents

--- a/app/lib/common/actions/close_room.dart
+++ b/app/lib/common/actions/close_room.dart
@@ -172,10 +172,10 @@ class _CloseRoomConfirmationState
 
       var skippedParents = 0;
       if (parents.isNotEmpty) {
-        for (var i = 1; i <= parents.length; i++) {
+        for (var i = 0; i < parents.length; i++) {
           EasyLoading.showProgress(
             i / parents.length,
-            status: lang.closingRoomRemovingFromParents(i, parents.length),
+            status: lang.closingRoomRemovingFromParents(i + 1, parents.length),
           );
           final parent = await ref.read(maybeSpaceProvider(parents[i]).future);
 


### PR DESCRIPTION
pos == 0 was missing,  pos == length is too many.

Fixes https://github.com/acterglobal/a3/issues/2357