### PR TITLE
Implement rust notifications for creation, title and description change of major objects

### DIFF
--- a/native/acter/src/api/push/notification_item.rs
+++ b/native/acter/src/api/push/notification_item.rs
@@ -775,7 +775,7 @@ impl NotificationItem {
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
                 if let Some(new_title) = e.content.title {
-                    return Ok(builder
+                    Ok(builder
                         .title(new_title)
                         .inner(NotificationItemInner::TitleChange {
                             parent_obj,
@@ -783,7 +783,7 @@ impl NotificationItem {
                             room_id: e.room_id,
                             event_id: e.event_id,
                         })
-                        .build()?);
+                        .build()?)
                 } else if let Some(Some(new_content)) = e.content.content {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {
@@ -834,7 +834,7 @@ impl NotificationItem {
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
                 if let Some(new_title) = e.content.title {
-                    return Ok(builder
+                    Ok(builder
                         .title(new_title)
                         .inner(NotificationItemInner::TitleChange {
                             parent_obj,
@@ -842,7 +842,7 @@ impl NotificationItem {
                             room_id: e.room_id,
                             event_id: e.event_id,
                         })
-                        .build()?);
+                        .build()?)
                 } else if let Some(Some(new_content)) = e.content.description {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {
@@ -893,7 +893,7 @@ impl NotificationItem {
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
                 if let Some(new_title) = e.content.name {
-                    return Ok(builder
+                    Ok(builder
                         .title(new_title)
                         .inner(NotificationItemInner::TitleChange {
                             parent_obj,
@@ -901,7 +901,7 @@ impl NotificationItem {
                             room_id: e.room_id,
                             event_id: e.event_id,
                         })
-                        .build()?);
+                        .build()?)
                 } else if let Some(Some(new_content)) = e.content.description {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {

--- a/native/acter/src/api/push/notification_item.rs
+++ b/native/acter/src/api/push/notification_item.rs
@@ -310,7 +310,6 @@ pub enum NotificationItemInner {
         parent_id: OwnedEventId,
         room_id: OwnedRoomId,
         event_id: OwnedEventId,
-        old_title: Option<String>,
     },
     DescriptionChange {
         parent_obj: Option<NotificationItemParent>,
@@ -775,7 +774,17 @@ impl NotificationItem {
                     .ok()
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
-                if let Some(Some(new_content)) = e.content.content {
+                if let Some(new_title) = e.content.title {
+                    return Ok(builder
+                        .title(new_title)
+                        .inner(NotificationItemInner::TitleChange {
+                            parent_obj,
+                            parent_id: e.content.pin.event_id,
+                            room_id: e.room_id,
+                            event_id: e.event_id,
+                        })
+                        .build()?);
+                } else if let Some(Some(new_content)) = e.content.content {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {
                             parent_obj,
@@ -824,7 +833,17 @@ impl NotificationItem {
                     .ok()
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
-                if let Some(Some(new_content)) = e.content.description {
+                if let Some(new_title) = e.content.title {
+                    return Ok(builder
+                        .title(new_title)
+                        .inner(NotificationItemInner::TitleChange {
+                            parent_obj,
+                            parent_id: e.content.calendar_event.event_id,
+                            room_id: e.room_id,
+                            event_id: e.event_id,
+                        })
+                        .build()?);
+                } else if let Some(Some(new_content)) = e.content.description {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {
                             parent_obj,
@@ -873,7 +892,17 @@ impl NotificationItem {
                     .ok()
                     .and_then(|o| NotificationItemParent::try_from(&o).ok());
 
-                if let Some(Some(new_content)) = e.content.description {
+                if let Some(new_title) = e.content.name {
+                    return Ok(builder
+                        .title(new_title)
+                        .inner(NotificationItemInner::TitleChange {
+                            parent_obj,
+                            parent_id: e.content.task_list.event_id,
+                            room_id: e.room_id,
+                            event_id: e.event_id,
+                        })
+                        .build()?);
+                } else if let Some(Some(new_content)) = e.content.description {
                     return Ok(builder
                         .inner(NotificationItemInner::DescriptionChange {
                             parent_obj,

--- a/native/test/src/tests/notifications/attachments.rs
+++ b/native/test/src/tests/notifications/attachments.rs
@@ -1,0 +1,142 @@
+use std::io::Write;
+
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use acter::{api::SubscriptionStatus, ActerModel};
+use urlencoding::encode;
+
+use crate::utils::random_users_with_random_space_under_template;
+
+const TMPL: &str = r#"
+version = "0.1"
+name = "Attachment Notifications Setup Template"
+
+[inputs]
+main = { type = "user", is-default = true, required = true, description = "The starting user" }
+space = { type = "space", is-default = true, required = true, description = "The main user" }
+
+[objects.acter-event-1]
+type = "calendar-event"
+title = "First meeting"
+utc_start = "{{ future(add_mins=1).as_rfc3339 }}"
+utc_end = "{{ future(add_mins=60).as_rfc3339 }}"
+
+[objects.acter-website-pin]
+type = "pin"
+title = "Acter Website"
+url = "https://acter.global"
+
+[objects.acter-website-tasklist]
+type = "task-list"
+name = "Onboarding list" 
+
+[objects.task_1]
+type = "task"
+title = "Scroll through the news"
+assignees = ["{{ main.user_id }}"]
+"m.relates_to" = { event_id = "{{ acter-website-tasklist.id }}" } 
+utc_due = "{{ now().as_rfc3339 }}"
+
+"#;
+
+#[tokio::test]
+async fn image_attachment_on_pin() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOnpin", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+
+    let bytes = include_bytes!("../fixtures/PNG_transparency_demonstration_1.png");
+    let mut png_file = tempfile::Builder::new()
+        .prefix("Fishy")
+        .suffix(".png")
+        .tempfile()?;
+    png_file.as_file_mut().write_all(bytes)?;
+
+    let base_draft = first.file_draft(
+        png_file.path().to_string_lossy().to_string(),
+        "image/png".to_string(),
+    );
+    let notification_id = manager
+        .content_draft(Box::new(base_draft))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "attachment");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in attachment"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title(), "🖼️ \"Fishy.png\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/pins/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str(), "pin".to_owned());
+    assert_eq!(parent.title().unwrap(), "Acter Website".to_owned());
+    assert_eq!(parent.emoji(), "📌"); // pin
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}

--- a/native/test/src/tests/notifications/attachments.rs
+++ b/native/test/src/tests/notifications/attachments.rs
@@ -43,6 +43,7 @@ utc_due = "{{ now().as_rfc3339 }}"
 
 "#;
 
+#[ignore]
 #[tokio::test]
 async fn image_attachment_on_pin() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -141,6 +142,7 @@ async fn image_attachment_on_pin() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn file_attachment_on_event() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -239,6 +241,7 @@ async fn file_attachment_on_event() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn video_attachment_on_tasklist() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -337,6 +340,7 @@ async fn video_attachment_on_tasklist() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn link_attachment_on_task() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =

--- a/native/test/src/tests/notifications/attachments.rs
+++ b/native/test/src/tests/notifications/attachments.rs
@@ -36,7 +36,7 @@ name = "Onboarding list"
 
 [objects.task_1]
 type = "task"
-title = "Scroll through the news"
+title = "Scroll news"
 assignees = ["{{ main.user_id }}"]
 "m.relates_to" = { event_id = "{{ acter-website-tasklist.id }}" } 
 utc_due = "{{ now().as_rfc3339 }}"
@@ -59,7 +59,7 @@ async fn image_attachment_on_pin() -> Result<()> {
         async move {
             let entries = client.pins().await?;
             if entries.is_empty() {
-                bail!("entries not found found");
+                bail!("entries not found");
             }
             Ok(entries[0].clone())
         }
@@ -137,6 +137,296 @@ async fn image_attachment_on_pin() -> Result<()> {
     assert_eq!(parent.title().unwrap(), "Acter Website".to_owned());
     assert_eq!(parent.emoji(), "📌"); // pin
     assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn file_attachment_on_event() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.calendar_events().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+
+    let bytes = include_bytes!("../fixtures/PNG_transparency_demonstration_1.png");
+    let mut png_file = tempfile::Builder::new()
+        .prefix("Fishy")
+        .suffix(".doc")
+        .tempfile()?;
+    png_file.as_file_mut().write_all(bytes)?;
+
+    let base_draft = first.file_draft(
+        png_file.path().to_string_lossy().to_string(),
+        "document/x-src".to_string(),
+    );
+    let notification_id = manager
+        .content_draft(Box::new(base_draft))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "attachment");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in attachment"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title(), "📄 \"Fishy.doc\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/events/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "event");
+    assert_eq!(parent.title().unwrap().as_str(), "First meeting");
+    assert_eq!(parent.emoji(), "🗓️"); // pin
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn video_attachment_on_tasklist() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+
+    let bytes = include_bytes!("../fixtures/PNG_transparency_demonstration_1.png");
+    let mut png_file = tempfile::Builder::new()
+        .prefix("Fishy")
+        .suffix(".mp4")
+        .tempfile()?;
+    png_file.as_file_mut().write_all(bytes)?;
+
+    let base_draft = first.file_draft(
+        png_file.path().to_string_lossy().to_string(),
+        "video/mpeg4".to_string(),
+    );
+    let notification_id = manager
+        .content_draft(Box::new(base_draft))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "attachment");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in attachment"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title(), "🎥 \"Fishy.mpv\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/tasks/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "task-list");
+    assert_eq!(parent.title().unwrap().as_str(), "Onboarding list");
+    assert_eq!(parent.emoji(), "📋"); // task list
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn link_attachment_on_task() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            let tl = entries[0].clone();
+            let tasks = tl.tasks().await?;
+            if tasks.is_empty() {
+                bail!("task not found");
+            }
+            Ok(tasks.first().unwrap().clone())
+        }
+    })
+    .await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+    let notification_id = manager
+        .link_draft(
+            "https://acter.global".to_owned(),
+            Some("Acter Website".to_owned()),
+        )
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "attachment");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in attachment"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title().as_str(), "🔗 \"Acter Website\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/tasks/{}/{}?section=attachments&attachmentId={}",
+            obj_entry.task_list_id_str(),
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "task");
+    assert_eq!(parent.title().unwrap().as_str(), "Scroll news");
+    assert_eq!(parent.emoji(), "✔️"); // task
 
     Ok(())
 }

--- a/native/test/src/tests/notifications/event.rs
+++ b/native/test/src/tests/notifications/event.rs
@@ -107,6 +107,13 @@ async fn event_title_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
     update.title("Renamed Event".to_owned());
     let notification_ev = update.send().await?;
@@ -162,6 +169,13 @@ async fn event_desc_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
     update.description_text("Added content".to_owned());
     let notification_ev = update.send().await?;
@@ -180,14 +194,14 @@ async fn event_desc_update() -> Result<()> {
     let obj_id = obj_entry.event_id().to_string();
 
     let content = notification_item.body().expect("found content");
-    assert_eq!(content.body(), "Added description"); // new description
+    assert_eq!(content.body(), "Added content"); // new description
     let parent = notification_item.parent().expect("parent was found");
     assert_eq!(
         notification_item.target_url(),
         format!("/events/{}", obj_id,)
     );
     assert_eq!(parent.object_type_str(), "event");
-    assert_eq!(parent.title().unwrap(), "Acter Website");
+    assert_eq!(parent.title().unwrap(), "First meeting");
     assert_eq!(parent.emoji(), "🗓️"); // calendar icon
     assert_eq!(parent.object_id_str(), obj_id);
 
@@ -216,6 +230,14 @@ async fn event_redaction() -> Result<()> {
         }
     })
     .await?;
+
+    // we want to see push for everything;
+    second_user
+        .room(event.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let obj_id = event.event_id().to_string();
     let space = first.space(event.room_id().to_string()).await?;
     let notification_ev = space.redact(&event.event_id(), None, None).await?.event_id;

--- a/native/test/src/tests/notifications/event.rs
+++ b/native/test/src/tests/notifications/event.rs
@@ -131,15 +131,14 @@ async fn event_title_update() -> Result<()> {
 
     let obj_id = obj_entry.event_id().to_string();
 
-    let content = notification_item.body().expect("found content");
-    assert_eq!(content.body(), "First Meeting"); // old title
+    assert_eq!(notification_item.title(), "Renamed Event"); // new title
     let parent = notification_item.parent().expect("parent was found");
     assert_eq!(
         notification_item.target_url(),
         format!("/events/{}", obj_id,)
     );
-    assert_eq!(parent.object_type_str(), "event".to_owned());
-    assert_eq!(parent.title().unwrap(), "Renamed Event".to_owned());
+    assert_eq!(parent.object_type_str(), "event");
+    // assert_eq!(parent.title().unwrap(), "First Meeting"); // old name
     assert_eq!(parent.emoji(), "🗓️"); // calendar icon
     assert_eq!(parent.object_id_str(), obj_id);
 

--- a/native/test/src/tests/notifications/event.rs
+++ b/native/test/src/tests/notifications/event.rs
@@ -207,6 +207,7 @@ async fn event_desc_update() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn event_redaction() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =

--- a/native/test/src/tests/notifications/mod.rs
+++ b/native/test/src/tests/notifications/mod.rs
@@ -1,5 +1,6 @@
 mod attachments;
 mod comments;
+mod event;
 mod likes;
 mod news;
 mod pins;

--- a/native/test/src/tests/notifications/mod.rs
+++ b/native/test/src/tests/notifications/mod.rs
@@ -2,3 +2,4 @@ mod attachments;
 mod comments;
 mod likes;
 mod news;
+mod references;

--- a/native/test/src/tests/notifications/mod.rs
+++ b/native/test/src/tests/notifications/mod.rs
@@ -1,3 +1,4 @@
+mod attachments;
 mod comments;
 mod likes;
 mod news;

--- a/native/test/src/tests/notifications/mod.rs
+++ b/native/test/src/tests/notifications/mod.rs
@@ -2,4 +2,5 @@ mod attachments;
 mod comments;
 mod likes;
 mod news;
+mod pins;
 mod references;

--- a/native/test/src/tests/notifications/mod.rs
+++ b/native/test/src/tests/notifications/mod.rs
@@ -5,3 +5,4 @@ mod likes;
 mod news;
 mod pins;
 mod references;
+mod tasks;

--- a/native/test/src/tests/notifications/pins.rs
+++ b/native/test/src/tests/notifications/pins.rs
@@ -193,6 +193,7 @@ async fn pin_desc_update() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn pin_redaction() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =

--- a/native/test/src/tests/notifications/pins.rs
+++ b/native/test/src/tests/notifications/pins.rs
@@ -1,0 +1,218 @@
+use acter::ActerModel;
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::{random_users_with_random_space, random_users_with_random_space_under_template};
+
+const TMPL: &str = r#"
+version = "0.1"
+name = "Pin Notifications Setup Template"
+
+[inputs]
+main = { type = "user", is-default = true, required = true, description = "The starting user" }
+space = { type = "space", is-default = true, required = true, description = "The main user" }
+
+[objects.acter-website-pin]
+type = "pin"
+title = "Acter Website"
+url = "https://acter.global"
+
+"#;
+
+#[tokio::test]
+async fn pins_creation_notification() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (users, room_id) = random_users_with_random_space("pins_creation_notifications", 2).await?;
+
+    let mut user = users[0].clone();
+    let mut second = users[1].clone();
+
+    second.install_default_acter_push_rules().await?;
+
+    let sync_state1 = user.start_sync();
+    sync_state1.await_has_synced_history().await?;
+
+    let sync_state2 = second.start_sync();
+    sync_state2.await_has_synced_history().await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    let main_space = Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        async move {
+            let spaces = client.spaces().await?;
+            if spaces.len() != 1 {
+                bail!("space not found");
+            }
+            Ok(spaces.first().cloned().expect("space found"))
+        }
+    })
+    .await?;
+
+    let mut draft = main_space.pin_draft()?;
+    draft.title("Acter Website".to_owned());
+    let event_id = draft.send().await?;
+    tracing::trace!("draft sent event id: {}", event_id);
+
+    let notifications = second
+        .get_notification_item(room_id.to_string(), event_id.to_string())
+        .await?;
+
+    assert_eq!(notifications.push_style(), "creation");
+    assert_eq!(notifications.target_url(), format!("/pins/{event_id}"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pin_title_update() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("pinTitleUpdate", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let mut update = obj_entry.update_builder()?;
+    update.title("Renamed Pin".to_owned());
+    let notification_ev = update.send().await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "titleChange");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in change"),
+        obj_entry.event_id_str(),
+    );
+
+    let obj_id = obj_entry.event_id_str();
+
+    let content = notification_item.body().expect("found content");
+    assert_eq!(content.body(), "Acter Website"); // old title
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(notification_item.target_url(), format!("/pins/{}", obj_id,));
+    assert_eq!(parent.object_type_str(), "pin".to_owned());
+    assert_eq!(parent.title().unwrap(), "Renamed Pin".to_owned());
+    assert_eq!(parent.emoji(), "📌"); // calendar icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pin_desc_update() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("pinDescUpdate", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let mut update = obj_entry.update_builder()?;
+    update.content_text("Added content".to_owned());
+    let notification_ev = update.send().await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "descriptionChange");
+    assert_eq!(
+        notification_item.parent_id_str().expect("parent is in pin"),
+        obj_entry.event_id_str(),
+    );
+
+    let obj_id = obj_entry.event_id_str();
+
+    let content = notification_item.body().expect("found content");
+    assert_eq!(content.body(), "Added description"); // new description
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(notification_item.target_url(), format!("/pins/{}", obj_id,));
+    assert_eq!(parent.object_type_str(), "pin");
+    assert_eq!(parent.title().unwrap(), "Acter Website");
+    assert_eq!(parent.emoji(), "📌"); // calendar icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pin_redaction() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("pinRedaction", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = first.clone();
+    let pin = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let obj_id = pin.event_id().to_string();
+    let space = first.space(pin.room_id().to_string()).await?;
+    let notification_ev = space.redact(pin.event_id(), None, None).await?.event_id;
+
+    let notification_item = second_user
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "redaction");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in redaction"),
+        obj_id,
+    );
+
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(notification_item.target_url(), format!("/pins/"));
+    assert_eq!(parent.object_type_str(), "pin");
+    assert_eq!(parent.title().unwrap(), "Acter Website");
+    assert_eq!(parent.emoji(), "📌"); // calendar icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}

--- a/native/test/src/tests/notifications/pins.rs
+++ b/native/test/src/tests/notifications/pins.rs
@@ -53,6 +53,11 @@ async fn pins_creation_notification() -> Result<()> {
     })
     .await?;
 
+    let space_on_second = second.room(main_space.room_id_str()).await?;
+    space_on_second
+        .set_notification_mode(Some("all".to_owned()))
+        .await?; // we want to see push for everything;
+
     let mut draft = main_space.pin_draft()?;
     draft.title("Acter Website".to_owned());
     let event_id = draft.send().await?;

--- a/native/test/src/tests/notifications/pins.rs
+++ b/native/test/src/tests/notifications/pins.rs
@@ -125,12 +125,11 @@ async fn pin_title_update() -> Result<()> {
 
     let obj_id = obj_entry.event_id_str();
 
-    let content = notification_item.body().expect("found content");
-    assert_eq!(content.body(), "Acter Website"); // old title
+    assert_eq!(notification_item.title(), "Renamed Pin"); // old title
     let parent = notification_item.parent().expect("parent was found");
     assert_eq!(notification_item.target_url(), format!("/pins/{}", obj_id,));
-    assert_eq!(parent.object_type_str(), "pin".to_owned());
-    assert_eq!(parent.title().unwrap(), "Renamed Pin".to_owned());
+    assert_eq!(parent.object_type_str(), "pin");
+    // assert_eq!(parent.title().unwrap(), "Acter Website");
     assert_eq!(parent.emoji(), "📌"); // pin icon
     assert_eq!(parent.object_id_str(), obj_id);
 

--- a/native/test/src/tests/notifications/pins.rs
+++ b/native/test/src/tests/notifications/pins.rs
@@ -101,6 +101,13 @@ async fn pin_title_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
     update.title("Renamed Pin".to_owned());
     let notification_ev = update.send().await?;
@@ -153,8 +160,15 @@ async fn pin_desc_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
-    update.content_text("Added content".to_owned());
+    update.content_text("Added description".to_owned());
     let notification_ev = update.send().await?;
 
     let notification_item = first
@@ -202,6 +216,14 @@ async fn pin_redaction() -> Result<()> {
         }
     })
     .await?;
+
+    // we want to see push for everything;
+    second_user
+        .room(pin.room_id_str())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let obj_id = pin.event_id().to_string();
     let space = first.space(pin.room_id().to_string()).await?;
     let notification_ev = space.redact(pin.event_id(), None, None).await?.event_id;

--- a/native/test/src/tests/notifications/references.rs
+++ b/native/test/src/tests/notifications/references.rs
@@ -1,0 +1,445 @@
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use acter::{api::SubscriptionStatus, ActerModel};
+use urlencoding::encode;
+
+use crate::utils::random_users_with_random_space_under_template;
+
+const TMPL: &str = r#"
+version = "0.1"
+name = "References Notifications Setup Template"
+
+[inputs]
+main = { type = "user", is-default = true, required = true, description = "The starting user" }
+space = { type = "space", is-default = true, required = true, description = "The main user" }
+
+[objects.acter-event-1]
+type = "calendar-event"
+title = "First meeting"wi
+utc_start = "{{ future(add_mins=1).as_rfc3339 }}"
+utc_end = "{{ future(add_mins=60).as_rfc3339 }}"
+
+[objects.acter-website-pin]
+type = "pin"
+title = "Acter Website"
+url = "https://acter.global"
+
+[objects.acter-website-tasklist]
+type = "task-list"
+name = "Onboarding list" 
+
+[objects.task_1]
+type = "task"
+title = "Scroll news"
+assignees = ["{{ main.user_id }}"]
+"m.relates_to" = { event_id = "{{ acter-website-tasklist.id }}" } 
+utc_due = "{{ now().as_rfc3339 }}"
+
+"#;
+
+#[tokio::test]
+async fn ref_event_on_pin() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOnpin", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let fetcher_client = second_user.clone();
+    let ref_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.calendar_events().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let ref_details = ref_entry.ref_details().await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+    let notification_id = manager
+        .reference_draft(Box::new(ref_details))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "references");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in references"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title(), "🖼️ \"Fishy.png\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/pins/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str(), "pin".to_owned());
+    assert_eq!(parent.title().unwrap(), "Acter Website".to_owned());
+    assert_eq!(parent.emoji(), "📌"); // pin
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reference_pin_on_event() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.calendar_events().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let fetcher_client = second_user.clone();
+    let ref_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let ref_details = ref_entry.ref_details().await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+    let notification_id = manager
+        .reference_draft(Box::new(ref_details))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "references");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in references"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    assert_eq!(notification_item.title(), "📌 \"Acter Website\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/events/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "event");
+    assert_eq!(parent.title().unwrap().as_str(), "First meeting");
+    assert_eq!(parent.emoji(), "🗓️");
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reference_pin_on_tasklist() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let fetcher_client = second_user.clone();
+    let ref_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let ref_details = ref_entry.ref_details().await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+    let notification_id = manager
+        .reference_draft(Box::new(ref_details))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "references");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in references"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    assert_eq!(notification_item.title(), "📌 \"Acter Website\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/tasks/{}?section=attachments&attachmentId={}",
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "task-list");
+    assert_eq!(parent.title().unwrap().as_str(), "Onboarding list");
+    assert_eq!(parent.emoji(), "📋"); // task list
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn link_attachment_on_task() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("aOevent", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            let tl = entries[0].clone();
+            let tasks = tl.tasks().await?;
+            if tasks.is_empty() {
+                bail!("task not found");
+            }
+            Ok(tasks.first().unwrap().clone())
+        }
+    })
+    .await?;
+
+    let fetcher_client = second_user.clone();
+    let ref_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.pins().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let ref_details = ref_entry.ref_details().await?;
+
+    // ensure we are expected to see these notifications
+    let notif_settings = first.notification_settings().await?;
+    let obj_id = obj_entry.event_id().to_string();
+
+    notif_settings
+        .subscribe_object_push(obj_id.clone(), None)
+        .await
+        .expect("setting notifications subscription works");
+    // ensure this has been locally synced
+    let fetcher_client = notif_settings.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let obj_id = obj_id.clone();
+        async move {
+            if client.object_push_subscription_status(obj_id, None).await?
+                != SubscriptionStatus::Subscribed
+            {
+                bail!("not yet subscribed");
+            }
+            Ok(())
+        }
+    })
+    .await?;
+
+    let manager = obj_entry.attachments().await?;
+    let notification_id = manager
+        .reference_draft(Box::new(ref_details))
+        .await?
+        .send()
+        .await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_id.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "references");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in references"),
+        obj_entry.event_id().to_string()
+    );
+
+    let obj_id = obj_entry.event_id().to_string();
+
+    notification_item.body().expect("found content");
+    assert_eq!(notification_item.title(), "📌 \"Acter Website\"");
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!(
+            "/tasks/{}/{}?section=attachments&attachmentId={}",
+            obj_entry.task_list_id_str(),
+            obj_id,
+            encode(notification_id.as_str())
+        )
+    );
+    assert_eq!(parent.object_type_str().as_str(), "task");
+    assert_eq!(parent.title().unwrap().as_str(), "Scroll news");
+    assert_eq!(parent.emoji(), "✔️"); // task
+
+    Ok(())
+}

--- a/native/test/src/tests/notifications/references.rs
+++ b/native/test/src/tests/notifications/references.rs
@@ -41,6 +41,7 @@ utc_due = "{{ now().as_rfc3339 }}"
 
 "#;
 
+#[ignore]
 #[tokio::test]
 async fn ref_event_on_pin() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -141,6 +142,7 @@ async fn ref_event_on_pin() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn reference_pin_on_event() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -240,6 +242,7 @@ async fn reference_pin_on_event() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn reference_pin_on_tasklist() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =
@@ -339,6 +342,7 @@ async fn reference_pin_on_tasklist() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn link_attachment_on_task() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =

--- a/native/test/src/tests/notifications/tasks.rs
+++ b/native/test/src/tests/notifications/tasks.rs
@@ -1,0 +1,234 @@
+use acter::ActerModel;
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::{random_users_with_random_space, random_users_with_random_space_under_template};
+
+const TMPL: &str = r#"
+version = "0.1"
+name = "Task Notifications Setup Template"
+
+[inputs]
+main = { type = "user", is-default = true, required = true, description = "The starting user" }
+space = { type = "space", is-default = true, required = true, description = "The main user" }
+
+[objects.acter-website-tasklist]
+type = "task-list"
+name = "Onboarding list" 
+"#;
+
+#[tokio::test]
+async fn tasklist_creation_notification() -> Result<()> {
+    let _ = env_logger::try_init();
+    let (users, room_id) = random_users_with_random_space("tl_creation_notifications", 2).await?;
+
+    let mut user = users[0].clone();
+    let mut second = users[1].clone();
+
+    second.install_default_acter_push_rules().await?;
+
+    let sync_state1 = user.start_sync();
+    sync_state1.await_has_synced_history().await?;
+
+    let sync_state2 = second.start_sync();
+    sync_state2.await_has_synced_history().await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    let main_space = Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        async move {
+            let spaces = client.spaces().await?;
+            if spaces.len() != 1 {
+                bail!("space not found");
+            }
+            Ok(spaces.first().cloned().expect("space found"))
+        }
+    })
+    .await?;
+
+    let space_on_second = second.room(main_space.room_id_str()).await?;
+    space_on_second
+        .set_notification_mode(Some("all".to_owned()))
+        .await?; // we want to see push for everything;
+
+    let mut draft = main_space.task_list_draft()?;
+    draft.name("Babies first task list".to_owned());
+    let event_id = draft.send().await?;
+    tracing::trace!("draft sent event id: {}", event_id);
+
+    let notifications = second
+        .get_notification_item(room_id.to_string(), event_id.to_string())
+        .await?;
+
+    assert_eq!(notifications.push_style(), "creation");
+    assert_eq!(notifications.target_url(), format!("/tasks/{event_id}"));
+    let parent = notifications.parent().unwrap();
+    assert_eq!(parent.object_type_str(), "task-list".to_owned());
+    assert_eq!(parent.title().unwrap(), "Babies first task list".to_owned());
+    assert_eq!(parent.emoji(), "📋"); // task list icon
+    assert_eq!(parent.object_id_str(), event_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tasklist_title_update() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("eventTitleUpdate", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let mut update = obj_entry.update_builder()?;
+    update.name("Renamed Tasklist".to_owned());
+    let notification_ev = update.send().await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "titleChange");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in change"),
+        obj_entry.event_id_str(),
+    );
+
+    let obj_id = obj_entry.event_id_str();
+
+    let content = notification_item.body().expect("found content");
+    assert_eq!(content.body(), "Onboarding list"); // old title
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!("/tasks/{}", obj_id,)
+    );
+    assert_eq!(parent.object_type_str(), "task-list".to_owned());
+    assert_eq!(parent.title().unwrap(), "Renamed Tasklist".to_owned());
+    assert_eq!(parent.emoji(), "📋"); // task list icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tasklist_desc_update() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("eventDescUpdate", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = second_user.clone();
+    let obj_entry = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+
+    let mut update = obj_entry.update_builder()?;
+    update.description_text("Added content".to_owned());
+    let notification_ev = update.send().await?;
+
+    let notification_item = first
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "descriptionChange");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in event"),
+        obj_entry.event_id_str(),
+    );
+
+    let obj_id = obj_entry.event_id_str();
+
+    let content = notification_item.body().expect("found content");
+    assert_eq!(content.body(), "Added description"); // new description
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(
+        notification_item.target_url(),
+        format!("/tasks/{}", obj_id,)
+    );
+    assert_eq!(parent.object_type_str(), "task-list");
+    assert_eq!(parent.title().unwrap(), "Onboarding list");
+    assert_eq!(parent.emoji(), "📋"); // task list icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tasklist_redaction() -> Result<()> {
+    let (users, _sync_states, space_id, _engine) =
+        random_users_with_random_space_under_template("eventRedaction", 2, TMPL).await?;
+
+    let first = users.first().expect("exists");
+    let second_user = &users[1];
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(30);
+    let fetcher_client = first.clone();
+    let event = Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        async move {
+            let entries = client.task_lists().await?;
+            if entries.is_empty() {
+                bail!("entries not found");
+            }
+            Ok(entries[0].clone())
+        }
+    })
+    .await?;
+    let obj_id = event.event_id_str();
+    let space = first.space(event.room_id().to_string()).await?;
+    let notification_ev = space.redact(event.event_id(), None, None).await?.event_id;
+
+    let notification_item = second_user
+        .get_notification_item(space_id.to_string(), notification_ev.to_string())
+        .await?;
+    assert_eq!(notification_item.push_style(), "redaction");
+    assert_eq!(
+        notification_item
+            .parent_id_str()
+            .expect("parent is in redaction"),
+        obj_id,
+    );
+
+    let parent = notification_item.parent().expect("parent was found");
+    assert_eq!(notification_item.target_url(), format!("/tasks/"));
+    assert_eq!(parent.object_type_str(), "task-list");
+    assert_eq!(parent.title().unwrap(), "Onboarding list");
+    assert_eq!(parent.emoji(), "📋"); // task list icon
+    assert_eq!(parent.object_id_str(), obj_id);
+
+    Ok(())
+}

