### PR TITLE
Increased contrast of icons on boosts & stories.

### DIFF
--- a/.changes/#2540-icon-visibility-improvement.md
+++ b/.changes/#2540-icon-visibility-improvement.md
@@ -1,0 +1,1 @@
+-[improvement] : A subtle shadow has been added to the icons for a more elevated, better appearance when displayed on the screen. This change applies to the boosts & stories icon.

--- a/app/lib/common/widgets/like_button.dart
+++ b/app/lib/common/widgets/like_button.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/animations/like_animation.dart';
+import 'package:acter/common/widgets/visibility/shadow_effect_widget.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
@@ -146,22 +147,24 @@ class _LikeButtonState extends State<LikeButton> with TickerProviderStateMixin {
                         }
                       }
                     },
-                    child: _LikeWidget(
-                      size: Size(
-                        heartSize.value * 30,
-                        heartSize.value * 30,
+                    child: ShadowEffectWidget(
+                      child: _LikeWidget(
+                        size: Size(
+                          heartSize.value * 30,
+                          heartSize.value * 30,
+                        ),
+                        icon: widget.isLiked
+                            ? Icon(
+                                Atlas.heart,
+                                fill: 1.0,
+                                color: Theme.of(context).colorScheme.error,
+                              )
+                            : const Icon(Atlas.heart),
+                        color: widget.isLiked
+                            ? Theme.of(context).colorScheme.tertiary
+                            : widget.color,
+                        isSmall: false,
                       ),
-                      icon: widget.isLiked
-                          ? Icon(
-                              Atlas.heart,
-                              fill: 1.0,
-                              color: Theme.of(context).colorScheme.error,
-                            )
-                          : const Icon(Atlas.heart),
-                      color: widget.isLiked
-                          ? Theme.of(context).colorScheme.tertiary
-                          : widget.color,
-                      isSmall: false,
                     ),
                   ),
                   Align(
@@ -189,9 +192,11 @@ class _LikeButtonState extends State<LikeButton> with TickerProviderStateMixin {
             );
           },
         ),
-        Text(
-          widget.likeCount.toString(),
-          style: widget.style,
+        ShadowEffectWidget(
+          child: Text(
+            widget.likeCount.toString(),
+            style: widget.style,
+          ),
         ),
       ],
     );

--- a/app/lib/common/widgets/visibility/shadow_effect_widget.dart
+++ b/app/lib/common/widgets/visibility/shadow_effect_widget.dart
@@ -13,7 +13,7 @@ class ShadowEffectWidget extends StatelessWidget {
         borderRadius: BorderRadius.circular(20),
         boxShadow: [
           BoxShadow(
-            color: Theme.of(context).shadowColor.withValues(alpha: 0.3), // Shadow color
+            color: Theme.of(context).shadowColor.withOpacity(0.3), // Shadow color
             spreadRadius: 1, // How much the shadow spreads
             blurRadius: 15, // How much the shadow blurs
             offset: const Offset(0, 4), // Adjust the shadow to be slightly below the icon

--- a/app/lib/common/widgets/visibility/shadow_effect_widget.dart
+++ b/app/lib/common/widgets/visibility/shadow_effect_widget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class ShadowEffectWidget extends StatelessWidget {
+
+  final Widget child;
+
+  const ShadowEffectWidget({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).shadowColor.withValues(alpha: 0.3), // Shadow color
+            spreadRadius: 1, // How much the shadow spreads
+            blurRadius: 15, // How much the shadow blurs
+            offset: const Offset(0, 4), // Adjust the shadow to be slightly below the icon
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}

--- a/app/lib/features/news/widgets/news_item/news_side_bar.dart
+++ b/app/lib/features/news/widgets/news_item/news_side_bar.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/common/widgets/like_button.dart';
+import 'package:acter/common/widgets/visibility/shadow_effect_widget.dart';
 import 'package:acter/features/comments/providers/comments_providers.dart';
 import 'package:acter/features/comments/types.dart';
 import 'package:acter/features/comments/widgets/comments_section_widget.dart';
@@ -114,9 +115,9 @@ class NewsSideBar extends ConsumerWidget {
             },
             icon: Column(
               children: [
-                const Icon(Atlas.comment_blank),
+                ShadowEffectWidget(child: Icon(Atlas.comment_blank),),
                 const SizedBox(height: 4),
-                Text(commentCount.toString(), style: style),
+                ShadowEffectWidget(child:Text(commentCount.toString(), style: style),),
               ],
             ),
           ),
@@ -137,7 +138,7 @@ class NewsSideBar extends ConsumerWidget {
               ),
             ),
             child: _SideBarItem(
-              icon: const Icon(Atlas.dots_horizontal_thin),
+              icon: ShadowEffectWidget(child: Icon(Atlas.dots_horizontal_thin)),
               label: '',
               style: bodyLarge?.copyWith(fontSize: 13),
             ),

--- a/app/lib/features/read_receipts/widgets/read_counter.dart
+++ b/app/lib/features/read_receipts/widgets/read_counter.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-
 import 'package:acter/common/toolkit/errors/inline_error_button.dart';
+import 'package:acter/common/widgets/visibility/shadow_effect_widget.dart';
 import 'package:acter/features/read_receipts/providers/read_receipts.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -65,7 +65,12 @@ class _ReadCounterWidgetState extends ConsumerState<ReadCounterWidget> {
     return manager.when(
       data: (manager) {
         final count = manager.readCount();
-        return Column(children: [Icon(PhosphorIcons.eye()), Text('$count')]);
+        return Column(
+          children: [
+            ShadowEffectWidget(child: Icon(PhosphorIcons.eye()),),
+            ShadowEffectWidget(child:Text('$count'),),
+          ],
+        );
       },
       loading: () => const _ReadCounterWidgetLoading(),
       error: (error, stackTrace) => Column(


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2526

In this PR, added shadow effects to the boost icons (heart, eye, comment and more) to enhance their visibility and depth. These updates aim to improve user experience.

Reference : 

![image](https://github.com/user-attachments/assets/eb360a2e-9e49-4148-9443-63a8e145a5b0)

