### PR TITLE
Reduce `NoClientException`-Problems

### DIFF
--- a/app/integration_test/tests/attachments.dart
+++ b/app/integration_test/tests/attachments.dart
@@ -35,7 +35,7 @@ extension ActerAttachments on ConvenientTest {
     );
     final context = tester.element(addAttachmentFinder);
     final ref = ProviderScope.containerOf(context);
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
 
     Uint8List bytes = await imageFile.readAsBytes();
     final decodedImage = await decodeImageFromList(bytes);
@@ -65,7 +65,7 @@ extension ActerAttachments on ConvenientTest {
     );
     final context = tester.element(addAttachmentFinder);
     final ref = ProviderScope.containerOf(context);
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
 
     Uint8List bytes = await videoFile.readAsBytes();
     final videoDraft =
@@ -92,7 +92,7 @@ extension ActerAttachments on ConvenientTest {
     );
     final context = tester.element(addAttachmentFinder);
     final ref = ProviderScope.containerOf(context);
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     String? mimeType = lookupMimeType(file.path);
     String fileName = file.path.split('/').last;
     int fileSize = await file.length();

--- a/app/lib/common/providers/chat_providers.dart
+++ b/app/lib/common/providers/chat_providers.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/notifiers/chat_notifiers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:riverpod/riverpod.dart';
 
@@ -16,11 +15,9 @@ final latestMessageProvider =
 );
 
 /// Provider for fetching rooms list. This’ll always bring up unsorted list.
