### PR TITLE
Acter Icon Widget : Fixes Unit test failure

### DIFF
--- a/app/test/common/widgets/acter_icon_widget_test.dart
+++ b/app/test/common/widgets/acter_icon_widget_test.dart
@@ -67,7 +67,7 @@ void main() {
     );
     expect(
       (tester.widget(find.byType(Icon)) as Icon).size,
-      100,
+      70,
     ); // Default size
     expect(
       (tester.widget(find.byType(Icon)) as Icon).color,


### PR DESCRIPTION
https://github.com/acterglobal/a3/pull/2511


Due to change in `ActerIconWidget ` default size in above PR widget test gets failed which is corrected in this PR.