### PR TITLE
Restore Desktop Window position and size on start

### DIFF
--- a/.changes/2435-restoring-windows.md
+++ b/.changes/2435-restoring-windows.md
@@ -1,0 +1,1 @@
+- Restore windows size and position to last known one on app start on supported platforms

--- a/app/lib/config/desktop.dart
+++ b/app/lib/config/desktop.dart
@@ -52,11 +52,12 @@ class _DesktopSupportState extends State<DesktopSupport>
       final preferences = await sharedPrefs();
       await preferences.setDouble('windowX', pos.dx);
       await preferences.setDouble('windowY', pos.dy);
-      await preferences.setDouble('windowWidth', size.width);
-      await preferences.setDouble('windowHeight', size.height);
+      await preferences.setDouble('windowWidth', size.height);
+      await preferences.setDouble('windowHeight', size.width);
 
-      print(
-          "stored window size to ${size.width}x${size.height} at (${pos.dx} | ${pos.dy})");
+      _log.info(
+        'stored window size to ${size.width}x${size.height} at (${pos.dx} | ${pos.dy})',
+      );
     });
   }
 
@@ -119,8 +120,9 @@ class _DesktopSupportState extends State<DesktopSupport>
     final windowY = preferences.getDouble('windowY');
     final windowWidth = preferences.getDouble('windowWidth');
     final windowHeight = preferences.getDouble('windowHeight');
-    print(
-        "resetting window size to ${windowWidth}x${windowHeight} at ($windowX | $windowY)");
+    _log.warning(
+      'resetting window size to ${windowWidth}x$windowHeight at ($windowX | $windowY)"',
+    );
     if (windowHeight != null && windowWidth != null) {
       windowManager.setSize(Size(windowHeight, windowWidth));
     }

--- a/app/lib/config/desktop.dart
+++ b/app/lib/config/desktop.dart
@@ -53,8 +53,8 @@ class _DesktopSupportState extends State<DesktopSupport>
       final preferences = await sharedPrefs();
       await preferences.setDouble('windowX', pos.dx);
       await preferences.setDouble('windowY', pos.dy);
-      await preferences.setDouble('windowWidth', size.height);
-      await preferences.setDouble('windowHeight', size.width);
+      await preferences.setDouble('windowHeight', size.height);
+      await preferences.setDouble('windowWidth', size.width);
 
       _log.info(
         'stored window size to ${size.width}x${size.height} at (${pos.dx} | ${pos.dy})',

--- a/app/linux/my_application.cc
+++ b/app/linux/my_application.cc
@@ -66,8 +66,9 @@ static void my_application_activate(GApplication* application) {
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+  gtk_widget_hide(GTK_WIDGET(window));
 
-  gtk_widget_grab_focus(GTK_WIDGET(view));
+  // gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
 // Implements GApplication::local_command_line.

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import window_manager
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -16,5 +17,10 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2196,7 +2196,7 @@ packages:
     source: hosted
     version: "0.1.3"
   screen_retriever:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_retriever
       sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -158,6 +158,7 @@ dependencies:
   pretty_qr_code: ^3.3.0
   qr_code_dart_scan: ^0.9.3
   appcheck: ^1.5.2
+  screen_retriever: ^0.1.9
 
 dev_dependencies:
   flutter_test:

--- a/app/windows/runner/win32_window.cpp
+++ b/app/windows/runner/win32_window.cpp
@@ -117,7 +117,7 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
   double scale_factor = dpi / 96.0;
 
   HWND window = CreateWindow(
-      window_class, title.c_str(), WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+      window_class, title.c_str(), WS_OVERLAPPEDWINDOW,
       Scale(origin.x, scale_factor), Scale(origin.y, scale_factor),
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);


### PR DESCRIPTION
1. keeps track of the size and position the user moved the window to
2. hide the window on start on all platforms
3. once flutter is up, read the last position and size and resize and position the window accordingly
4. in that make sure the window is always visible on the main screen (image having closed acter when plugged to larger external monitor -we'd move the window outside of the screen dimensions) with at least 20% real estate from the monitors size.

Works on Linux:


https://github.com/user-attachments/assets/5c045541-adf9-41ee-a32a-d71637e2fb35



MacOS:

https://github.com/user-attachments/assets/ff974600-4d17-4159-ba07-891e245b1491



and Windows:



https://github.com/user-attachments/assets/edb440f1-279d-4472-820a-1d7b75248ade


