### PR TITLE
news is still a valid name to serialize the index from

### DIFF
--- a/native/core/src/referencing.rs
+++ b/native/core/src/referencing.rs
@@ -10,6 +10,7 @@ use strum::{Display, EnumString};
 #[strum(serialize_all = "snake_case")]
 #[repr(u8)]
 pub enum SectionIndex {
+    #[strum(serialize = "news", serialize = "boosts")]
     Boosts = 0,
     Calendar,
     Pins,


### PR DESCRIPTION
#2515 introduced a minor bug where the wrong word was expected for access the list of boosts (previously known as `news`). This fix ensures we accept either via the API.