### PR TITLE
Submit Exceptions logged to Sentry

### DIFF
--- a/app/lib/common/utils/logging.dart
+++ b/app/lib/common/utils/logging.dart
@@ -1,6 +1,7 @@
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 final Map<(String, String), bool> logStateCache = {};
 
@@ -19,6 +20,11 @@ Future<void> initLogging() async {
       levelName = 'warn';
     } else if (level == Level.SEVERE || level == Level.SHOUT) {
       levelName = 'error';
+      Sentry.captureMessage(record.message, level: SentryLevel.error);
+      final exception = record.object;
+      if (exception != null) {
+        Sentry.captureException(exception, stackTrace: record.stackTrace);
+      }
     } else if (level == Level.INFO) {
       levelName = 'info';
     } else if (level == Level.CONFIG) {

--- a/app/lib/features/auth/actions/register_action.dart
+++ b/app/lib/features/auth/actions/register_action.dart
@@ -3,7 +3,6 @@ import 'package:acter/features/super_invites/providers/super_invites_providers.d
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 final _log = Logger('a3::auth::register');
 
@@ -12,9 +11,7 @@ Future<void> _tryRedeem(SuperInvites superInvites, String token) async {
   try {
     await superInvites.redeem(token);
   } catch (error, stack) {
-    Sentry.captureMessage('Redeeming post-registration token $token failed');
-    Sentry.captureException(error, stackTrace: stack);
-    _log.warning('redeeming super invite `$token` failed: $error');
+    _log.severe('redeeming super invite `$token` failed: $error', error, stack);
   }
 }
 


### PR DESCRIPTION
expanding our logger facilities to submit all exceptions logged in the flutter side directly to the sentry (if activated). Note: This will bring up a bunch of false-positives (e.g. could not connect to server), which we want to filter out in the future.  