### PR TITLE
Add a way to force a reload if boost content fails to load.

### DIFF
--- a/.changes/2551-add-tryagain-boost-contentfails.md
+++ b/.changes/2551-add-tryagain-boost-contentfails.md
@@ -1,1 +1,1 @@
-- [improvement] : - Added a "Try Again" button to reload the video and image while boost video or image failed to load, also improved the error message for better clarity and user experience.
+- [improvement] : Ability to reload the boost if the media fails to load.

--- a/.changes/2551-add-tryagain-boost-contentfails.md
+++ b/.changes/2551-add-tryagain-boost-contentfails.md
@@ -1,0 +1,1 @@
+- [improvement] : - Added a "Try Again" button to reload the video and image while boost video or image failed to load, also improved the error message for better clarity and user experience.

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -48,6 +48,7 @@ class _ImageSlideState extends State<ImageSlide> {
 
   Widget buildImageUI(Uint8List imageData) {
     return Container(
+      key: Key('image_container'),
       foregroundDecoration: BoxDecoration(
         image: DecorationImage(
           fit: BoxFit.contain,

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -9,7 +9,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 final _log = Logger('a3::news::image_slide');
 
-class ImageSlide extends StatelessWidget {
+class ImageSlide extends StatefulWidget {
   final NewsSlide slide;
 
   const ImageSlide({
@@ -17,6 +17,11 @@ class ImageSlide extends StatelessWidget {
     required this.slide,
   });
 
+  @override
+  State<ImageSlide> createState() => _ImageSlideState();
+}
+
+class _ImageSlideState extends State<ImageSlide> {
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -27,7 +32,7 @@ class ImageSlide extends StatelessWidget {
 
   Widget renderImageContent() {
     return FutureBuilder<FfiBufferUint8>(
-      future: slide.sourceBinary(null),
+      future: widget.slide.sourceBinary(null),
       builder: (BuildContext context, AsyncSnapshot<FfiBufferUint8> snapshot) {
         final data = snapshot.data;
         final error = snapshot.error;
@@ -68,7 +73,28 @@ class ImageSlide extends StatelessWidget {
   ) {
     _log.severe('Failed to load image of slide', error, stackTrace);
     return Center(
-      child: Text(L10n.of(context).errorLoadingImage(error)),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            PhosphorIcons.imageBroken(),
+            size: 100,
+          ),
+          SizedBox(height: 10),
+          Text(L10n.of(context).unableToLoadImage),
+          SizedBox(height: 20),
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.white, width: 1),
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+            ),
+            child: TextButton(
+              onPressed: () => setState(() {}),
+              child: Text(L10n.of(context).tryAgain),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/features/news/widgets/news_item_slide/video_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/video_slide.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/features/news/model/keys.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,7 +11,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 final _log = Logger('a3::news::video_slide');
 
-class VideoSlide extends StatelessWidget {
+class VideoSlide extends StatefulWidget {
   final NewsSlide slide;
 
   const VideoSlide({
@@ -20,9 +19,15 @@ class VideoSlide extends StatelessWidget {
     required this.slide,
   });
 
+  @override
+  State<VideoSlide> createState() => _VideoSlideState();
+}
+
+class _VideoSlideState extends State<VideoSlide> {
+
   Future<File> getNewsVideoFile() async {
-    final newsVideo = await slide.sourceBinary(null);
-    final videoName = slide.uniqueId();
+    final newsVideo = await widget.slide.sourceBinary(null);
+    final videoName = widget.slide.uniqueId();
     final tempDir = await getTemporaryDirectory();
     final filePath = p.join(tempDir.path, videoName);
     File file = File(filePath);
@@ -80,7 +85,28 @@ class VideoSlide extends StatelessWidget {
   ) {
     _log.severe('Failed to load video of slide', error, stackTrace);
     return Center(
-      child: Text(L10n.of(context).loadingFailed(error)),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.videocam_off_outlined,
+            size: 100,
+          ),
+          SizedBox(height: 10),
+          Text(L10n.of(context).unableToLoadVideo),
+          SizedBox(height: 20),
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.white, width: 1),
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+            ),
+            child: TextButton(
+              onPressed: () => setState(() {}),
+              child: Text(L10n.of(context).tryAgain),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2330,5 +2330,8 @@
   "removeReferenceConfirmation": "Are you sure you want to remove this reference?",
   "noObjectAccess": "You are not part of {spaceName} so you can't access this {objectType}",
   "shareLink": "Share link",
+  "tryAgain": "Try Again",
+  "unableToLoadVideo": "Unable to load video",
+  "unableToLoadImage": "Unable to load image",
   "@addComment": {}
 }

--- a/app/test/features/news/image_slide_widget_test.dart
+++ b/app/test/features/news/image_slide_widget_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'package:acter/features/news/widgets/news_item_slide/image_slide.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockingjay/mockingjay.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+class MockNewsSlide extends Mock implements NewsSlide {}
+
+// Mock class for FfiBufferUint8 to mock the return value of asTypedList
+class MockFfiBufferUint8 extends Mock implements FfiBufferUint8 {}
+
+void main() {
+  group('ImageSlide Widget Test', () {
+    late MockNewsSlide mockSlide;
+    late MockFfiBufferUint8 mockFfiBuffer;
+
+    setUp(() {
+      mockSlide = MockNewsSlide();
+      mockFfiBuffer = MockFfiBufferUint8();
+    });
+
+    testWidgets('shows loading UI when data is loading', (tester) async {
+      // Mock the sourceBinary method to simulate loading
+      when(() => mockSlide.sourceBinary(null)).thenAnswer(
+        (_) async => mockFfiBuffer,
+      );
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+        ),
+      );
+
+      // Verify that the loading UI (icon) is displayed
+      expect(find.byIcon(PhosphorIcons.image()), findsOneWidget);
+    });
+
+    testWidgets('shows error UI and retries loading on TextButton click',
+        (tester) async {
+      when(() => mockSlide.sourceBinary(null))
+          .thenAnswer((_) async => Future.error('Failed to load image'));
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(PhosphorIcons.imageBroken()), findsOneWidget);
+      expect(find.text('Unable to load image'), findsOneWidget);
+      expect(find.byType(TextButton), findsOneWidget);
+
+      await tester.tap(find.byType(TextButton));
+      await tester.pumpAndSettle(); // Wait for the widget to rebuild
+
+      verify(() => mockSlide.sourceBinary(null)).called(2); // Called twice (1 for the initial error, 1 for retry)
+    });
+
+    testWidgets('shows image UI when data loading is successful',
+        (tester) async {
+      const validImageBase64 =
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/yy7K8EAAAAASUVORK5CYII=';
+
+      final validImageBytes = base64Decode(validImageBase64);
+
+      // Mock the sourceBinary method to return the image data
+      when(() => mockSlide.sourceBinary(null)).thenAnswer(
+        (_) async => mockFfiBuffer,
+      );
+      when(() => mockFfiBuffer.asTypedList()).thenReturn(validImageBytes);
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+        ),
+      );
+
+      // Wait for Future to complete and all widgets to settle
+      await tester.pumpAndSettle();
+      expect(find.byKey(Key('image_container')), findsOneWidget);
+      await tester.pump(Duration(seconds: 1)); // Waiting for 1 second
+    });
+  });
+}

--- a/app/test/features/news/video_slide_widget_test.dart
+++ b/app/test/features/news/video_slide_widget_test.dart
@@ -1,0 +1,67 @@
+
+import 'package:acter/features/news/widgets/news_item_slide/video_slide.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockingjay/mockingjay.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+class MockNewsSlide extends Mock implements NewsSlide {}
+
+// Mock class for FfiBufferUint8 to mock the return value of asTypedList
+class MockFfiBufferUint8 extends Mock implements FfiBufferUint8 {}
+
+void main() {
+  group('VideoSlide Widget Test', () {
+    late MockNewsSlide mockSlide;
+    late MockFfiBufferUint8 mockFfiBuffer;
+
+    setUp(() {
+      mockSlide = MockNewsSlide();
+      mockFfiBuffer = MockFfiBufferUint8();
+    });
+
+    testWidgets('shows loading UI when data is loading', (tester) async {
+      // Mock the sourceBinary method to simulate loading
+      when(() => mockSlide.sourceBinary(null)).thenAnswer(
+        (_) async => mockFfiBuffer,
+      );
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: VideoSlide(slide: mockSlide)),
+        ),
+      );
+
+      // Verify that the loading UI (icon) is displayed
+      expect(find.byIcon(PhosphorIcons.video()), findsOneWidget);
+    });
+
+    testWidgets('shows error UI and retries loading on TextButton click',
+        (tester) async {
+      when(() => mockSlide.sourceBinary(null))
+          .thenAnswer((_) async => Future.error('Failed to load video'));
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: VideoSlide(slide: mockSlide)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.videocam_off_outlined), findsOneWidget);
+      expect(find.text('Unable to load video'), findsOneWidget);
+      expect(find.byType(TextButton), findsOneWidget);
+
+      await tester.tap(find.byType(TextButton));
+      await tester.pumpAndSettle(); // Wait for the widget to rebuild
+
+      verify(() => mockSlide.sourceBinary(null)).called(2); // Called twice (1 for the initial error, 1 for retry)
+    });
+  });
+}


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2514

In this PR, Fixed video and image loading behavior when network connection is not stable or slow.

Key Changes : 

1. Added a "Try Again" button to let users retry loading the video and image.
2. Improved error messaging for a clearer and more helpful user experience.

Reference Video:

https://github.com/user-attachments/assets/55a7cf5a-9da9-4dc4-bf84-c33820850828

Reference Image: 

![finalunabletoloadimage](https://github.com/user-attachments/assets/79c99f80-d34e-4cd6-87d6-a20f77d2a244)![finalunabletoloadvideo](https://github.com/user-attachments/assets/32279d2d-577d-414c-a8e8-e69276c292c3)
