### PR TITLE
Events sorting improvements.

### DIFF
--- a/.changes/2531-events-sorting-improvement.md
+++ b/.changes/2531-events-sorting-improvement.md
@@ -1,1 +1,1 @@
-- [Improvement] : Better events filter representation added for Happening Now, Upcoming and Past events.
+- [Improvement] : Better management of event list sorting mechanism and also improve visualisation

--- a/.changes/2531-events-sorting-improvement.md
+++ b/.changes/2531-events-sorting-improvement.md
@@ -1,0 +1,1 @@
+- [Improvement] : Better events filter representation added for Happening Now, Upcoming and Past events.

--- a/.changes/2531-events-sorting-improvement.md
+++ b/.changes/2531-events-sorting-improvement.md
@@ -1,1 +1,2 @@
-- [Improvement] : Better management of event list sorting mechanism and also improve visualisation
+- [Improvement] : Reorganized event list to show "Happening Now" first, followed by "Upcoming" and "Past" events - replacing the previous bookmark-based sorting.
+- [Improvement] : Events list now also categorizes events into distinct sections for better visibility.

--- a/app/lib/features/events/pages/event_list_page.dart
+++ b/app/lib/features/events/pages/event_list_page.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/widgets/space_name_widget.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/events/widgets/event_list_empty_state.dart';
 import 'package:acter/features/events/widgets/event_list_widget.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -166,42 +167,38 @@ class _EventListPageState extends ConsumerState<EventListPage> {
     }
 
     return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (eventFilters.value == EventFilters.bookmarked)
-            EventListWidget(
-              isShowSpaceName: widget.spaceId == null,
-              onTapEventItem: widget.onSelectEventItem,
-              listProvider: bookmarkedEventListProvider(widget.spaceId),
-            ),
-          if (eventFilters.value == EventFilters.all ||
-              eventFilters.value == EventFilters.ongoing)
-            EventListWidget(
-              isShowSpaceName: widget.spaceId == null,
-              onTapEventItem: widget.onSelectEventItem,
-              listProvider:
-                  allOngoingEventListWithSearchProvider(widget.spaceId),
-            ),
-          if (eventFilters.value == EventFilters.all) SizedBox(height: 20),
-          if (eventFilters.value == EventFilters.all ||
-              eventFilters.value == EventFilters.upcoming)
-            EventListWidget(
-              isShowSpaceName: widget.spaceId == null,
-              onTapEventItem: widget.onSelectEventItem,
-              listProvider:
-                  allUpcomingEventListWithSearchProvider(widget.spaceId),
-            ),
-          if (eventFilters.value == EventFilters.all) SizedBox(height: 20),
-          if (eventFilters.value == EventFilters.all ||
-              eventFilters.value == EventFilters.past)
-            EventListWidget(
-              isShowSpaceName: widget.spaceId == null,
-              onTapEventItem: widget.onSelectEventItem,
-              listProvider: allPastEventListWithSearchProvider(widget.spaceId),
-            ),
-        ],
-      ),
+      child: switch (eventFilters.value) {
+        EventFilters.bookmarked => _buildEventList(
+            bookmarkedEventListProvider(widget.spaceId),
+          ),
+        EventFilters.ongoing => _buildEventList(
+            allOngoingEventListWithSearchProvider(widget.spaceId),
+          ),
+        EventFilters.upcoming => _buildEventList(
+            allUpcomingEventListWithSearchProvider(widget.spaceId),
+          ),
+        EventFilters.past => _buildEventList(
+            allPastEventListWithSearchProvider(widget.spaceId),
+          ),
+        EventFilters.all => Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildEventList(allOngoingEventListWithSearchProvider(widget.spaceId)),
+              const SizedBox(height: 14),
+              _buildEventList(allUpcomingEventListWithSearchProvider(widget.spaceId)),
+              const SizedBox(height: 14),
+              _buildEventList(allPastEventListWithSearchProvider(widget.spaceId)),
+            ],
+          ),
+      },
+    );
+  }
+
+  Widget _buildEventList(ProviderBase<AsyncValue<List<CalendarEvent>>> provider) {
+    return EventListWidget(
+      isShowSpaceName: widget.spaceId == null,
+      onTapEventItem: widget.onSelectEventItem,
+      listProvider: provider,
     );
   }
 }

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -42,12 +42,24 @@ final allEventListProvider =
   ),
 );
 
