### PR TITLE
Pre-loaded next slide to the right as well as below with minimal delay.

### DIFF
--- a/.changes/2550-preload-nextslide-improvements.md
+++ b/.changes/2550-preload-nextslide-improvements.md
@@ -1,0 +1,1 @@
+- [improvement] : Accelerate slide transitions and minimize loading delays while navigating between slides, ensuring smooth horizontal and vertical navigation for users.

--- a/app/lib/features/news/widgets/news_full_view.dart
+++ b/app/lib/features/news/widgets/news_full_view.dart
@@ -5,6 +5,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:preload_page_view/preload_page_view.dart';
 
 class NewsFullView extends ConsumerStatefulWidget {
   final List<NewsEntry> newsList;
@@ -21,12 +22,12 @@ class NewsFullView extends ConsumerStatefulWidget {
 }
 
 class NewsVerticalViewState extends ConsumerState<NewsFullView> {
-  static PageController? _pageController;
+  static PreloadPageController? _pageController;
 
   @override
   void initState() {
     super.initState();
-    _pageController = PageController(initialPage: widget.initialPageIndex);
+    _pageController = PreloadPageController(initialPage: widget.initialPageIndex);
   }
 
   @override
@@ -59,23 +60,26 @@ class NewsVerticalViewState extends ConsumerState<NewsFullView> {
           PointerDeviceKind.stylus,
         },
       ),
-      child: PageView.builder(
-        controller: _pageController,
-        itemCount: widget.newsList.length,
-        scrollDirection: Axis.vertical,
-        itemBuilder: (context, index) => InkWell(
-          onDoubleTap: () async {
-            LikeAnimation.run(index);
-            final news = widget.newsList[index];
-            final manager = await ref.read(newsReactionsProvider(news).future);
-            final status = manager.likedByMe();
-            if (!status) {
-              await manager.sendLike();
-            }
-          },
-          child: NewsItem(news: widget.newsList[index]),
-        ),
-      ),
+      child: PreloadPageView.builder(
+          controller: _pageController,
+          itemCount: widget.newsList.length,
+          scrollDirection: Axis.vertical,
+          preloadPagesCount: widget.newsList.length > 5 ? 5 : widget.newsList.length,
+          itemBuilder: (context, index) {
+            return InkWell(
+              onDoubleTap: () async {
+                LikeAnimation.run(index);
+                final news = widget.newsList[index];
+                final manager =
+                    await ref.read(newsReactionsProvider(news).future);
+                final status = manager.likedByMe();
+                if (!status) {
+                  await manager.sendLike();
+                }
+              },
+              child: NewsItem(news: widget.newsList[index]),
+            );
+          },),
     );
   }
 }

--- a/app/lib/features/news/widgets/news_item/news_item.dart
+++ b/app/lib/features/news/widgets/news_item/news_item.dart
@@ -9,6 +9,7 @@ import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:carousel_indicator/carousel_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:preload_page_view/preload_page_view.dart';
 
 class NewsItem extends ConsumerStatefulWidget {
   final NewsEntry news;
@@ -21,6 +22,20 @@ class NewsItem extends ConsumerStatefulWidget {
 
 class _NewsItemState extends ConsumerState<NewsItem> {
   final ValueNotifier<int> currentSlideIndex = ValueNotifier(0);
+  PreloadPageController? _pageController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PreloadPageController(initialPage: currentSlideIndex.value);
+  }
+
+  @override
+  void dispose() {
+    _pageController?.dispose();
+    _pageController = null;
+    super.dispose();
+  }
 
   @override
   void didChangeDependencies() {
@@ -43,10 +58,12 @@ class _NewsItemState extends ConsumerState<NewsItem> {
   }
 
   Widget buildSlidesUI(List<NewsSlide> slides) {
-    return PageView.builder(
+    return PreloadPageView.builder(
+      controller: _pageController,
       scrollDirection: Axis.horizontal,
       itemCount: slides.length,
-      onPageChanged: (page) => currentSlideIndex.value = page,
+      preloadPagesCount: slides.length,
+      onPageChanged: (page) =>  currentSlideIndex.value = page,
       itemBuilder: (context, index) => NewsSlideItem(slide: slides[index]),
     );
   }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -161,6 +161,7 @@ dependencies:
   screen_retriever: ^0.1.9
   android_intent_plus: ^5.2.1
   collection: ^1.18.0
+  preload_page_view: ^0.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2525

In this PR, I optimizes slide navigation by pre-loading the content of the next slide to the right and below the current slide. This ensures that users can quickly access the upcoming slides with minimal delay.

Key Changes:

- Implemented [preload_page_view ](https://pub.dev/packages/preload_page_view) dependency, which provides the preload pages count. Preloaded 5 pages vertically and all in horizontal slides, ensuring smoother transitions and better user experience by reducing loading delays.
