### PR TITLE
Fix too many calendars on Android

### DIFF
--- a/.changes/2503-fix-calendar-on-android.md
+++ b/.changes/2503-fix-calendar-on-android.md
@@ -1,0 +1,1 @@
+- Fix App generating too many device calendars on some devices

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -66,8 +66,6 @@ android {
             signingConfig signingConfigs.release
 
             minifyEnabled true
-            useProguard true
-
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro' 
 
         }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -64,6 +64,12 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+
+            minifyEnabled true
+            useProguard true
+
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro' 
+
         }
     }
     namespace 'global.acter.app'

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,10 +1,20 @@
 # Flutter Wrapper
--keep class io.flutter.app.** { *; }
 -keep class io.flutter.plugin.**  { *; }
 -keep class io.flutter.util.**  { *; }
 -keep class io.flutter.view.**  { *; }
--keep class io.flutter.**  { *; }
 -keep class io.flutter.plugins.**  { *; }
+
+# FIX for: ERROR: R8: Library class android.content.res.XmlResourceParser implements program class org.xmlpull.v1.XmlPullParser
+-dontwarn org.xmlpull.v1.**
+-dontwarn org.kxml2.io.**
+-dontwarn android.content.res.**
+-dontwarn org.slf4j.impl.StaticLoggerBinder
+-keep class org.xmlpull.** { *; }
+-keepclassmembers class org.xmlpull.** { *; }
+
+# -keep class io.flutter.app.** { *; }
+# -keep class io.flutter.**  { *; }
+# --- /end fix
 
 # ---- Specific plugins:
 # Firebase for notifications

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,0 +1,14 @@
+# Flutter Wrapper
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.**  { *; }
+-keep class io.flutter.view.**  { *; }
+-keep class io.flutter.**  { *; }
+-keep class io.flutter.plugins.**  { *; }
+
+# ---- Specific plugins:
+# Firebase for notifications
+-keep class com.google.firebase.** { *; }
+# Device Calendar fix 
+# see https://github.com/builttoroam/device_calendar/issues/99
+-keep class com.builttoroam.devicecalendar.** { *; }

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs= -Xmx8g -Xms512M -XX:ReservedCodeCacheSize=2048m -XX:+UseComp
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.enableR8=true

--- a/app/lib/features/calendar_sync/calendar_sync.dart
+++ b/app/lib/features/calendar_sync/calendar_sync.dart
@@ -162,7 +162,7 @@ Future<void> _refreshCalendar(
   final currentLinkKeys = currentLinks.values;
   List<Event> foundEvents = [];
   if (currentLinkKeys.isNotEmpty) {
-    _log.info('Current links: $calendarId: ${currentLinkKeys}');
+    _log.info('Current links: $calendarId: $currentLinkKeys');
     final foundEventsResult = await deviceCalendar.retrieveEvents(
       calendarId,
       RetrieveEventsParams(eventIds: currentLinks.values.toList()),

--- a/app/lib/features/calendar_sync/calendar_sync.dart
+++ b/app/lib/features/calendar_sync/calendar_sync.dart
@@ -162,7 +162,7 @@ Future<void> _refreshCalendar(
   final currentLinkKeys = currentLinks.values;
   List<Event> foundEvents = [];
   if (currentLinkKeys.isNotEmpty) {
-    _log.info('Current links: $calendarId: ${currentLinkKeys.length}');
+    _log.info('Current links: $calendarId: ${currentLinkKeys}');
     final foundEventsResult = await deviceCalendar.retrieveEvents(
       calendarId,
       RetrieveEventsParams(eventIds: currentLinks.values.toList()),


### PR DESCRIPTION
The logs of https://github.com/acterglobal/a3-meta/issues/709 showed that despite our local cached info being retrieved properly, the calendars were not found and instead a new one was created:

```
[2025-01-15][14:39:47.711234][a3::calendar_sync][INFO] Previous key found 1057 null null null
[2025-01-15][14:39:47.773262][a3::calendar_sync][INFO] No previous calendar found, creating a new one null null null
[2025-01-15][14:39:47.821049][a3::calendar_sync][INFO] ignoring state change without value null null null
 ...
[2025-01-15][14:39:50.831929][a3::calendar_sync][INFO] Current links: 1058: 3 null null null
[2025-01-15][14:39:50.873099][a3::calendar_sync][INFO] 1058: creating new items for $Ent7jKLpXl20AxOZGy96jW5FhPEDnXy1yAnKOuKID8U null null null
[2025-01-15][14:39:50.909107][a3::calendar_sync][INFO] 1058: creating new items for $ITaQQ-V58nIODj0KI7Aa4SZQ9GYaDffMhaQmW32i4zU null null null
[2025-01-15][14:39:50.936522][a3::calendar_sync][INFO] 1058: creating new items for $MS2tsQbSjD5GYZjw1OmM-IB9RdRePt0KRr3qCunhdA8 null null null
[2025-01-15][14:39:50.963767][a3::calendar_sync][INFO] Storing new mapping: [$Ent7jKLpXl20AxOZGy96jW5FhPEDnXy1yAnKOuKID8U=7096, $ITaQQ-V58nIODj0KI7Aa4SZQ9GYaDffMhaQmW32i4zU=7097, $MS2tsQbSjD5GYZjw1OmM-IB9RdRePt0KRr3qCunhdA8=7098] null null null
```

As if the call for `retrieveCalendars` wasn't working at all. Checking the [documentation of the plugin]((https://pub.dev/packages/device_calendar)), we can see that there is a section about if exactly that kind of problem, which I ignored in the past, as we didn't have configured. But revisiting this, it seems that this is exactly the issue causing #2369 and also explaining why all is fine in debug mode and we only see it on nightly and release:

> By default, all android apps go through R8 for file shrinking when building a release version. Currently, it interferes with some functions such as retrieveCalendars().
> 
> You may add the following setting to the ProGuard rules file proguard-rules.pro (thanks to [Britannio Jarrett](https://github.com/britannio)). Read more about the issue [here](https://github.com/builttoroam/device_calendar/issues/99) 


This PR applies those changes (and a minor more verbose trace) so we can try it out in a nightly release (after this release) and confirm the fix.