+final isEmptyEventList = FutureProvider.autoDispose.family<bool, String?>(
+  (ref, spaceId) async {
+    final allEvents = await ref.watch(_allEventListProvider(spaceId).future);
+    return allEvents.isEmpty;
+  },
+);
+
 final allEventSorted =
     FutureProvider.autoDispose.family<List<ffi.CalendarEvent>, String?>(
-  (ref, spaceId) async =>  (
-       await ref.watch(allOngoingEventListProvider(spaceId).future)).followedBy(
-       await ref.watch(allUpcomingEventListProvider(spaceId).future),).followedBy(
-      await ref.watch(allPastEventListProvider(spaceId).future),).toList(),
+  (ref, spaceId) async =>
+      (await ref.watch(allOngoingEventListProvider(spaceId).future))
+          .followedBy(
+            await ref.watch(allUpcomingEventListProvider(spaceId).future),
+          )
+          .followedBy(
+            await ref.watch(allPastEventListProvider(spaceId).future),
+          )
+          .toList(),
 );
 
 //ALL ONGOING EVENTS
@@ -72,6 +84,19 @@ final allOngoingEventListProvider = FutureProvider.autoDispose
       )
       .toList();
   return sortEventListAscTime(allOngoingEventList);
+});
+
+//ALL ONGOING EVENTS
+final allOngoingEventListWithSearchProvider = FutureProvider.autoDispose
+    .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
+  final allEventList =
+      await ref.watch(allOngoingEventListProvider(spaceId).future);
+  final searchTerm = ref.watch(eventListSearchTermProvider(spaceId));
+  final eventList = _filterEventBySearchTerm(
+    searchTerm,
+    allEventList,
+  );
+  return sortEventListAscTime(eventList);
 });
 
 //MY ONGOING EVENTS
@@ -102,6 +127,19 @@ final allUpcomingEventListProvider = FutureProvider.autoDispose
   return sortEventListAscTime(allUpcomingEventList);
 });
 
+//ALL UPCOMING EVENTS
+final allUpcomingEventListWithSearchProvider = FutureProvider.autoDispose
+    .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
+  final allEventList =
+      await ref.watch(allUpcomingEventListProvider(spaceId).future);
+  final searchTerm = ref.watch(eventListSearchTermProvider(spaceId));
+  final eventList = _filterEventBySearchTerm(
+    searchTerm,
+    allEventList,
+  );
+  return sortEventListAscTime(eventList);
+});
+
 //MY UPCOMING EVENTS
 final myUpcomingEventListProvider = FutureProvider.autoDispose
     .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
@@ -128,6 +166,19 @@ final allPastEventListProvider = FutureProvider.autoDispose
       )
       .toList();
   return sortEventListDscTime(allPastEventList);
+});
+
+//ALL PAST EVENTS
+final allPastEventListWithSearchProvider = FutureProvider.autoDispose
+    .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
+  final allEventList =
+      await ref.watch(allPastEventListProvider(spaceId).future);
+  final searchTerm = ref.watch(eventListSearchTermProvider(spaceId));
+  final eventList = _filterEventBySearchTerm(
+    searchTerm,
+    allEventList,
+  );
+  return sortEventListAscTime(eventList);
 });
 
 //MY PAST EVENTS
@@ -219,8 +270,7 @@ final eventListSearchedAndFilterProvider = FutureProvider.autoDispose
       await ref.watch(allUpcomingEventListProvider(spaceId).future),
     EventFilters.past =>
       await ref.watch(allPastEventListProvider(spaceId).future),
-    EventFilters.all =>
-       await ref.watch(allEventSorted(spaceId).future),
+    EventFilters.all => await ref.watch(allEventSorted(spaceId).future),
   };
 
   final searchTerm = ref.watch(eventListSearchTermProvider(spaceId));
@@ -228,5 +278,4 @@ final eventListSearchedAndFilterProvider = FutureProvider.autoDispose
     searchTerm,
     filteredEventList,
   );
-
 });

--- a/app/lib/features/events/providers/event_providers.dart
+++ b/app/lib/features/events/providers/event_providers.dart
@@ -1,6 +1,5 @@
 import 'package:acter/features/bookmarks/providers/bookmarks_provider.dart';
 import 'package:acter/features/bookmarks/types.dart';