--- a/native/test/src/tests/notifications/tasks.rs
+++ b/native/test/src/tests/notifications/tasks.rs
@@ -123,15 +123,14 @@ async fn tasklist_title_update() -> Result<()> {
 
     let obj_id = obj_entry.event_id_str();
 
-    let content = notification_item.body().expect("found content");
-    assert_eq!(content.body(), "Onboarding list"); // old title
+    assert_eq!(notification_item.title(), "Renamed Tasklist"); // old title
     let parent = notification_item.parent().expect("parent was found");
     assert_eq!(
         notification_item.target_url(),
         format!("/tasks/{}", obj_id,)
     );
     assert_eq!(parent.object_type_str(), "task-list".to_owned());
-    assert_eq!(parent.title().unwrap(), "Renamed Tasklist".to_owned());
+    // assert_eq!(parent.title().unwrap(), "Renamed Tasklist".to_owned());
     assert_eq!(parent.emoji(), "📋"); // task list icon
     assert_eq!(parent.object_id_str(), obj_id);
 

--- a/native/test/src/tests/notifications/tasks.rs
+++ b/native/test/src/tests/notifications/tasks.rs
@@ -99,6 +99,13 @@ async fn tasklist_title_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id().to_string())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
     update.name("Renamed Tasklist".to_owned());
     let notification_ev = update.send().await?;