-final _convosProvider =
-    StateNotifierProvider<ChatRoomsListNotifier, List<Convo>>((ref) {
-  final client = ref.watch(alwaysClientProvider);
-  return ChatRoomsListNotifier(ref: ref, client: client);
-});
+final _convosProvider = NotifierProvider<ChatRoomsListNotifier, List<Convo>>(
+  () => ChatRoomsListNotifier(),
+);
 
 /// Provider that sorts up list based on latest timestamp from [_convosProvider].
 final chatsProvider = Provider<List<Convo>>((ref) {

--- a/app/lib/common/providers/common_providers.dart
+++ b/app/lib/common/providers/common_providers.dart
@@ -13,7 +13,7 @@ final _log = Logger('a3::common::common_providers');
 
 final genericUpdatesStream =
     StreamProvider.family<int, String>((ref, key) async* {
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   int counter = 0; // to ensure the value updates
 
   // ignore: unused_local_variable
@@ -24,14 +24,14 @@ final genericUpdatesStream =
 });
 
 final myUserIdStrProvider = Provider(
-  (ref) => ref.watch(
-    alwaysClientProvider.select((client) => client.userId().toString()),
-  ),
+  (ref) =>
+      ref.watch(alwaysClientProvider).valueOrNull?.userId().toString() ??
+      '@acter:acter.global',
 );
 
-final accountProvider = Provider(
+final accountProvider = FutureProvider(
   (ref) => ref.watch(
-    alwaysClientProvider.select((client) => client.account()),
+    alwaysClientProvider.selectAsync((client) => client.account()),
   ),
 );
 
@@ -39,12 +39,9 @@ final hasFirstSyncedProvider = Provider(
   (ref) => ref.watch(syncStateProvider.select((v) => !v.initialSync)),
 );
 
-final isGuestProvider =
-    Provider((ref) => ref.watch(alwaysClientProvider).isGuest());
-
-final deviceIdProvider = Provider(
+final deviceIdProvider = FutureProvider(
   (ref) => ref.watch(
-    alwaysClientProvider.select(
+    alwaysClientProvider.selectAsync(
       (v) => v.deviceId().toString(),
     ),
   ),
@@ -52,8 +49,7 @@ final deviceIdProvider = Provider(
 
 /// Gives [AvatarInfo] object for user account. Stays up-to-date internally.
 final accountAvatarInfoProvider = StateProvider.autoDispose<AvatarInfo>((ref) {
-  final account = ref.watch(accountProvider);
-  final userId = account.userId().toString();
+  final userId = ref.watch(myUserIdStrProvider);
 
   final displayName = ref.watch(accountDisplayNameProvider).valueOrNull;
   final avatar = ref.watch(_accountAvatarProvider).valueOrNull;
@@ -74,14 +70,14 @@ final accountAvatarInfoProvider = StateProvider.autoDispose<AvatarInfo>((ref) {
 /// Caching the name of each Room
 final accountDisplayNameProvider =
     FutureProvider.autoDispose<String?>((ref) async {
-  final account = ref.watch(accountProvider);
+  final account = await ref.watch(accountProvider.future);
   return (await account.displayName()).text();
 });
 
 final _accountAvatarProvider =
     FutureProvider.autoDispose<MemoryImage?>((ref) async {
   final sdk = await ref.watch(sdkProvider.future);
-  final account = ref.watch(accountProvider);
+  final account = await ref.watch(accountProvider.future);
   final thumbSize = sdk.api.newThumbSize(48, 48);
   final avatar = await account.avatar(thumbSize);
   // Only call data() once as it will consume the value and any subsequent
@@ -100,7 +96,7 @@ class EmailAddresses {
 }
 
 final emailAddressesProvider = FutureProvider((ref) async {
-  final account = ref.watch(accountProvider);
+  final account = await ref.watch(accountProvider.future);
   // ensure we are updated if the upgrade comes down the wire.
   ref.watch(genericUpdatesStream('global.acter.dev.three_pid'));
   final confirmed = asDartStringList(await account.confirmedEmailAddresses());

--- a/app/lib/common/providers/notifiers/chat_notifiers.dart
+++ b/app/lib/common/providers/notifiers/chat_notifiers.dart
@@ -19,7 +19,7 @@ class AsyncConvoNotifier extends FamilyAsyncNotifier<Convo?, String> {
   @override
   FutureOr<Convo?> build(String arg) async {
     final roomId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener = client.subscribeStream(roomId); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {
@@ -50,7 +50,7 @@ class AsyncLatestMsgNotifier extends FamilyAsyncNotifier<RoomMessage?, String> {
   @override
   FutureOr<RoomMessage?> build(String arg) async {
     final roomId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener = client.subscribeStream('$roomId::latest_message');
     _poller = _listener.listen(
       (data) async {
@@ -70,20 +70,15 @@ class AsyncLatestMsgNotifier extends FamilyAsyncNotifier<RoomMessage?, String> {
   }
 }
 
-class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
-  final Client client;
+class ChatRoomsListNotifier extends Notifier<List<Convo>> {
   late Stream<ConvoDiff> _listener;
-  late StreamSubscription<ConvoDiff> _poller;
+  StreamSubscription<ConvoDiff>? _poller;
+  late ProviderSubscription _providerSubscription;
 
-  ChatRoomsListNotifier({
-    required Ref ref,
-    required this.client,
-  }) : super(List<Convo>.empty(growable: false)) {
-    _init(ref);
-  }
-
-  void _init(Ref ref) {
+  void _reset(Client client) {
+    state = List<Convo>.empty(growable: false);
     _listener = client.convosStream(); // keep it resident in memory
+    _poller?.cancel();
     _poller = _listener.listen(
       _handleDiff,
       onError: (e, s) {
@@ -93,7 +88,7 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
         _log.info('convo list stream ended');
       },
     );
-    ref.onDispose(() => _poller.cancel());
+    ref.onDispose(() => _poller?.cancel());
   }
 
   List<Convo> listCopy() => List.from(state, growable: true);
@@ -203,6 +198,24 @@ class ChatRoomsListNotifier extends StateNotifier<List<Convo>> {
       default:
         break;
     }
+  }
+
+  @override
+  List<Convo> build() {
+    _providerSubscription = ref.listen<AsyncValue<Client?>>(
+      alwaysClientProvider,
+      (AsyncValue<Client?>? oldVal, AsyncValue<Client?> newVal) {
+        final client = newVal.valueOrNull;
+        if (client == null) {
+          // we don't care for not having a proper client yet
+          return;
+        }
+        _reset(client);
+      },
+      fireImmediately: true,
+    );
+    ref.onDispose(() => _providerSubscription.close());
+    return List<Convo>.empty(growable: false);
   }
 }
 

--- a/app/lib/common/providers/notifiers/client_pref_notifier.dart
+++ b/app/lib/common/providers/notifiers/client_pref_notifier.dart
@@ -7,8 +7,9 @@
 ///
 library;
 
+import 'dart:async';
+
 import 'package:acter/common/providers/common_providers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -16,31 +17,26 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// The type parameter `T` is the type of value that will
 /// be persisted in [SharedPreferences].
 ///
-/// To update the value, use the [update()] function.
+/// To update the value, use the [set()] function.
 /// Direct assignment to state cannot be used.
 ///
 /// ```dart
-/// await watch(booPrefProvider.notifier).update(v);
+/// await watch(booPrefProvider.notifier).set(v);
 /// ```
 ///
 ///
-class PrefNotifier<T> extends StateNotifier<T> {
-  PrefNotifier(this.prefKey, this.defaultValue) : super(defaultValue) {
-    _init();
-  }
+class PrefNotifier<T> extends Notifier<T> {
+  PrefNotifier(this.prefKeySuffix, this.defaultValue);
 
+  final String prefKeySuffix;
+  late String deviceId;
   late SharedPreferences prefs;
-  String prefKey;
+
+  String get prefKey => '$deviceId-$prefKeySuffix';
   T defaultValue;
 
-  void _init() async {
-    prefs = await sharedPrefs();
-    final newValue = (prefs.get(prefKey) as T? ?? defaultValue);
-    state = newValue;
-  }
-
   /// Updates the value asynchronously.
-  Future<void> update(T value) async {
+  Future<void> set(T value) async {
     if (value is String) {
       await prefs.setString(prefKey, value);
     } else if (value is bool) {
@@ -55,16 +51,18 @@ class PrefNotifier<T> extends StateNotifier<T> {
     super.state = value;
   }
 
-  /// Do not use the setter for state.
-  /// Instead, use `await update(value).`
   @override
-  set state(T value) {
-    assert(
-      false,
-      'Don’t use the setter for state. Instead use `await update(value)`.',
-    );
-    Future(() async {
-      await update(value);
+  T build() {
+    _init();
+    return defaultValue;
+  }
+
+  void _init() async {
+    prefs = await sharedPrefs();
+    deviceId = await ref.watch(deviceIdProvider.future);
+    Future.delayed(Duration(milliseconds: 10), () {
+      // make sure we do this _after_ the initial build function has passed
+      state = (prefs.get(prefKey) as T? ?? defaultValue);
     });
   }
 }
@@ -104,65 +102,60 @@ class PrefNotifier<T> extends StateNotifier<T> {
 ///
 /// ```dart
 ///
-///   await watch(booPrefProvider.notifier).update(true);
+///   await watch(booPrefProvider.notifier).set(true);
 ///
 /// ```
 ///
-StateNotifierProvider<PrefNotifier<T>, T> createPrefProvider<T>({
+NotifierProvider<PrefNotifier<T>, T> createPrefProvider<T>({
   required String prefKey,
   required T defaultValue,
-}) {
-  return StateNotifierProvider<PrefNotifier<T>, T>((ref) {
-    final clientId =
-        ref.watch(alwaysClientProvider.select((v) => v.deviceId().toString()));
-    return PrefNotifier<T>('$clientId-$prefKey', defaultValue);
-  });
-}
+}) =>
+    NotifierProvider<PrefNotifier<T>, T>(
+      () => PrefNotifier<T>(prefKey, defaultValue),
+    );
 
 /// Converts the value of type parameter `T` to a String and persists
 /// it in SharedPreferences.
 ///
-/// To update the value, use the [update()] function.
+/// To update the value, use the [set()] function.
 /// Direct assignment to state cannot be used.
 ///
 /// ```dart
-/// await watch(mapPrefProvider.notifier).update(v);
+/// await watch(mapPrefProvider.notifier).set(v);
 /// ```
 ///
-class MapPrefNotifier<T> extends StateNotifier<T> {
-  MapPrefNotifier(this.prefKey, this.mapFrom, this.mapTo)
-      : super(mapFrom(null)) {
-    _init();
-  }
+class MapPrefNotifier<T> extends Notifier<T> {
+  MapPrefNotifier(this.prefKeySuffix, this.mapFrom, this.mapTo);
 
+  late String deviceId;
   late SharedPreferences prefs;
-  String prefKey;
+
+  final String prefKeySuffix;
   T Function(String?) mapFrom;
   String Function(T) mapTo;
 
+  String get prefKey => '$deviceId-$prefKeySuffix';
+
   void _init() async {
+    deviceId = await ref.watch(deviceIdProvider.future);
     prefs = await sharedPrefs();
     final newValue = mapFrom(prefs.getString(prefKey));
-    super.state = newValue;
+    Future.delayed(Duration(milliseconds: 10), () {
+      // make sure we do this _after_ the initial build function has passed
+      state = newValue;
+    });
   }
 
   /// Updates the value asynchronously.
-  Future<void> update(T value) async {
+  Future<void> set(T value) async {
     await prefs.setString(prefKey, mapTo(value));
-    super.state = value;
+    state = value;
   }
 
-  /// Do not use the setter for state.
-  /// Instead, use `await update(value).`
   @override
-  set state(T value) {
-    assert(
-      false,
-      'Don’t use the setter for state. Instead use `await update(value)`.',
-    );
-    Future(() async {
-      await update(value);
-    });
+  T build() {
+    _init();
+    return mapFrom(null);
   }
 }
 
@@ -210,17 +203,15 @@ class MapPrefNotifier<T> extends StateNotifier<T> {
 ///
 /// ```dart
 ///
-///   await watch(enumPrefProvider.notifier).update(EnumValues.bar);
+///   await watch(enumPrefProvider.notifier).set(EnumValues.bar);
 ///
 /// ```
 ///
-StateNotifierProvider<MapPrefNotifier<T>, T> createMapPrefProvider<T>({
+NotifierProvider<MapPrefNotifier<T>, T> createMapPrefProvider<T>({
   required String prefKey,
   required T Function(String?) mapFrom,
   required String Function(T) mapTo,
-}) {
-  return StateNotifierProvider<MapPrefNotifier<T>, T>((ref) {
-    final clientId = ref.watch(deviceIdProvider);
-    return MapPrefNotifier<T>('$clientId-$prefKey', mapFrom, mapTo);
-  });
-}
+}) =>
+    NotifierProvider<MapPrefNotifier<T>, T>(
+      () => MapPrefNotifier<T>(prefKey, mapFrom, mapTo),
+    );

--- a/app/lib/common/providers/notifiers/room_notifiers.dart
+++ b/app/lib/common/providers/notifiers/room_notifiers.dart
@@ -25,7 +25,7 @@ class AsyncMaybeRoomNotifier extends FamilyAsyncNotifier<Room?, String> {
 
   @override
   Future<Room?> build(String arg) async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener = client.subscribeStream(arg); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -3,33 +3,47 @@ import 'dart:math';
 
 import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/models/sync_state/sync_state.dart';
+import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:riverpod/riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 // ignore_for_file: avoid_print
-class SyncNotifier extends StateNotifier<SyncState> {
-  final ffi.Client client;
-  final Ref ref;
+class SyncNotifier extends Notifier<SyncState> {
+  late ffi.Client client;
 
   late ffi.SyncState syncState;
-  late Stream<bool> _syncListener;
-  late StreamSubscription<bool> _syncPoller;
-  late Stream<String> _errorListener;
-  late StreamSubscription<String> _errorPoller;
+  Stream<bool>? _syncListener;
+  StreamSubscription<bool>? _syncPoller;
+  Stream<String>? _errorListener;
+  StreamSubscription<String>? _errorPoller;
+  late ProviderSubscription _providerSubscription;
   Timer? _retryTimer;
 
-  SyncNotifier(this.client, this.ref)
-      : super(const SyncState(initialSync: true)) {
-    _startSync(ref);
-  }
-
-  void _startSync(Ref ref) {
-    // on release we have a really weird behavior, where, if we schedule
-    // any async call in rust too early, they just pend forever. this
-    // hack unfortunately means we have two wait a bit but that means
-    // we get past the threshold where it is okay to schedule...
-    Future.delayed(const Duration(milliseconds: 1500), () => _restartSync());
+  @override
+  SyncState build() {
+    _providerSubscription = ref.listen<AsyncValue<ffi.Client?>>(
+      alwaysClientProvider,
+      (AsyncValue<ffi.Client?>? oldVal, AsyncValue<ffi.Client?> newVal) {
+        final newClient = newVal.valueOrNull;
+        if (newClient == null) {
+          // we don't care for not having a proper client yet
+          return;
+        }
+        // on release we have a really weird behavior, where, if we schedule
+        // any async call in rust too early, they just pend forever. this
+        // hack unfortunately means we have two wait a bit but that means
+        // we get past the threshold where it is okay to schedule...
+        client = newClient;
+        Future.delayed(
+          const Duration(milliseconds: 1500),
+          () => _restartSync(),
+        );
+      },
+      fireImmediately: true,
+    );
+    ref.onDispose(() => _providerSubscription.close());
+    return const SyncState(initialSync: true);
   }
 
   void _tickSyncState() {
@@ -48,46 +62,44 @@ class SyncNotifier extends StateNotifier<SyncState> {
 
   void _restartSync() {
     syncState = client.startSync();
-    if (_retryTimer != null) {
-      _retryTimer!.cancel();
-      _retryTimer = null;
-    }
+
+    // reset states
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _syncPoller?.cancel();
+    _errorPoller?.cancel();
 
     _syncListener = syncState.firstSyncedRx(); // keep it resident in memory
-    _syncPoller = _syncListener.listen((synced) {
+    _syncPoller = _syncListener?.listen((synced) {
       if (synced) {
-        if (mounted) {
-          state = const SyncState(initialSync: false);
-        }
+        state = const SyncState(initialSync: false);
       }
     });
-    ref.onDispose(() => _syncPoller.cancel());
+    ref.onDispose(() => _syncPoller?.cancel());
 
     _errorListener = syncState.syncErrorRx(); // keep it resident in memory
-    _errorPoller = _errorListener.listen((msg) {
+    _errorPoller = _errorListener?.listen((msg) {
       Sentry.captureMessage('Sync failure: $msg', level: SentryLevel.error);
-      if (mounted) {
-        if (msg == 'SoftLogout' || msg == 'Unauthorized') {
-          // regular logout, we do nothing here
-          state = SyncState(initialSync: false, errorMsg: msg);
-        } else {
-          final retry = min(
-            state.nextRetry.map((nextRetry) => nextRetry * 2) ?? 5,
-            300,
-          ); // we double this to a max of 5min.
-          state = state.copyWith(
-            initialSync: false,
-            errorMsg: msg,
-            countDown: retry,
-            nextRetry: retry,
-          );
-          _retryTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-            _tickSyncState();
-          });
-          // custom errors, means we will start the retry loop
-        }
+      if (msg == 'SoftLogout' || msg == 'Unauthorized') {
+        // regular logout, we do nothing here
+        state = SyncState(initialSync: false, errorMsg: msg);
+      } else {
+        final retry = min(
+          state.nextRetry.map((nextRetry) => nextRetry * 2) ?? 5,
+          300,
+        ); // we double this to a max of 5min.
+        state = state.copyWith(
+          initialSync: false,
+          errorMsg: msg,
+          countDown: retry,
+          nextRetry: retry,
+        );
+        _retryTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+          _tickSyncState();
+        });
+        // custom errors, means we will start the retry loop
       }
     });
-    ref.onDispose(() => _errorPoller.cancel());
+    ref.onDispose(() => _errorPoller?.cancel());
   }
 }

--- a/app/lib/common/providers/space_providers.dart
+++ b/app/lib/common/providers/space_providers.dart
@@ -2,7 +2,6 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/providers/notifiers/relations_notifier.dart';
 import 'package:acter/common/providers/notifiers/space_notifiers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:logging/logging.dart';
@@ -12,10 +11,7 @@ final _log = Logger('a3::common::space_providers');
 
 /// Provider the list of all spaces, keeps up to date with the order and the underlying client
 final spacesProvider =
-    StateNotifierProvider<SpaceListNotifier, List<Space>>((ref) {
-  final client = ref.watch(alwaysClientProvider);
-  return SpaceListNotifier(ref: ref, client: client);
-});
+    NotifierProvider<SpaceListNotifier, List<Space>>(() => SpaceListNotifier());
 
 final hasSpacesProvider =
     Provider((ref) => ref.watch(spacesProvider).isNotEmpty);

--- a/app/lib/features/attachments/actions/handle_selected_attachments.dart
+++ b/app/lib/features/attachments/actions/handle_selected_attachments.dart
@@ -29,7 +29,7 @@ Future<void> handleAttachmentSelected({
   /// only supports image/video/audio/file.
   final lang = L10n.of(context);
   EasyLoading.show(status: lang.sendingAttachment);
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
   List<AttachmentDraft> drafts = [];
   try {
     for (final file in attachments) {

--- a/app/lib/features/auth/actions/register_action.dart
+++ b/app/lib/features/auth/actions/register_action.dart
@@ -34,7 +34,7 @@ Future<bool> register({
     throw errorMsg;
   }
   if (token.isNotEmpty) {
-    final superInvites = ref.read(superInvitesProvider);
+    final superInvites = await ref.read(superInvitesProvider.future);
     _tryRedeem(superInvites, token);
   }
   return true;

--- a/app/lib/features/auth/providers/notifiers/auth_notifier.dart
+++ b/app/lib/features/auth/providers/notifiers/auth_notifier.dart
@@ -23,7 +23,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.login(username, password);
-      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
+      ref.read(clientProvider.notifier).setClient(client);
       state = false;
       return null;
     } catch (e, s) {
@@ -38,7 +38,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.newGuestClient(setAsCurrent: true);
-      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
+      ref.read(clientProvider.notifier).setClient(client);
       state = false;
       if (context != null && context.mounted) {
         context.goNamed(Routes.main.name);
@@ -58,7 +58,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.register(username, password, displayName, token);
-      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
+      ref.read(clientProvider.notifier).setClient(client);
       state = false;
       return null;
     } catch (e) {
@@ -72,8 +72,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final stillHasClient = await sdk.logout();
     if (stillHasClient) {
       _log.info('Still has clients, dropping back to other');
-      ref.read(clientProvider.notifier).state =
-          AsyncValue.data(sdk.currentClient);
+      ref.read(clientProvider.notifier).setClient(sdk.currentClient);
       if (context.mounted) {
         context.goNamed(Routes.main.name);
       }

--- a/app/lib/features/auth/providers/notifiers/auth_notifier.dart
+++ b/app/lib/features/auth/providers/notifiers/auth_notifier.dart
@@ -23,7 +23,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.login(username, password);
-      ref.read(clientProvider.notifier).state = client;
+      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
       state = false;
       return null;
     } catch (e, s) {
@@ -38,7 +38,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.newGuestClient(setAsCurrent: true);
-      ref.read(clientProvider.notifier).state = client;
+      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
       state = false;
       if (context != null && context.mounted) {
         context.goNamed(Routes.main.name);
@@ -58,7 +58,7 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final sdk = await ref.read(sdkProvider.future);
     try {
       final client = await sdk.register(username, password, displayName, token);
-      ref.read(clientProvider.notifier).state = client;
+      ref.read(clientProvider.notifier).state = AsyncValue.data(client);
       state = false;
       return null;
     } catch (e) {
@@ -72,7 +72,8 @@ class AuthStateNotifier extends StateNotifier<bool> {
     final stillHasClient = await sdk.logout();
     if (stillHasClient) {
       _log.info('Still has clients, dropping back to other');
-      ref.read(clientProvider.notifier).state = sdk.currentClient;
+      ref.read(clientProvider.notifier).state =
+          AsyncValue.data(sdk.currentClient);
       if (context.mounted) {
         context.goNamed(Routes.main.name);
       }

--- a/app/lib/features/backups/dialogs/provide_recovery_key_dialog.dart
+++ b/app/lib/features/backups/dialogs/provide_recovery_key_dialog.dart
@@ -81,7 +81,7 @@ class __RecoveryKeyDialogState extends ConsumerState<_RecoveryKeyDialog> {
     EasyLoading.show(status: lang.encryptionBackupRecoverRecovering);
     try {
       final key = recoveryKey.text;
-      final manager = ref.read(backupManagerProvider);
+      final manager = await ref.read(backupManagerProvider.future);
       final recoveryWorked = await manager.recover(key);
       if (recoveryWorked) {
         if (!context.mounted) {

--- a/app/lib/features/backups/dialogs/show_confirm_disabling.dart
+++ b/app/lib/features/backups/dialogs/show_confirm_disabling.dart
@@ -46,7 +46,7 @@ class _ShowConfirmResetDialog extends ConsumerWidget {
     final lang = L10n.of(context);
     EasyLoading.show(status: lang.encryptionBackupResetting);
     try {
-      final manager = ref.read(backupManagerProvider);
+      final manager = await ref.read(backupManagerProvider.future);
       final newKey = await manager.reset();
       if (!context.mounted) {
         EasyLoading.dismiss();

--- a/app/lib/features/backups/providers/backup_manager_provider.dart
+++ b/app/lib/features/backups/providers/backup_manager_provider.dart
@@ -1,5 +1,10 @@
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final backupManagerProvider =
-    StateProvider((ref) => ref.watch(alwaysClientProvider).backupManager());
+final backupManagerProvider = FutureProvider(
+  (ref) => ref.watch(
+    alwaysClientProvider.selectAsync(
+      (client) => client.backupManager(),
+    ),
+  ),
+);

--- a/app/lib/features/backups/providers/notifiers/backup_state_notifier.dart
+++ b/app/lib/features/backups/providers/notifiers/backup_state_notifier.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:acter/features/backups/providers/backup_manager_provider.dart';
 import 'package:acter/features/backups/types.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
@@ -9,13 +10,30 @@ final _log = Logger('a3::backups::backup_state');
 
 class RecoveryStateNotifier extends Notifier<RecoveryState> {
   late Stream<String> _listener;
-  late StreamSubscription<String> _poller;
+  StreamSubscription<String>? _poller;
+  late ProviderSubscription _providerSubscription;
 
   @override
   RecoveryState build() {
-    // Load initial todo list from the remote repository
-    final backup = ref.watch(backupManagerProvider);
+    _providerSubscription =
+        ref.listen<AsyncValue<BackupManager?>>(backupManagerProvider, (
+      AsyncValue<BackupManager?>? oldVal,
+      AsyncValue<BackupManager?> newVal,
+    ) {
+      final next = newVal.valueOrNull;
+      if (next == null) {
+        // we don't care for not having a proper client yet
+        return;
+      }
+      _reset(next);
+    });
+    ref.onDispose(() => _providerSubscription.close());
+    return RecoveryState.unknown;
+  }
+
+  void _reset(BackupManager backup) {
     _listener = backup.stateStream(); // keep it resident in memory
+    _poller?.cancel();
     _poller = _listener.listen(
       (data) async {
         state = stringToState(data);
@@ -27,7 +45,6 @@ class RecoveryStateNotifier extends Notifier<RecoveryState> {
         _log.info('stream ended');
       },
     );
-    ref.onDispose(() => _poller.cancel());
-    return stringToState(backup.stateStr());
+    ref.onDispose(() => _poller?.cancel());
   }
 }

--- a/app/lib/features/backups/widgets/backup_state_widget.dart
+++ b/app/lib/features/backups/widgets/backup_state_widget.dart
@@ -111,7 +111,7 @@ class BackupStateWidget extends ConsumerWidget {
     EasyLoading.show(status: lang.encryptionBackupEnabling);
     String secret;
     try {
-      final manager = ref.read(backupManagerProvider);
+      final manager = await ref.read(backupManagerProvider.future);
       secret = await manager.enable();
     } catch (e, s) {
       _log.severe('Failed to enable backup', e, s);

--- a/app/lib/features/bookmarks/providers/notifiers.dart
+++ b/app/lib/features/bookmarks/providers/notifiers.dart
@@ -14,7 +14,7 @@ class BookmarksManagerNotifier extends AsyncNotifier<Bookmarks> {
 
   @override
   Future<Bookmarks> build() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
 
     _listener = client.subscribeStream('global.acter.bookmarks');
 

--- a/app/lib/features/chat/actions/create_chat.dart
+++ b/app/lib/features/chat/actions/create_chat.dart
@@ -50,7 +50,7 @@ Future<String?> createChat(
     if (parentId != null) {
       config.setParent(parentId);
     }
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final roomId = await client.createConvo(config.build());
     final roomIdStr = roomId.toString();
     // add room to child of space (if given)

--- a/app/lib/features/chat/providers/chat_providers.dart
+++ b/app/lib/features/chat/providers/chat_providers.dart
@@ -187,7 +187,7 @@ final isRoomEncryptedProvider =
 
 final chatTypingEventProvider = StreamProvider.autoDispose
     .family<List<types.User>, String>((ref, roomId) async* {
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   final userId = ref.watch(myUserIdStrProvider);
   yield [];
   await for (final event in client.subscribeToTypingEventStream(roomId)) {

--- a/app/lib/features/chat/widgets/create_chat.dart
+++ b/app/lib/features/chat/widgets/create_chat.dart
@@ -132,8 +132,8 @@ class _CreateChatWidgetState extends ConsumerState<CreateChatPage> {
     );
     if (roomIdStr != null) {
       try {
-        final convo =
-            await ref.read(alwaysClientProvider).convoWithRetry(roomIdStr, 120);
+        final convo = await (await ref.read(alwaysClientProvider.future))
+            .convoWithRetry(roomIdStr, 120);
         EasyLoading.showToast(roomCreated);
         return convo;
       } catch (e, s) {
@@ -205,7 +205,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
       return lang.startGroupDM;
     } else {
       final otherUserId = selectedUsers[0].userId().toString();
-      final client = ref.watch(alwaysClientProvider);
+      final client = ref.watch(alwaysClientProvider).valueOrNull;
       if (checkUserDMExists(otherUserId, client) != null) {
         return lang.goToDM;
       } else {
@@ -215,8 +215,8 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
   }
 
   // checks whether user DM already exists or needs created
-  String? checkUserDMExists(String userId, ffi.Client client) {
-    return client.dmWithUser(userId).text();
+  String? checkUserDMExists(String userId, ffi.Client? client) {
+    return client?.dmWithUser(userId).text();
   }
 
   Widget renderSelectedUsers(BuildContext context) {
@@ -389,7 +389,7 @@ class _CreateChatWidgetConsumerState extends ConsumerState<_CreateChatWidget> {
       }
 
       final otherUserId = selectedUsers[0].userId().toString();
-      final client = ref.read(alwaysClientProvider);
+      final client = ref.read(alwaysClientProvider).valueOrNull;
       String? roomId = checkUserDMExists(otherUserId, client);
       if (roomId != null) {
         EasyLoading.dismiss();

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -511,7 +511,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
     List<File> files,
     AttachmentType attachmentType,
   ) async {
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final inputState = ref.read(chatInputProvider);
     final lang = L10n.of(context);
     final stream = await ref.read(timelineStreamProvider(widget.roomId).future);
@@ -674,7 +674,7 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
       });
 
       // make the actual draft
-      final client = ref.read(alwaysClientProvider);
+      final client = await ref.read(alwaysClientProvider.future);
       MsgDraft draft = client.textMarkdownDraft(markdownText);
 
       for (final userId in userMentions) {

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -511,9 +511,9 @@ class __ChatInputState extends ConsumerState<_ChatInput> {
     List<File> files,
     AttachmentType attachmentType,
   ) async {
+    final lang = L10n.of(context);
     final client = await ref.read(alwaysClientProvider.future);
     final inputState = ref.read(chatInputProvider);
-    final lang = L10n.of(context);
     final stream = await ref.read(timelineStreamProvider(widget.roomId).future);
 
     try {

--- a/app/lib/features/chat/widgets/mention_profile_builder.dart
+++ b/app/lib/features/chat/widgets/mention_profile_builder.dart
@@ -1,7 +1,7 @@
 import 'package:acter/common/models/types.dart';
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_trigger_auto_complete/acter_trigger_autocomplete.dart';
 import 'package:flutter/material.dart';
@@ -24,8 +24,7 @@ class MentionProfileBuilder extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final client = ref.watch(alwaysClientProvider);
-    final userId = client.userId().toString();
+    final userId = ref.watch(myUserIdStrProvider);
     final membersLoader = ref.watch(membersIdsProvider(roomQuery.roomId));
     return membersLoader.when(
       loading: () => Skeletonizer(

--- a/app/lib/features/chat/widgets/room_avatar.dart
+++ b/app/lib/features/chat/widgets/room_avatar.dart
@@ -1,6 +1,6 @@
 import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -86,7 +86,7 @@ class RoomAvatar extends ConsumerWidget {
   }
 
   Widget dmAvatar(WidgetRef ref, BuildContext context) {
-    final client = ref.watch(alwaysClientProvider);
+    final myUserId = ref.watch(myUserIdStrProvider);
     final membersLoader = ref.watch(membersIdsProvider(roomId));
     return membersLoader.when(
       data: (members) {
@@ -103,7 +103,7 @@ class RoomAvatar extends ConsumerWidget {
           return memberAvatar(members[0], ref);
         } else if (count == 2) {
           //Show opponent member avatar
-          if (members[0] != client.userId().toString()) {
+          if (members[0] != myUserId) {
             return memberAvatar(members[0], ref);
           } else {
             return memberAvatar(members[1], ref);

--- a/app/lib/features/chat/widgets/rooms_list.dart
+++ b/app/lib/features/chat/widgets/rooms_list.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/acter_search_widget.dart';
@@ -177,24 +176,22 @@ class RoomsListWidgetState extends ConsumerState<RoomsListWidget> {
               duration: const Duration(milliseconds: 400),
               child: _isSearchVisible
                   ? Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: filterBox(context),
-              )
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: filterBox(context),
+                    )
                   : const SizedBox.shrink(),
             ),
             searchTerms(context),
             Expanded(
-              child: ref.watch(isGuestProvider)
-                  ? empty
-                  : ChatsList(
-                      onSelected: (roomId) {
-                        ref
-                            .read(roomListFilterProvider.notifier)
-                            .updateSearchTerm(null);
-                        setState(() => _isSearchVisible = false);
-                        widget.onSelected(roomId);
-                      },
-                    ),
+              child: ChatsList(
+                onSelected: (roomId) {
+                  ref
+                      .read(roomListFilterProvider.notifier)
+                      .updateSearchTerm(null);
+                  setState(() => _isSearchVisible = false);
+                  widget.onSelected(roomId);
+                },
+              ),
             ),
           ],
         ),

--- a/app/lib/features/chat_ng/actions/attachment_upload_action.dart
+++ b/app/lib/features/chat_ng/actions/attachment_upload_action.dart
@@ -19,9 +19,9 @@ Future<void> attachmentUploadAction({
   required BuildContext context,
   required Logger log,
 }) async {
+  final lang = L10n.of(context);
   final client = await ref.read(alwaysClientProvider.future);
   final inputState = ref.read(chatInputProvider);
-  final lang = L10n.of(context);
   final stream = await ref.read(timelineStreamProvider(roomId).future);
 
   try {

--- a/app/lib/features/chat_ng/actions/attachment_upload_action.dart
+++ b/app/lib/features/chat_ng/actions/attachment_upload_action.dart
@@ -19,7 +19,7 @@ Future<void> attachmentUploadAction({
   required BuildContext context,
   required Logger log,
 }) async {
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
   final inputState = ref.read(chatInputProvider);
   final lang = L10n.of(context);
   final stream = await ref.read(timelineStreamProvider(roomId).future);

--- a/app/lib/features/chat_ng/actions/send_message_action.dart
+++ b/app/lib/features/chat_ng/actions/send_message_action.dart
@@ -31,7 +31,7 @@ Future<void> sendMessageAction({
     onTyping?.map((cb) => cb(false));
 
     // make the actual draft
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     late MsgDraft draft;
     if (html.isNotEmpty) {
       draft = client.textHtmlDraft(html, body);

--- a/app/lib/features/cross_signing/providers/verification_providers.dart
+++ b/app/lib/features/cross_signing/providers/verification_providers.dart
@@ -1,10 +1,8 @@
 import 'package:acter/features/cross_signing/providers/notifiers/verification_notifiers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:riverpod/riverpod.dart';
 
 /// Provider of verification state
 final verificationStateProvider =
-    StateNotifierProvider<VerificationNotifier, VerificationState>((ref) {
-  final client = ref.watch(alwaysClientProvider);
-  return VerificationNotifier(ref: ref, client: client);
-});
+    NotifierProvider<VerificationNotifier, VerificationState>(
+  () => VerificationNotifier(),
+);

--- a/app/lib/features/cross_signing/widgets/cross_signing.dart
+++ b/app/lib/features/cross_signing/widgets/cross_signing.dart
@@ -149,11 +149,11 @@ class CrossSigningState extends ConsumerState<CrossSigning> {
     );
   }
 
-  void onRequestTransitioned(VerificationEvent event) {
+  void onRequestTransitioned(VerificationEvent event) async {
     _log.info('emitter request.transitioned');
 
     // start sas event loop
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     client.installSasEventHandler(event.flowId());
   }
 
@@ -207,7 +207,7 @@ class CrossSigningState extends ConsumerState<CrossSigning> {
     );
   }
 
-  void onVerificationRequest(VerificationEvent event) {
+  void onVerificationRequest(VerificationEvent event) async {
     _log.info('emitter verification.request');
 
     // starting of verifiee’s flow
@@ -218,11 +218,12 @@ class CrossSigningState extends ConsumerState<CrossSigning> {
     });
 
     // start request event loop
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     client.installRequestEventHandler(fId);
 
     // open verification.request dialog
     showModalBottomSheet(
+      // ignore: use_build_context_synchronously
       context: context,
       builder: (BuildContext context) => VerificationRequestView(
         sender: event.sender(),

--- a/app/lib/features/events/pages/create_event_page.dart
+++ b/app/lib/features/events/pages/create_event_page.dart
@@ -460,7 +460,7 @@ class CreateEventPageConsumerState extends ConsumerState<CreateEventPage> {
       draft.utcEndFromRfc3339(utcEndDateTime);
       draft.descriptionHtml(plainDescription, htmlBodyDescription);
       final eventId = (await draft.send()).toString();
-      final client = ref.read(alwaysClientProvider);
+      final client = await ref.read(alwaysClientProvider.future);
       final calendarEvent = await client.waitForCalendarEvent(eventId, null);
 
       /// Event is created, set RSVP status to `Yes` by default for host.

--- a/app/lib/features/events/pages/event_details_page.dart
+++ b/app/lib/features/events/pages/event_details_page.dart
@@ -380,7 +380,7 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
       final rsvpId = await draft.send();
       _log.info('new rsvp id: $rsvpId');
       // refresh cache
-      final client = ref.read(alwaysClientProvider);
+      final client = await ref.read(alwaysClientProvider.future);
       await client.waitForRsvp(rsvpId.toString(), null);
       EasyLoading.dismiss();
     } catch (e, s) {
@@ -449,10 +449,11 @@ class _EventDetailPageConsumerState extends ConsumerState<EventDetailPage> {
         openShareSpaceObjectDialog(
           context: context,
           refDetails: refDetails,
-          internalLink: internalLink, shareContentBuilder: () async {
-          Navigator.pop(context);
-          return await refDetails.generateExternalLink();
-        },
+          internalLink: internalLink,
+          shareContentBuilder: () async {
+            Navigator.pop(context);
+            return await refDetails.generateExternalLink();
+          },
           fileDetailContentBuilder: () async {
             Navigator.pop(context);
             final filename =

--- a/app/lib/features/events/providers/notifiers/event_notifiers.dart
+++ b/app/lib/features/events/providers/notifiers/event_notifiers.dart
@@ -26,7 +26,7 @@ class EventListNotifier
   @override
   Future<List<CalendarEvent>> build(String? arg) async {
     final spaceId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
 
     //GET ALL EVENTS
     if (spaceId == null) {
@@ -57,7 +57,7 @@ class AsyncCalendarEventNotifier
   @override
   Future<CalendarEvent> build(String arg) async {
     final calEvtId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener = client.subscribeStream(calEvtId); // keep it resident in memory
     _listener.forEach((e) async {
       state = await AsyncValue.guard(

--- a/app/lib/features/events/providers/notifiers/participants_notifier.dart
+++ b/app/lib/features/events/providers/notifiers/participants_notifier.dart
@@ -18,7 +18,7 @@ class AsyncParticipantsNotifier
   @override
   Future<List<String>> build(String arg) async {
     final calEvtId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener =
         client.subscribeStream('$calEvtId::rsvp'); // keep it resident in memory
     _listener.forEach((e) async {

--- a/app/lib/features/events/providers/notifiers/rsvp_notifier.dart
+++ b/app/lib/features/events/providers/notifiers/rsvp_notifier.dart
@@ -24,7 +24,7 @@ class AsyncRsvpStatusNotifier
   @override
   Future<RsvpStatusTag?> build(String arg) async {
     final calEvtId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener =
         client.subscribeStream('$calEvtId::rsvp'); // keep it resident in memory
     _listener.forEach((e) async {

--- a/app/lib/features/home/pages/dashboard.dart
+++ b/app/lib/features/home/pages/dashboard.dart
@@ -7,7 +7,6 @@ import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/empty_state_widget.dart';
 import 'package:acter/common/widgets/user_avatar.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
-import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/home/widgets/features_nav_widget.dart';
 import 'package:acter/features/home/widgets/important_activities_section.dart';
 import 'package:acter/features/home/widgets/in_dashboard.dart';
@@ -15,8 +14,6 @@ import 'package:acter/features/home/widgets/my_events.dart';
 import 'package:acter/features/home/widgets/my_spaces_section.dart';
 import 'package:acter/features/home/widgets/my_tasks.dart';
 import 'package:acter/features/main/providers/main_providers.dart';
-import 'package:acter_avatar/acter_avatar.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -29,7 +26,6 @@ class Dashboard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final client = ref.watch(alwaysClientProvider);
     return InDashboard(
       child: SafeArea(
         bottom: false,
@@ -38,7 +34,7 @@ class Dashboard extends ConsumerWidget {
               ? FloatingActionButtonLocation.miniEndDocked
               : FloatingActionButtonLocation.miniEndFloat,
           floatingActionButtonAnimator: FloatingActionButtonAnimator.scaling,
-          appBar: _buildDashboardAppBar(context, client),
+          appBar: _buildDashboardAppBar(context),
           floatingActionButton: manageQuickAddButton(context, ref),
           body: _buildDashboardBodyUI(context, ref),
         ),
@@ -46,7 +42,7 @@ class Dashboard extends ConsumerWidget {
     );
   }
 
-  AppBar _buildDashboardAppBar(BuildContext context, Client client) {
+  AppBar _buildDashboardAppBar(BuildContext context) {
     final lang = L10n.of(context);
     return AppBar(
       leading: !isDesktop
@@ -58,21 +54,9 @@ class Dashboard extends ConsumerWidget {
       centerTitle: true,
       title: Text(isDesktop ? lang.myDashboard : lang.acter),
       actions: <Widget>[
-        Visibility(
-          // FIXME: Only show mobile / when bottom bar shown...
-          visible: !client.isGuest(),
-          replacement: InkWell(
-            onTap: () => context.pushNamed(Routes.authLogin.name),
-            child: ActerAvatar(
-              options: AvatarOptions.DM(
-                AvatarInfo(uniqueId: UniqueKey().toString()),
-              ),
-            ),
-          ),
-          child: InkWell(
-            onTap: () => context.pushNamed(Routes.settings.name),
-            child: const UserAvatarWidget(size: 20),
-          ),
+        InkWell(
+          onTap: () => context.pushNamed(Routes.settings.name),
+          child: const UserAvatarWidget(size: 20),
         ),
       ],
     );

--- a/app/lib/features/home/providers/client_providers.dart
+++ b/app/lib/features/home/providers/client_providers.dart
@@ -8,22 +8,19 @@ class NoClientException implements Exception {
   NoClientException();
 }
 
-final clientProvider = StateNotifierProvider<ClientNotifier, Client?>((ref) {
-  return ClientNotifier(ref);
-});
+final clientProvider =
+    AsyncNotifierProvider<ClientNotifier, Client?>(() => ClientNotifier());
 
-final alwaysClientProvider = StateProvider((ref) {
-  final client = ref.watch(clientProvider);
+final alwaysClientProvider = FutureProvider((ref) async {
+  final client = await ref.watch(clientProvider.future);
   if (client == null) {
     throw NoClientException();
   }
   return client;
 });
 
-final syncStateProvider = StateNotifierProvider<SyncNotifier, SyncState>((ref) {
-  final client = ref.watch(alwaysClientProvider);
-  return SyncNotifier(client, ref);
-});
+final syncStateProvider =
+    NotifierProvider<SyncNotifier, SyncState>(() => SyncNotifier());
 
 final isSyncingStateProvider = StateProvider<bool>((ref) {
   return ref.watch(syncStateProvider).initialSync;

--- a/app/lib/features/home/providers/events.dart
+++ b/app/lib/features/home/providers/events.dart
@@ -3,7 +3,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:riverpod/riverpod.dart';
 
 final myEventsProvider = FutureProvider<List<CalendarEvent>>((ref) async {
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   // FIXME: how to get informed about updates!?!
   final calendarEvents = await client.calendarEvents();
   return calendarEvents.toList();

--- a/app/lib/features/home/providers/notifiers/client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/client_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -7,17 +9,14 @@ import 'package:riverpod/riverpod.dart';
 
 final _log = Logger('a3::home::client_notifier');
 
-class ClientNotifier extends StateNotifier<Client?> {
-  ClientNotifier(Ref ref) : super(null) {
-    _loadUp(ref);
-  }
-
-  Future<void> _loadUp(Ref ref) async {
+class ClientNotifier extends AsyncNotifier<Client?> {
+  @override
+  FutureOr<Client?> build() async {
     final asyncSdk = await ref.read(sdkProvider.future);
     PlatformDispatcher.instance.onError = (exception, stackTrace) {
       _log.severe('platform dispatch error', exception, stackTrace);
       return true; // make this error handled
     };
-    state = asyncSdk.currentClient;
+    return asyncSdk.currentClient;
   }
 }

--- a/app/lib/features/home/providers/notifiers/client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/client_notifier.dart
@@ -19,4 +19,6 @@ class ClientNotifier extends AsyncNotifier<Client?> {
     };
     return asyncSdk.currentClient;
   }
+
+  void setClient(Client? client) => state = AsyncData(client);
 }

--- a/app/lib/features/home/providers/task_providers.dart
+++ b/app/lib/features/home/providers/task_providers.dart
@@ -14,7 +14,7 @@ class MyOpenTasksNotifier extends AsyncNotifier<List<Task>> {
   @override
   Future<List<Task>> build() async {
     // Load initial todo list from the remote repository
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener =
         client.subscribeMyOpenTasksStream(); // keep it resident in memory
     _poller = _listener.listen(

--- a/app/lib/features/invitations/providers/notifiers/invitation_list_notifier.dart
+++ b/app/lib/features/invitations/providers/notifiers/invitation_list_notifier.dart
@@ -13,7 +13,7 @@ class InvitationListNotifier extends Notifier<List<Invitation>> {
 
   @override
   List<Invitation> build() {
-    final client = ref.watch(clientProvider);
+    final client = ref.watch(clientProvider).valueOrNull;
     if (client == null) {
       return [];
     }

--- a/app/lib/features/invitations/widgets/invitation_card.dart
+++ b/app/lib/features/invitations/widgets/invitation_card.dart
@@ -200,7 +200,7 @@ class _InvitationCardState extends ConsumerState<InvitationCard> {
   void _onTapAcceptInvite(BuildContext context) async {
     final lang = L10n.of(context);
     EasyLoading.show(status: lang.joining);
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final roomId = widget.invitation.roomIdStr();
     final isSpace = widget.invitation.room().isSpace();
     try {

--- a/app/lib/features/main/app_shell.dart
+++ b/app/lib/features/main/app_shell.dart
@@ -64,8 +64,10 @@ class AppShellState extends ConsumerState<AppShell> {
       // ignore: use_build_context_synchronously
       () => bottomNavigationTutorials(context: context),
     );
-    initShake();
+    _initShake();
     _initDeepLinking();
+    // initalize main providers
+    _initProviders();
 
     // these want to be sure to execute in order
     await _initNotifications();
@@ -73,7 +75,16 @@ class AppShellState extends ConsumerState<AppShell> {
     await _initCalendarSync();
   }
 
-  Future<void> initShake() async {
+  Future<void> _initProviders() async {
+    // we read a few providers immediately at start up to ensure
+    // the content is being fetched and cached
+    ref.read(spacesProvider);
+    ref.read(chatsProvider);
+    ref.read(newsListProvider(null));
+    ref.read(hasActivitiesProvider);
+  }
+
+  Future<void> _initShake() async {
     // shake is possible in only actual mobile devices
     if (isBugReportingEnabled && await isRealPhone()) {
       detector = ShakeDetector.autoStart(

--- a/app/lib/features/main/app_shell.dart
+++ b/app/lib/features/main/app_shell.dart
@@ -1,10 +1,13 @@
 import 'package:acter/common/providers/app_state_provider.dart';
+import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/common_providers.dart';
+import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart';
 import 'package:acter/common/utils/constants.dart';
 import 'package:acter/common/utils/device.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/config/notifications/init.dart';
+import 'package:acter/features/activities/providers/activities_providers.dart';
 import 'package:acter/features/auth/pages/logged_out_screen.dart';
 import 'package:acter/features/bug_report/actions/open_bug_report.dart';
 import 'package:acter/features/bug_report/providers/bug_report_providers.dart';
@@ -17,6 +20,7 @@ import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
 import 'package:acter/features/main/providers/main_providers.dart';
 import 'package:acter/features/main/widgets/bottom_navigation_widget.dart';
+import 'package:acter/features/news/providers/news_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -84,25 +88,27 @@ class AppShellState extends ConsumerState<AppShell> {
   }
 
   Future<void> _initNotifications() async {
-    final client = ref.read(clientProvider);
+    final client = await ref.read(clientProvider.future);
     if (client != null) {
       _initPushForClient(client);
     }
     ref.listenManual(clientProvider, (previous, next) {
-      if (next != null) {
-        _initPushForClient(next);
+      final newClient = next.valueOrNull;
+      if (newClient != null) {
+        _initPushForClient(newClient);
       }
     });
   }
 
   Future<void> _initCalendarSync() async {
-    final client = ref.read(clientProvider);
+    final client = await ref.read(clientProvider.future);
     if (client != null) {
       // calendar sync only works if we have a client
       await initCalendarSync();
     }
     ref.listenManual(clientProvider, (previous, next) {
-      if (next != null) {
+      final newClient = next.valueOrNull;
+      if (newClient != null) {
         initCalendarSync();
       }
     });
@@ -130,7 +136,7 @@ class AppShellState extends ConsumerState<AppShell> {
   @override
   Widget build(BuildContext context) {
     // get platform of context.
-    if (ref.watch(clientProvider) == null) {
+    if (ref.watch(clientProvider).valueOrNull == null) {
       // at the very startup we might not yet have a client loaded
       // show a loading spinner meanwhile.
       return const Scaffold(

--- a/app/lib/features/member/providers/invite_providers.dart
+++ b/app/lib/features/member/providers/invite_providers.dart
@@ -28,14 +28,14 @@ final searchResultProvider = FutureProvider<List<UserProfile>>((ref) async {
     // ignore we got cancelled
     return [];
   }
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   return (await client.searchUsers(newSearchValue)).toList();
 });
 
 final suggestedUsersProvider =
     FutureProvider.family<List<UserProfile>, String?>(
   (ref, roomId) async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     return (await client.suggestedUsers(roomId)).toList();
   },
 );

--- a/app/lib/features/news/actions/submit_news.dart
+++ b/app/lib/features/news/actions/submit_news.dart
@@ -24,7 +24,7 @@ Future<NewsSlideDraft> _makeTextSlide(
   L10n lang,
 ) async {
   final sdk = await ref.read(sdkProvider.future);
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
 
   final text = slidePost.text?.trim();
   if (text == null || text.isEmpty == true) {
@@ -55,7 +55,7 @@ Future<NewsSlideDraft> _makeImageSlide(
   L10n lang,
 ) async {
   final sdk = await ref.read(sdkProvider.future);
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
 
   final file = slidePost.mediaFile;
   if (file == null) {
@@ -92,7 +92,7 @@ Future<NewsSlideDraft> _makeVideoSlide(
   L10n lang,
 ) async {
   final sdk = await ref.read(sdkProvider.future);
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
   final file = slidePost.mediaFile;
   if (file == null) {
     throw 'Video File missing';

--- a/app/lib/features/news/providers/notifiers/news_list_notifier.dart
+++ b/app/lib/features/news/providers/notifiers/news_list_notifier.dart
@@ -16,7 +16,7 @@ class AsyncNewsListNotifier
   @override
   Future<List<NewsEntry>> build(String? arg) async {
     final spaceId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
 
     //GET ALL NEWS
     if (spaceId == null) {

--- a/app/lib/features/notifications/pages/notifications_page.dart
+++ b/app/lib/features/notifications/pages/notifications_page.dart
@@ -328,7 +328,7 @@ class NotificationsSettingsPage extends ConsumerWidget {
     if (!context.mounted) return;
     if (emailToAdd == null) return;
     EasyLoading.show(status: lang.adding(emailToAdd));
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     try {
       await client.addEmailPusher(
         appIdPrefix,

--- a/app/lib/features/notifications/providers/notifiers/notification_settings_notifier.dart
+++ b/app/lib/features/notifications/providers/notifiers/notification_settings_notifier.dart
@@ -15,7 +15,7 @@ class AsyncNotificationSettingsNotifier
 
   @override
   Future<NotificationSettings> build() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     final settings = await client.notificationSettings();
     _listener = settings.changesStream();
     _poller = _listener.listen(

--- a/app/lib/features/notifications/widgets/labs_notifications_settings_tile.dart
+++ b/app/lib/features/notifications/widgets/labs_notifications_settings_tile.dart
@@ -44,7 +44,7 @@ class _LabNotificationSettingsTile extends ConsumerWidget {
     final lang = L10n.of(context);
     await updateFeatureState(ref, LabsFeature.mobilePushNotifications, newVal);
     if (!newVal) return;
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     EasyLoading.show(status: lang.changingSettings);
     try {
       var granted = await setupPushNotifications(client, forced: true);

--- a/app/lib/features/onboarding/pages/link_email_page.dart
+++ b/app/lib/features/onboarding/pages/link_email_page.dart
@@ -101,7 +101,7 @@ class LinkEmailPage extends ConsumerWidget {
   Future<void> linkEmail(BuildContext context, WidgetRef ref) async {
     if (!formKey.currentState!.validate()) return;
     final lang = L10n.of(context);
-    final account = ref.read(accountProvider);
+    final account = await ref.read(accountProvider.future);
     EasyLoading.show(status: lang.linkingEmailAddress);
     try {
       final emailAddr = emailController.text.trim();

--- a/app/lib/features/onboarding/pages/link_email_page.dart
+++ b/app/lib/features/onboarding/pages/link_email_page.dart
@@ -117,7 +117,9 @@ class LinkEmailPage extends ConsumerWidget {
       );
     } finally {
       EasyLoading.dismiss();
-      context.goNamed(Routes.uploadAvatar.name);
+      if (context.mounted) {
+        context.goNamed(Routes.uploadAvatar.name);
+      }
     }
   }
 

--- a/app/lib/features/onboarding/pages/upload_avatar_page.dart
+++ b/app/lib/features/onboarding/pages/upload_avatar_page.dart
@@ -141,7 +141,7 @@ class UploadAvatarPage extends ConsumerWidget {
   Future<void> uploadAvatar(BuildContext context, WidgetRef ref) async {
     final lang = L10n.of(context);
     try {
-      final account = ref.watch(accountProvider);
+      final account = await ref.watch(accountProvider.future);
       final filePath = selectedUserAvatar.value?.path;
       if (filePath == null) {
         if (context.mounted) EasyLoading.showToast(lang.avatarEmpty);

--- a/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
+++ b/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
@@ -21,7 +21,7 @@ class AsyncPinNotifier
   @override
   Future<ActerPin> build(String arg) async {
     final pinId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     _listener = client.subscribeStream(pinId); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {
@@ -50,7 +50,7 @@ class AsyncPinListNotifier
   @override
   Future<List<ActerPin>> build(String? arg) async {
     final spaceId = arg;
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
 
     //GET ALL PINS
     if (spaceId == null) {

--- a/app/lib/features/profile/pages/my_profile_page.dart
+++ b/app/lib/features/profile/pages/my_profile_page.dart
@@ -102,7 +102,7 @@ class MyProfilePage extends StatelessWidget {
     if (newText == null) return;
 
     EasyLoading.show(status: lang.updatingDisplayName);
-    final account = ref.read(accountProvider);
+    final account = await ref.read(accountProvider.future);
     await account.setDisplayName(newText);
     ref.invalidate(accountProvider);
 
@@ -123,7 +123,7 @@ class MyProfilePage extends StatelessWidget {
       }
       if (!context.mounted) return;
       EasyLoading.show(status: L10n.of(context).updatingProfileImage);
-      final account = ref.read(accountProvider);
+      final account = await ref.read(accountProvider.future);
       await account.uploadAvatar(filePath);
       ref.invalidate(accountProvider);
       // close loading

--- a/app/lib/features/public_room_search/providers/notifiers/public_spaces_notifier.dart
+++ b/app/lib/features/public_room_search/providers/notifiers/public_spaces_notifier.dart
@@ -56,7 +56,7 @@ class PublicSearchNotifier extends StateNotifier<PublicSearchResultState>
     }
 
     final pageReq = page.next ?? '';
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final searchValue = state.filter.searchTerm;
     final server = state.filter.server;
     final roomFilter = state.filter.filterBy.name;

--- a/app/lib/features/room/actions/join_room.dart
+++ b/app/lib/features/room/actions/join_room.dart
@@ -38,7 +38,7 @@ Future<String?> joinRoom(
 ) async {
   final lang = L10n.of(context);
   EasyLoading.show(status: displayMsg);
-  final client = ref.read(alwaysClientProvider);
+  final client = await ref.read(alwaysClientProvider.future);
   try {
     final newRoom = await client.joinRoom(roomIdOrAlias, server);
     final roomId = newRoom.roomIdStr();

--- a/app/lib/features/settings/pages/blocked_users.dart
+++ b/app/lib/features/settings/pages/blocked_users.dart
@@ -147,7 +147,7 @@ class BlockedUsersPage extends ConsumerWidget {
     }
     EasyLoading.show(status: lang.blockingUserProgress);
     try {
-      final account = ref.read(accountProvider);
+      final account = await ref.read(accountProvider.future);
       await account.ignoreUser(userToAdd);
       if (!context.mounted) {
         EasyLoading.dismiss();
@@ -175,7 +175,7 @@ class BlockedUsersPage extends ConsumerWidget {
     final lang = L10n.of(context);
     EasyLoading.show(status: lang.unblockingUser);
     try {
-      final account = ref.read(accountProvider);
+      final account = await ref.read(accountProvider.future);
       await account.unignoreUser(userId);
       if (!context.mounted) {
         EasyLoading.dismiss();

--- a/app/lib/features/settings/pages/change_password.dart
+++ b/app/lib/features/settings/pages/change_password.dart
@@ -183,7 +183,7 @@ class _ChangePasswordPageState extends ConsumerState<ChangePasswordPage> {
     final lang = L10n.of(context);
     EasyLoading.show(status: lang.changingYourPassword);
     try {
-      final client = ref.read(alwaysClientProvider);
+      final client = await ref.read(alwaysClientProvider.future);
       final account = client.account();
       await account.changePassword(
         oldPassword.text.trim(),

--- a/app/lib/features/settings/pages/email_addresses.dart
+++ b/app/lib/features/settings/pages/email_addresses.dart
@@ -214,7 +214,7 @@ class EmailAddressesPage extends ConsumerWidget {
 
   Future<void> addEmailAddress(BuildContext context, WidgetRef ref) async {
     final lang = L10n.of(context);
-    final account = ref.read(accountProvider);
+    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<String>(
       context: context,
       builder: (BuildContext context) => const AddEmailAddr(),

--- a/app/lib/features/settings/pages/email_addresses.dart
+++ b/app/lib/features/settings/pages/email_addresses.dart
@@ -214,13 +214,13 @@ class EmailAddressesPage extends ConsumerWidget {
 
   Future<void> addEmailAddress(BuildContext context, WidgetRef ref) async {
     final lang = L10n.of(context);
-    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<String>(
       context: context,
       builder: (BuildContext context) => const AddEmailAddr(),
     );
     if (newValue != null && context.mounted) {
       EasyLoading.show(status: lang.addingEmailAddress);
+      final account = await ref.read(accountProvider.future);
       try {
         await account.request3pidManagementTokenViaEmail(newValue);
         ref.invalidate(emailAddressesProvider);

--- a/app/lib/features/settings/pages/info_page.dart
+++ b/app/lib/features/settings/pages/info_page.dart
@@ -46,8 +46,9 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
     final colorScheme = Theme.of(context).colorScheme;
     final appNameDigest = sha1.convert(utf8.encode(Env.rageshakeAppName));
     final urlDigest = sha1.convert(utf8.encode(Env.rageshakeUrl));
-    final deviceId = ref.watch(deviceIdProvider);
-    final devIdDigest = sha1.convert(utf8.encode(deviceId));
+    final deviceId = ref.watch(deviceIdProvider).valueOrNull;
+    final devIdDigest =
+        deviceId != null ? sha1.convert(utf8.encode(deviceId)) : 'none';
     final allowReportSending =
         ref.watch(allowSentryReportingProvider).valueOrNull ?? isNightly;
     return WithSidebar(
@@ -151,7 +152,7 @@ class _SettingsInfoPageState extends ConsumerState<SettingsInfoPage> {
                           lang.deviceId,
                           style: textTheme.bodyMedium,
                         ),
-                        value: Text(deviceId),
+                        value: Text(deviceId ?? 'none'),
                       )
                     : SettingsTile(
                         title: Text(

--- a/app/lib/features/settings/pages/settings_page.dart
+++ b/app/lib/features/settings/pages/settings_page.dart
@@ -47,10 +47,9 @@ class SettingsPage extends ConsumerWidget {
   }
 
   Widget _userProfileUI(BuildContext context, WidgetRef ref) {
-    final account = ref.watch(accountProvider);
     final accountInfo = ref.watch(accountAvatarInfoProvider);
     final shouldGoReplacement = context.isLargeScreen;
-    final userId = account.userId().toString();
+    final userId = ref.watch(myUserIdStrProvider);
     return InkWell(
       onTap: () => shouldGoReplacement
           ? context.pushReplacementNamed(Routes.myProfile.name)

--- a/app/lib/features/settings/providers/notifications_mode_provider.dart
+++ b/app/lib/features/settings/providers/notifications_mode_provider.dart
@@ -12,7 +12,7 @@ class AsyncNotificationSettingNotifier
 
   @override
   Future<NotificationSettings> build() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     final settings = await client.notificationSettings();
     _listener = settings.changesStream(); // stay up to date
     _listener.forEach((e) async {

--- a/app/lib/features/settings/providers/notifiers/app_settings_notifier.dart
+++ b/app/lib/features/settings/providers/notifiers/app_settings_notifier.dart
@@ -19,7 +19,7 @@ class UserAppSettingsNotifier
 
   @override
   Future<ActerUserAppSettings> build() async {
-    final account = ref.watch(accountProvider);
+    final account = await ref.watch(accountProvider.future);
     _listener = account.subscribeAppSettingsStream();
     _poller = _listener.listen(
       (data) async {

--- a/app/lib/features/settings/providers/notifiers/devices_notifier.dart
+++ b/app/lib/features/settings/providers/notifiers/devices_notifier.dart
@@ -18,7 +18,7 @@ class AsyncDevicesNotifier extends AsyncNotifier<List<DeviceRecord>> {
 
   @override
   Future<List<DeviceRecord>> build() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     final manager = client.sessionManager();
 
     _listener = client.deviceEventRx();

--- a/app/lib/features/settings/providers/settings_providers.dart
+++ b/app/lib/features/settings/providers/settings_providers.dart
@@ -12,12 +12,12 @@ final localeProvider =
     StateNotifierProvider<LocaleNotifier, String>((ref) => LocaleNotifier());
 
 final ignoredUsersProvider = FutureProvider<List<UserId>>((ref) async {
-  final account = ref.watch(accountProvider);
+  final account = await ref.watch(accountProvider.future);
   return (await account.ignoredUsers()).toList();
 });
 
 final pushersProvider = FutureProvider<List<Pusher>>((ref) async {
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   return (await client.pushers()).toList();
 });
 

--- a/app/lib/features/settings/widgets/email_address_card.dart
+++ b/app/lib/features/settings/widgets/email_address_card.dart
@@ -134,7 +134,7 @@ class EmailAddressCard extends ConsumerWidget {
           ),
           ActerPrimaryActionButton(
             onPressed: () async {
-              final account = ref.read(accountProvider);
+              final account = await ref.read(accountProvider.future);
               await account.removeEmailAddress(emailAddress);
               ref.invalidate(emailAddressesProvider);
 
@@ -153,7 +153,7 @@ class EmailAddressCard extends ConsumerWidget {
     WidgetRef ref,
   ) async {
     final lang = L10n.of(context);
-    final account = ref.read(accountProvider);
+    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<String>(
       context: context,
       builder: (BuildContext context) => const PasswordConfirm(),
@@ -187,7 +187,7 @@ class EmailAddressCard extends ConsumerWidget {
     WidgetRef ref,
   ) async {
     final lang = L10n.of(context);
-    final account = ref.read(accountProvider);
+    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<EmailConfirm>(
       context: context,
       builder: (BuildContext context) => const TokenConfirm(),

--- a/app/lib/features/settings/widgets/email_address_card.dart
+++ b/app/lib/features/settings/widgets/email_address_card.dart
@@ -153,7 +153,6 @@ class EmailAddressCard extends ConsumerWidget {
     WidgetRef ref,
   ) async {
     final lang = L10n.of(context);
-    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<String>(
       context: context,
       builder: (BuildContext context) => const PasswordConfirm(),
@@ -161,6 +160,7 @@ class EmailAddressCard extends ConsumerWidget {
     if (!context.mounted) return;
     if (newValue == null) return;
     EasyLoading.show(status: lang.tryingToConfirmToken);
+    final account = await ref.read(accountProvider.future);
     try {
       await account.tryConfirmEmailStatus(emailAddress, newValue);
       ref.invalidate(emailAddressesProvider);
@@ -187,7 +187,6 @@ class EmailAddressCard extends ConsumerWidget {
     WidgetRef ref,
   ) async {
     final lang = L10n.of(context);
-    final account = await ref.read(accountProvider.future);
     final newValue = await showDialog<EmailConfirm>(
       context: context,
       builder: (BuildContext context) => const TokenConfirm(),
@@ -195,6 +194,7 @@ class EmailAddressCard extends ConsumerWidget {
     if (!context.mounted) return;
     if (newValue == null) return;
     EasyLoading.show(status: lang.tryingToConfirmToken);
+    final account = await ref.read(accountProvider.future);
     try {
       final result = await account.submitTokenFromEmail(
         emailAddress,

--- a/app/lib/features/settings/widgets/session_card.dart
+++ b/app/lib/features/settings/widgets/session_card.dart
@@ -142,7 +142,7 @@ class SessionCard extends ConsumerWidget {
       },
     );
     if (result != true) return;
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final manager = client.sessionManager();
     await manager.deleteDevice(
       deviceRecord.deviceId().toString(),
@@ -154,7 +154,7 @@ class SessionCard extends ConsumerWidget {
 
   Future<void> onVerify(BuildContext context, WidgetRef ref) async {
     final devId = deviceRecord.deviceId().toString();
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     // final manager = client.sessionManager();
 
     final event = await client.requestVerification(devId);

--- a/app/lib/features/spaces/actions/create_space.dart
+++ b/app/lib/features/spaces/actions/create_space.dart
@@ -49,7 +49,7 @@ Future<String?> createSpace(
     if (roomVisibility != null) {
       config.setVisibility(roomVisibility.name);
     }
-    final client = ref.read(alwaysClientProvider);
+    final client = await ref.read(alwaysClientProvider.future);
     final result = await client.createActerSpace(config.build());
     final roomId = result.toString();
     if (parentRoomId != null) {

--- a/app/lib/features/super_invites/dialogs/redeem_dialog.dart
+++ b/app/lib/features/super_invites/dialogs/redeem_dialog.dart
@@ -106,7 +106,7 @@ class _ShowRedeemTokenDialog extends ConsumerWidget {
 
   void redeem(BuildContext context, WidgetRef ref) async {
     final lang = L10n.of(context);
-    final superInvites = ref.read(superInvitesProvider);
+    final superInvites = await ref.read(superInvitesProvider.future);
 
     EasyLoading.show(status: lang.redeeming(token));
     try {

--- a/app/lib/features/super_invites/pages/create.dart
+++ b/app/lib/features/super_invites/pages/create.dart
@@ -54,9 +54,8 @@ class _CreateSuperInviteTokenPageConsumerState
   List<String> _roomIds = [];
 
   @override
-  void initState() {
+  void initState() async {
     super.initState();
-    final provider = ref.read(superInvitesProvider);
     final token = widget.token;
     if (token != null) {
       // given an update builder we are in an edit mode
@@ -67,7 +66,8 @@ class _CreateSuperInviteTokenPageConsumerState
       _initialDmCheck = token.createDm();
       tokenUpdater = token.updateBuilder();
     } else {
-      tokenUpdater = provider.newTokenUpdater();
+      tokenUpdater =
+          (await ref.read(superInvitesProvider.future)).newTokenUpdater();
     }
   }
 
@@ -280,7 +280,7 @@ class _CreateSuperInviteTokenPageConsumerState
         tokenUpdater.token(tokenTxt);
       }
       // all other changes happen on the object itself;
-      final superInvites = ref.read(superInvitesProvider);
+      final superInvites = await ref.read(superInvitesProvider.future);
       await superInvites.createOrUpdateToken(tokenUpdater);
       ref.invalidate(superInvitesTokensProvider);
       EasyLoading.dismiss();
@@ -340,7 +340,7 @@ class _CreateSuperInviteTokenPageConsumerState
     try {
       final tokenTxt = _tokenController.text;
       // all other changes happen on the object itself;
-      final provider = ref.read(superInvitesProvider);
+      final provider = await ref.read(superInvitesProvider.future);
       await provider.delete(tokenTxt);
       ref.invalidate(superInvitesTokensProvider);
       EasyLoading.dismiss();

--- a/app/lib/features/super_invites/providers/super_invites_providers.dart
+++ b/app/lib/features/super_invites/providers/super_invites_providers.dart
@@ -11,7 +11,7 @@ final hasSuperTokensAccess = FutureProvider<bool>((ref) async {
 
 final superInvitesTokensProvider =
     FutureProvider<List<SuperInviteToken>>((ref) async {
-  final superInvites = ref.watch(superInvitesProvider);
+  final superInvites = await ref.watch(superInvitesProvider.future);
   return (await superInvites.tokens()).toList();
 });
 
@@ -24,10 +24,11 @@ final superInviteTokenProvider = FutureProvider.autoDispose
   throw 'SuperInvite $tokenCode not found';
 });
 
-final superInvitesProvider = Provider<SuperInvites>((ref) {
-  final client = ref.watch(alwaysClientProvider);
-  return client.superInvites();
-});
+final superInvitesProvider = FutureProvider<SuperInvites>(
+  (ref) => ref.watch(
+    alwaysClientProvider.selectAsync((client) => client.superInvites()),
+  ),
+);
 
 /// List of SuperInviteTokens that have the given roomId in their to-invite list
 final superInvitesForRoom = FutureProvider.autoDispose
@@ -44,7 +45,7 @@ Future<String> newSuperInviteForRooms(
   List<String> rooms, {
   String? inviteCode,
 }) async {
-  final superInvites = ref.read(superInvitesProvider);
+  final superInvites = await ref.read(superInvitesProvider.future);
   final builder = superInvites.newTokenUpdater();
   if (inviteCode != null) {
     builder.token(inviteCode);
@@ -59,6 +60,6 @@ Future<String> newSuperInviteForRooms(
 
 final superInviteInfoProvider = FutureProvider.autoDispose
     .family<SuperInviteInfo, String>((ref, token) async {
-  final superInvites = ref.watch(superInvitesProvider);
+  final superInvites = await ref.watch(superInvitesProvider.future);
   return await superInvites.info(token);
 });

--- a/app/lib/features/tasks/providers/notifiers.dart
+++ b/app/lib/features/tasks/providers/notifiers.dart
@@ -70,7 +70,7 @@ class TaskListItemNotifier extends FamilyAsyncNotifier<TaskList, String> {
   @override
   Future<TaskList> build(String arg) async {
     // Load initial todo list from the remote repository
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     final taskList = await _refresh(client, arg);
     _listener = taskList.subscribeStream(); // keep it resident in memory
     _poller = _listener.listen(
@@ -125,7 +125,7 @@ class AsyncAllTaskListsNotifier extends AsyncNotifier<List<TaskList>> {
 
   @override
   Future<List<TaskList>> build() async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
 
     //GET ALL TASKS LIST
     _listener = client.subscribeStream('tasks');

--- a/app/lib/features/users/providers/user_profile_provider.dart
+++ b/app/lib/features/users/providers/user_profile_provider.dart
@@ -10,7 +10,7 @@ import 'package:riverpod/riverpod.dart';
 
 final globalUserProfileProvider =
     FutureProvider.family<UserProfile?, String>((ref, userId) async {
-  final client = ref.watch(alwaysClientProvider);
+  final client = await ref.watch(alwaysClientProvider.future);
   return (await client.searchUsers(userId)).toList().firstOrNull;
 });
 

--- a/app/lib/features/users/widgets/message_user_button.dart
+++ b/app/lib/features/users/widgets/message_user_button.dart
@@ -22,8 +22,8 @@ class MessageUserButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = L10n.of(context);
-    final client = ref.watch(alwaysClientProvider);
-    final dmId = client.dmWithUser(userId).text();
+    final dmId =
+        ref.watch(alwaysClientProvider).valueOrNull?.dmWithUser(userId).text();
     if (dmId != null) {
       return Center(
         child: OutlinedButton.icon(

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -73,7 +73,7 @@ Future<String?> forwardRedirect(
       // ignore: use_build_context_synchronously
       final ref = ProviderScope.containerOf(context);
       // ensure we have selected the right client
-      ref.invalidate(clientProvider);
+      ref.read(clientProvider.notifier).setClient(client);
     } catch (e, s) {
       _log.severe('Client not found', e, s);
       return null;

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -70,14 +70,27 @@ Future<String?> forwardRedirect(
       final deviceId = state.uri.queryParameters['deviceId']
           .expect('query params should contain device id');
       client = await acterSdk.getClientWithDeviceId(deviceId, true);
-      // ignore: use_build_context_synchronously
-      final ref = ProviderScope.containerOf(context);
-      // ensure we have selected the right client
-      ref.read(clientProvider.notifier).setClient(client);
     } catch (e, s) {
-      _log.severe('Client not found', e, s);
-      return null;
+      _log.severe('Specified Client not found', e, s);
+      final currentClient = acterSdk.currentClient;
+      if (currentClient == null) {
+        // we have no client at all, forward through login
+        final next = Uri.encodeComponent(state.uri.toString());
+
+        // ignore: deprecated_member_use
+        return state.namedLocation(
+          Routes.intro.name,
+          queryParameters: {'next': next},
+        );
+      }
+      client = currentClient; // continuing with the client we did find
     }
+
+    // ignore: use_build_context_synchronously
+    final ref = ProviderScope.containerOf(context);
+    // ensure we have selected the right client
+    ref.read(clientProvider.notifier).setClient(client);
+
     final roomId = state.uri.queryParameters['roomId'];
     if (roomId == null) {
       _log.severe(
@@ -91,7 +104,7 @@ Future<String?> forwardRedirect(
       // we haven’t joined yet or have been kicked
       // either way, we are to be shown the thing on the activities page
       return state.namedLocation(
-        Routes.activities.name,
+        Routes.myOpenInvitations.name,
         queryParameters: state.uri.queryParameters,
       );
     }

--- a/app/test/features/chat/chat_listing_search_test.dart
+++ b/app/test/features/chat/chat_listing_search_test.dart
@@ -26,9 +26,9 @@ const Map<String, AvatarInfo> _roomsData = {
 void main() {
   group('Chat Listing Search', () {
     final mockedProviders = [
-      // Same as before
-      isGuestProvider.overrideWithValue(false),
-      deviceIdProvider.overrideWithValue('asdf'),
+      deviceIdProvider.overrideWith((a) async {
+        return 'asdf';
+      }),
       hasFirstSyncedProvider.overrideWithValue(true),
       ...mockChatRoomProviders(_roomsData),
     ];

--- a/app/test/features/home/my_spaces_section_test.dart
+++ b/app/test/features/home/my_spaces_section_test.dart
@@ -11,7 +11,7 @@ void main() {
     testWidgets('Empty renders fine', (tester) async {
       await tester.pumpProviderWidget(
         overrides: [
-          spacesProvider.overrideWith((a) => MockSpaceListNotifiers([])),
+          spacesProvider.overrideWith(() => MockSpaceListNotifiers([])),
           bookmarkedSpacesProvider.overrideWith((a) => []),
         ],
         child: const MySpacesSection(),

--- a/app/test/features/link_room/link_room_page_test.dart
+++ b/app/test/features/link_room/link_room_page_test.dart
@@ -96,7 +96,7 @@ void main() {
               .overrideWith(() => MockRoomAvatarInfoNotifier()),
           roomMembershipProvider.overrideWith((a, b) => null),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
               mockSpaceA,
               mockSpaceB,

--- a/app/test/features/link_room/link_room_trailing_test.dart
+++ b/app/test/features/link_room/link_room_trailing_test.dart
@@ -69,7 +69,7 @@ void main() {
               .overrideWith(() => MockRoomAvatarInfoNotifier()),
           roomMembershipProvider.overrideWith((a, b) => null),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),
@@ -138,7 +138,7 @@ void main() {
               .overrideWith(() => MockRoomAvatarInfoNotifier()),
           roomMembershipProvider.overrideWith((a, b) => null),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),
@@ -207,7 +207,7 @@ void main() {
               .overrideWith(() => MockRoomAvatarInfoNotifier()),
           roomMembershipProvider.overrideWith((a, b) => null),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),
@@ -284,7 +284,7 @@ void main() {
             (a, b) => b == 'child-space' ? childMembership : null,
           ),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),
@@ -358,7 +358,7 @@ void main() {
             (a, b) => b == 'child-space' ? childMembership : null,
           ),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),
@@ -434,7 +434,7 @@ void main() {
             (a, b) => b == 'child-space' ? childMembership : null,
           ),
           spacesProvider.overrideWith(
-            (a) => MockSpaceListNotifiers([
+            () => MockSpaceListNotifiers([
               parentSpace,
             ]),
           ),

--- a/app/test/features/spaces/search_provider_test.dart
+++ b/app/test/features/spaces/search_provider_test.dart
@@ -27,7 +27,7 @@ void main() {
       };
       final container = ProviderContainer(
         overrides: [
-          spacesProvider.overrideWith((a) => MockSpaceListNotifiers(spaces)),
+          spacesProvider.overrideWith(() => MockSpaceListNotifiers(spaces)),
           roomAvatarInfoProvider.overrideWith(
             () => MockRoomAvatarInfoNotifier(items: spaceInfos),
           ),
@@ -71,7 +71,7 @@ void main() {
       };
       final container = ProviderContainer(
         overrides: [
-          spacesProvider.overrideWith((a) => MockSpaceListNotifiers(spaces)),
+          spacesProvider.overrideWith(() => MockSpaceListNotifiers(spaces)),
           roomAvatarInfoProvider.overrideWith(
             () => MockRoomAvatarInfoNotifier(items: spaceInfos),
           ),

--- a/app/test/helpers/mock_a3sdk.dart
+++ b/app/test/helpers/mock_a3sdk.dart
@@ -102,7 +102,7 @@ class MockComposeDraft extends Mock implements ComposeDraft {
 class MockAsyncConvoNotifier extends AsyncConvoNotifier {
   @override
   FutureOr<Convo> build(String roomId) async {
-    final client = ref.watch(alwaysClientProvider);
+    final client = await ref.watch(alwaysClientProvider.future);
     return await client.convoWithRetry(roomId, 0);
   }
 }

--- a/app/test/helpers/mock_chat_providers.dart
+++ b/app/test/helpers/mock_chat_providers.dart
@@ -176,7 +176,7 @@ class MockPersistentPrefNotifier extends StateNotifier<FilterSelection>
 
   /// Updates the value asynchronously.
   @override
-  Future<void> update(FilterSelection value) async {
+  Future<void> set(FilterSelection value) async {
     super.state = value;
   }
 }
@@ -184,7 +184,7 @@ class MockPersistentPrefNotifier extends StateNotifier<FilterSelection>
 List<Override> mockChatRoomProviders(MockedRoomData roomsData) {
   return [
     persistentRoomListFilterSelector
-        .overrideWith((_) => MockPersistentPrefNotifier()),
+        .overrideWith(() => MockPersistentPrefNotifier()),
     chatIdsProvider.overrideWithValue(roomsData.keys.toList()),
     chatTypingEventProvider.overrideWith((ref, roomId) => const Stream.empty()),
     roomIsMutedProvider.overrideWith((ref, roomId) => false),

--- a/app/test/helpers/mock_space_providers.dart
+++ b/app/test/helpers/mock_space_providers.dart
@@ -80,8 +80,13 @@ class MockSpaceHierarchyRoomInfo extends Fake
   bool suggested() => isSuggested;
 }
 
-class MockSpaceListNotifiers extends StateNotifier<List<Space>>
+class MockSpaceListNotifiers extends Notifier<List<Space>>
     with Mock
     implements SpaceListNotifier {
-  MockSpaceListNotifiers(super.spaces);
+  MockSpaceListNotifiers(this.spaces);
+
+  final List<Space> spaces;
+
+  @override
+  List<Space> build() => spaces;
 }


### PR DESCRIPTION
### The user problem:

we have seen several reports of the app "freezing" or indicating to the user that the client was logged out, when it fact, it was not.

### The diagnosis:
These were most often seen on Apple devices. Looking through the logs we find the curious case of
```
[2025-01-19][18:53:02.077422][acter::api::auth][INFO] Successfully logged in user @XXXX:acter.global, device Some("YYYYYYY") with token.
[2025-01-19][18:53:02.312033][a3::calendar_sync][INFO] Previous key found ASSASS-2212-898-B3A1-DF113B2A71A6 null null null
[2025-01-19][18:53:02.312498][a3::calendar_sync][INFO] Existing calendar found 6D0008DD-2212-4176-B3A1-DF113B2A71A6 null null null
[2025-01-19][18:53:02.312808][a3::calendar_sync][INFO] ignoring state change without value null null null
[2025-01-19][18:53:02.580610][a3::home::client_notifier][ERROR] platform dispatch error Instance of 'NoClientException' null #1      pid: 13446, tid: 6109229056, name io.flutter.1.ui (unparsed:0:0)
```
Yes, that's right, we see a `NoClientException` despite just four lines above it states that the user successfully logged in. How can that be?

Well, we have been wrapping the async `acterSdk.instance`-call (which trigger that first line of logging) inside a sync provider that will raise said exception if no client is found. This can happen if the providers actual value is looked up _quicker_ than the async code actually setting the internal value. Classic race condition because we are not properly `await`ing the code that issues that first log entry.

As you might now, several parts of the application _assume_ there to be a client, and if they are sent to a screen that causes a `NoClientException` to occur, they behave differently: sometimes a proper error is shown (if that is wrapped in another provider), sometimes you are redirected to the login screen (if you happen to come across the auth guard while the data is not yet available) and often times, when the provider is used directly, we have an exception right in the render thread, which leads to flutter just rendering a box of nothing - which is easily understood as a "app freeze" (despite it not actually, technically, being a freeze).

### The fix 

The fix is simple but substantial: we need to make the `clientProvider` and it's parent the `alwaysClientProvider` async and await that initialization phase. Simple enough. _Unfortunately_ a lot of other providers directly or indirectly link to that provider and thus also need updating. And thus a cascade of refactoring was necessary.

#### Specific

This happens in a few specific parts that I commented in the code. But here is the gist:
 1. make the Client provider async and have it await for the initialization before handing over a client
 2. Make all those `StateNotifier`s that rely on it regular `Notifier`s or `AsyncNotifiers` that `listen` to the client being updated internally rather than assuming a state notifier that is already available (as this is through `ref.listen` make sure they are set to `fireImmediately: true` or you won't see the first draw)
 3. Follow the cascade and replace all other instances of Providers accordingly, simplify cases were possible
 4. Some minor drive-by updates on top:
   - removed support for `isGuest` as we don't actually use that anywhere anyhow
   - have the main app read these providers to preload that data: dca2436c75ea1d454b344ee5ecd5573a61e9f47a
   - some minor refactoring in the notification forward handler related to the same problem: ba180d0316edc1fe958a299bf3c10940bf18a057


Fixes https://github.com/acterglobal/a3-meta/issues/714, https://github.com/acterglobal/a3-meta/issues/715 https://github.com/acterglobal/a3-meta/issues/411 https://github.com/acterglobal/a3/issues/1977