-import 'package:acter/features/bookmarks/util.dart';
 import 'package:acter/features/events/providers/event_type_provider.dart';
 import 'package:acter/features/events/actions/sort_event_list.dart';
 import 'package:acter/features/events/providers/notifiers/event_notifiers.dart';
@@ -253,29 +252,5 @@ final eventListQuickSearchedProvider =
   return _filterEventBySearchTerm(
     searchTerm,
     allEventList,
-  );
-});
-
-final eventListSearchedAndFilterProvider = FutureProvider.autoDispose
-    .family<List<ffi.CalendarEvent>, String?>((ref, spaceId) async {
-  //Declare filtered event list
-
-  final List<ffi.CalendarEvent> filteredEventList =
-      switch (ref.watch(eventListFilterProvider(spaceId))) {
-    EventFilters.bookmarked =>
-      await ref.watch(bookmarkedEventListProvider(spaceId).future),
-    EventFilters.ongoing =>
-      await ref.watch(allOngoingEventListProvider(spaceId).future),
-    EventFilters.upcoming =>
-      await ref.watch(allUpcomingEventListProvider(spaceId).future),
-    EventFilters.past =>
-      await ref.watch(allPastEventListProvider(spaceId).future),
-    EventFilters.all => await ref.watch(allEventSorted(spaceId).future),
-  };
-
-  final searchTerm = ref.watch(eventListSearchTermProvider(spaceId));
-  return _filterEventBySearchTerm(
-    searchTerm,
-    filteredEventList,
   );
 });