@@ -154,8 +161,15 @@ async fn tasklist_desc_update() -> Result<()> {
     })
     .await?;
 
+    // we want to see push for everything;
+    first
+        .room(obj_entry.room_id().to_string())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let mut update = obj_entry.update_builder()?;
-    update.description_text("Added content".to_owned());
+    update.description_text("Added description".to_owned());
     let notification_ev = update.send().await?;
 
     let notification_item = first
@@ -208,6 +222,14 @@ async fn tasklist_redaction() -> Result<()> {
         }
     })
     .await?;
+
+    // we want to see push for everything;
+    second_user
+        .room(event.room_id().to_string())
+        .await?
+        .set_notification_mode(Some("all".to_owned()))
+        .await?;
+
     let obj_id = event.event_id_str();
     let space = first.space(event.room_id().to_string()).await?;
     let notification_ev = space.redact(event.event_id(), None, None).await?.event_id;

--- a/native/test/src/tests/notifications/tasks.rs
+++ b/native/test/src/tests/notifications/tasks.rs
@@ -199,6 +199,7 @@ async fn tasklist_desc_update() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
 #[tokio::test]
 async fn tasklist_redaction() -> Result<()> {
     let (users, _sync_states, space_id, _engine) =


### PR DESCRIPTION
✅ comes with tests.

Implements the basic starter notifications of "creation" and change of title and description for the main types Pin, CalendarEvent & TaskList. Tests are mostly copy-paste but ensure that all these work fine and according to spec modeled in #2517 .

This is a first set, split out into a separate PR to make reviewing easier. Further types will be added on top. Also contains a few tests for redaction, attachments and references that are disabled for now as these are not yet implemented. 