--- a/app/lib/features/space/pages/space_details_page.dart
+++ b/app/lib/features/space/pages/space_details_page.dart
@@ -288,7 +288,7 @@ class _SpaceDetailsPageState extends ConsumerState<SpaceDetailsPage> {
       TabEntry.events => EventListWidget(
           isShowSpaceName: false,
           showSectionHeader: true,
-          listProvider: allEventListProvider(widget.spaceId),
+          listProvider: allEventSorted(widget.spaceId),
           limit: 3,
           onClickSectionHeader: () => context.pushNamed(
             Routes.spaceEvents.name,

--- a/app/test/features/events/error_pages_test.dart
+++ b/app/test/features/events/error_pages_test.dart
@@ -12,94 +12,74 @@ import '../../helpers/mock_event_providers.dart';
 import '../../helpers/test_util.dart';
 
 void main() {
+  Future<void> createWidgetUnderTest({
+    required WidgetTester tester,
+    String? spaceId,
+    String? searchText,
+  }) async {
+    bool shouldFail = true;
+    await tester.pumpProviderWidget(
+      overrides: [
+        allUpcomingEventListWithSearchProvider.overrideWith((a, b) {
+          if (shouldFail) {
+            // toggle failure so the retry works
+            shouldFail = !shouldFail;
+            throw 'Expected fail: Space not loaded';
+          }
+          return [];
+        }),
+        allOngoingEventListWithSearchProvider.overrideWith((a, b) {
+          if (shouldFail) {
+            // toggle failure so the retry works
+            shouldFail = !shouldFail;
+            throw 'Expected fail: Space not loaded';
+          }
+          return [];
+        }),
+        allPastEventListWithSearchProvider.overrideWith((a, b) {
+          if (shouldFail) {
+            // toggle failure so the retry works
+            shouldFail = !shouldFail;
+            throw 'Expected fail: Space not loaded';
+          }
+          return [];
+        }),
+        bookmarkedEventListProvider.overrideWith((a, b) {
+          if (shouldFail) {
+            // toggle failure so the retry works
+            shouldFail = !shouldFail;
+            throw 'Expected fail: Space not loaded';
+          }
+          return [];
+        }),
+        searchValueProvider.overrideWith((_) => searchText ?? ''), // set a search string
+        roomDisplayNameProvider.overrideWith((a, b) => 'test'),
+        roomMembershipProvider.overrideWith((a, b) => null),
+        hasSpaceWithPermissionProvider.overrideWith((_, ref) => false),
+      ],
+      child: EventListPage(
+        spaceId: spaceId,
+      ),
+    );
+    await tester.ensureErrorPageWithRetryWorks();
+  }
+
   group('Event List Error Pages', () {
-    testWidgets('full list', (tester) async {
-      bool shouldFail = true;
-      await tester.pumpProviderWidget(
-        overrides: [
-          eventListSearchedAndFilterProvider.overrideWith((a, b) {
-            if (shouldFail) {
-              // toggle failure so the retry works
-              shouldFail = !shouldFail;
-              throw 'Expected fail: Space not loaded';
-            }
-            return [];
-          }),
-          hasSpaceWithPermissionProvider.overrideWith((_, ref) => false),
-        ],
-        child: const EventListPage(),
-      );
-      await tester.ensureErrorPageWithRetryWorks();
+    testWidgets('All event list', (tester) async {
+      createWidgetUnderTest(tester: tester);
     });
-    testWidgets('full list with search', (tester) async {
-      bool shouldFail = true;
-
-      await tester.pumpProviderWidget(
-        overrides: [
-          searchValueProvider
-              .overrideWith((_) => 'some string'), // set a search string
-
-          eventListSearchedAndFilterProvider.overrideWith((a, b) {
-            if (shouldFail) {
-              // toggle failure so the retry works
-              shouldFail = !shouldFail;
-              throw 'Expected fail: Space not loaded';
-            }
-            return [];
-          }),
-          hasSpaceWithPermissionProvider.overrideWith((_, ref) => false),
-        ],
-        child: const EventListPage(),
-      );
-      await tester.ensureErrorPageWithRetryWorks();
+    testWidgets('All event list : with search', (tester) async {
+      createWidgetUnderTest(tester: tester, searchText: 'some string');
     });
-
-    testWidgets('space list', (tester) async {
-      bool shouldFail = true;
-      await tester.pumpProviderWidget(
-        overrides: [
-          roomDisplayNameProvider.overrideWith((a, b) => 'test'),
-          roomMembershipProvider.overrideWith((a, b) => null),
-          eventListSearchedAndFilterProvider.overrideWith((a, b) {
-            if (shouldFail) {
-              // toggle failure so the retry works
-              shouldFail = !shouldFail;
-              throw 'Expected fail: Space not loaded';
-            }
-            return [];
-          }),
-          hasSpaceWithPermissionProvider.overrideWith((_, ref) => false),
-        ],
-        child: const EventListPage(
-          spaceId: '!test',
-        ),
-      );
-      await tester.ensureErrorPageWithRetryWorks();
+    testWidgets('Space event list', (tester) async {
+      createWidgetUnderTest(tester: tester, spaceId: '!test');
     });
-
-    testWidgets('space list with search', (tester) async {
-      bool shouldFail = true;
-      await tester.pumpProviderWidget(
-        overrides: [
-          roomDisplayNameProvider.overrideWith((a, b) => 'test'),
-          roomMembershipProvider.overrideWith((a, b) => null),
-          searchValueProvider
-              .overrideWith((_) => 'some search'), // set a search string
-          eventListSearchedAndFilterProvider.overrideWith((a, b) {
-            if (shouldFail) {
-              // toggle failure so the retry works
-              shouldFail = !shouldFail;
-              throw 'Expected fail: Space not loaded';
-            }
-            return [];
-          }),
-          hasSpaceWithPermissionProvider.overrideWith((_, ref) => false),
-        ],
-        child: const EventListPage(
-          spaceId: '!test',
-        ),
+    testWidgets('Space event list : with search', (tester) async {
+      createWidgetUnderTest(
+        tester: tester,
+        spaceId: 'spaceId',
+        searchText: 'some string',
       );
-      await tester.ensureErrorPageWithRetryWorks();
     });
   });
   group('Event Details Error Pages', () {


### PR DESCRIPTION
Fixes [#707](https://github.com/acterglobal/a3-meta/issues/707)

This PR addresses the following points:

1. Event Sorting:

 Events are now sorted with priority:
 Happening Now events will appear first, followed by Upcoming events and then, Past Events will be listed at the end.

 Note: Previously, bookmarked events were prioritized and displayed first, but this is now updated according to the above 
 sorting order.

2. Improved Event List Representation:

 The Events list now categorizes events into distinct sections:
 Happening Now, Upcoming, and Past Events,  providing a clearer and more organized view.

 Reference Video:

 https://github.com/user-attachments/assets/17b95c9c-45c7-485e-bff0-b193a35c2bf2

 Additional Notes:

 Due to the changes in event categorization, the error page event test cases were previously failing. These test cases have now 
 been Fixed.