### PR TITLE
Make alwaysClientProvider never fail

### DIFF
--- a/.changes/2552-always-client.md
+++ b/.changes/2552-always-client.md
@@ -1,0 +1,1 @@
+- Fix an internal race conditions that lead to some systems not properly redeeming invitations upon registration

--- a/app/lib/features/home/providers/client_providers.dart
+++ b/app/lib/features/home/providers/client_providers.dart
@@ -1,23 +1,17 @@
 import 'package:acter/common/models/sync_state/sync_state.dart';
+import 'package:acter/features/home/providers/notifiers/always_client_notifier.dart';
 import 'package:acter/features/home/providers/notifiers/client_notifier.dart';
 import 'package:acter/common/providers/notifiers/sync_notifier.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk.dart' show Client;
 import 'package:riverpod/riverpod.dart';
 
-class NoClientException implements Exception {
-  NoClientException();
-}
-
 final clientProvider =
     AsyncNotifierProvider<ClientNotifier, Client?>(() => ClientNotifier());
 
-final alwaysClientProvider = FutureProvider((ref) async {
-  final client = await ref.watch(clientProvider.future);
-  if (client == null) {
-    throw NoClientException();
-  }
-  return client;
-});
+final alwaysClientProvider =
+    AsyncNotifierProvider<AlwaysClientNotifier, Client>(
+  () => AlwaysClientNotifier(),
+);
 
 final syncStateProvider =
     NotifierProvider<SyncNotifier, SyncState>(() => SyncNotifier());

--- a/app/lib/features/home/providers/notifiers/always_client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/always_client_notifier.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart' show Client;
+import 'package:riverpod/riverpod.dart';
+
+class AlwaysClientNotifier extends AsyncNotifier<Client> {
+  Completer<Client>? completer;
+  late ProviderSubscription subscription;
+  @override
+  FutureOr<Client> build() async {
+    subscription = ref.listen<AsyncValue<Client?>>(clientProvider, _updated);
+    final client = await ref.read(clientProvider.future);
+    if (client != null) {
+      return client;
+    }
+
+    final cpl = completer ??= Completer<Client>();
+    return cpl.future;
+  }
+
+  void _updated(AsyncValue<Client?>? old, AsyncValue<Client?> newV) {
+    // set up the refresh
+    final newClient = newV.valueOrNull;
+    if (newClient != null) {
+      state = AsyncData(newClient);
+      // and inform any pending completers
+      completer?.complete(newClient);
+      completer = null;
+    } else {
+      state = AsyncValue.loading();
+    }
+  }
+}

--- a/app/test/common/providers/client_providers_test.dart
+++ b/app/test/common/providers/client_providers_test.dart
@@ -1,0 +1,94 @@
+import 'package:acter/features/home/providers/client_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/mock_a3sdk.dart';
+import '../../helpers/mock_client_provider.dart';
+
+void main() {
+  group('Always Client Provider tests', () {
+    testWidgets('is pending on none', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          // no client
+          clientProvider.overrideWith(() => MockClientNotifier(client: null)),
+        ],
+      );
+      await expectLater(
+        container.read(alwaysClientProvider.future),
+        doesNotComplete,
+      );
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      await container.pump();
+      await expectLater(
+        container.read(alwaysClientProvider.future),
+        doesNotComplete,
+      );
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('future updates on set', (tester) async {
+      final provider = MockClientNotifier(client: null);
+      final container = ProviderContainer(
+        overrides: [
+          // no client
+          clientProvider.overrideWith(() => provider),
+        ],
+      );
+      // it updates
+      final ftr = container.read(alwaysClientProvider.future);
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      final cl = MockClient();
+
+      provider.state = AsyncValue.data(cl);
+      expect(container.read(alwaysClientProvider).isLoading, false);
+      expect(container.read(alwaysClientProvider).value, cl);
+
+      expect(ftr, completes);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('double set and reset', (tester) async {
+      final provider = MockClientNotifier(client: null);
+      final container = ProviderContainer(
+        overrides: [
+          // no client
+          clientProvider.overrideWith(() => provider),
+        ],
+      );
+      // it updates
+      final ftr = container.read(alwaysClientProvider.future);
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      final cl = MockClient();
+
+      provider.state = AsyncValue.data(cl);
+      expect(container.read(alwaysClientProvider).isLoading, false);
+      expect(container.read(alwaysClientProvider).value, cl);
+
+      expect(ftr, completes);
+      await tester.pumpAndSettle();
+
+      // user changes to another client
+      final newCl = MockClient();
+
+      provider.state = AsyncValue.data(newCl);
+      expect(container.read(alwaysClientProvider).isLoading, false);
+      expect(container.read(alwaysClientProvider).value, newCl);
+
+      expect(ftr, completes);
+      await tester.pumpAndSettle();
+
+      // user logs out, no client left
+      provider.state = AsyncValue.data(null);
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      await container.pump();
+      await expectLater(
+        container.read(alwaysClientProvider.future),
+        doesNotComplete,
+      );
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      await tester.pumpAndSettle();
+    });
+  });
+}

--- a/app/test/features/calendar_sync/calendar_sync_test.dart
+++ b/app/test/features/calendar_sync/calendar_sync_test.dart
@@ -15,6 +15,7 @@ import '../../helpers/mock_a3sdk.dart';
 
 import 'package:mocktail/mocktail.dart';
 
+import '../../helpers/mock_client_provider.dart';
 import '../../helpers/mock_event_providers.dart';
 import '../../helpers/mock_room_providers.dart';
 
@@ -148,7 +149,7 @@ void main() {
         overrides: [
           utcNowProvider.overrideWith((ref) => MockUtcNowNotifier()),
           allEventListProvider.overrideWith((r, a) => events),
-          alwaysClientProvider.overrideWith((ref) => client),
+          clientProvider.overrideWith(() => MockClientNotifier(client: client)),
           maybeRoomProvider.overrideWith(
             () => MockAlwaysTheSameRoomNotifier(
               room: mockRoom,
@@ -200,7 +201,7 @@ void main() {
         overrides: [
           utcNowProvider.overrideWith((ref) => MockUtcNowNotifier()),
           allEventListProvider.overrideWith((r, a) => events),
-          alwaysClientProvider.overrideWith((ref) => client),
+          clientProvider.overrideWith(() => MockClientNotifier(client: client)),
           maybeRoomProvider.overrideWith(
             () => MockAsyncMaybeRoomNotifier(
               items: {'roomA': roomA, 'roomB': roomB, 'roomC': roomC},

--- a/app/test/features/chat/custom_input_test.dart
+++ b/app/test/features/chat/custom_input_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/mock_client_provider.dart';
 import '../../helpers/room_test_wrapper.dart';
 import '../../helpers/utils.dart';
 import '../../helpers/mock_a3sdk.dart';
@@ -26,7 +27,9 @@ void main() {
                 // Same as before
                 canSendMessageProvider.overrideWith((ref, roomId) => false),
                 sdkProvider.overrideWith((ref) => MockActerSdk()),
-                alwaysClientProvider.overrideWith((ref) => MockClient()),
+                clientProvider.overrideWith(
+                  () => MockClientNotifier(client: MockClient()),
+                ),
               ],
               child: const InActerContextTestWrapper(
                 child: CustomChatInput(
@@ -72,7 +75,9 @@ void main() {
                 canSendMessageProvider.overrideWith((ref, roomId) => true),
                 isRoomEncryptedProvider.overrideWith((ref, roomId) => true),
                 sdkProvider.overrideWith((ref) => MockActerSdk()),
-                alwaysClientProvider.overrideWith((ref) => MockClient()),
+                clientProvider.overrideWith(
+                  () => MockClientNotifier(client: MockClient()),
+                ),
                 chatComposerDraftProvider
                     .overrideWith((ref, roomId) => MockComposeDraft()),
               ],
@@ -95,7 +100,9 @@ void main() {
       canSendMessageProvider.overrideWith((ref, roomId) => true),
       isRoomEncryptedProvider.overrideWith((ref, roomId) => true),
       sdkProvider.overrideWith((ref) => MockActerSdk()),
-      alwaysClientProvider.overrideWith((ref) => MockClient()),
+      clientProvider.overrideWith(
+        () => MockClientNotifier(client: MockClient()),
+      ),
       chatProvider.overrideWith(() => MockAsyncConvoNotifier()),
       chatComposerDraftProvider
           .overrideWith((ref, roomId) => MockComposeDraft()),
@@ -196,7 +203,9 @@ void main() {
       canSendMessageProvider.overrideWith((ref, roomId) => true),
       isRoomEncryptedProvider.overrideWith((ref, roomId) => true),
       sdkProvider.overrideWith((ref) => MockActerSdk()),
-      alwaysClientProvider.overrideWith((ref) => MockClient()),
+      clientProvider.overrideWith(
+        () => MockClientNotifier(client: MockClient()),
+      ),
       chatProvider.overrideWith(() => MockAsyncConvoNotifier()),
       chatComposerDraftProvider
           .overrideWith((ref, roomId) => Future.value(roomDrafts[roomId])),

--- a/app/test/helpers/mock_client_provider.dart
+++ b/app/test/helpers/mock_client_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:acter/features/home/providers/notifiers/client_notifier.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:mocktail/mocktail.dart';
@@ -9,4 +11,7 @@ class MockClientNotifier extends AsyncNotifier<Client?>
   final Client? client;
 
   MockClientNotifier({required this.client});
+
+  @override
+  FutureOr<Client?> build() => client;
 }

--- a/app/test/helpers/mock_client_provider.dart
+++ b/app/test/helpers/mock_client_provider.dart
@@ -1,0 +1,12 @@
+import 'package:acter/features/home/providers/notifiers/client_notifier.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:riverpod/riverpod.dart';
+
+class MockClientNotifier extends AsyncNotifier<Client?>
+    with Mock
+    implements ClientNotifier {
+  final Client? client;
+
+  MockClientNotifier({required this.client});
+}


### PR DESCRIPTION
This PR is the final step in making the `alwaysClientProvider` truly async and infallible. It came about that we might still have a minor race in the registration code, where the `alwaysClientProvider` could still be in the `NoClientException`-failed-mode when the client setting hasn't fully trickled through the `async` loops of the system at the time we try to use that to redeem an invite. Leading to, depending on the situation, a freeze on registration or at the very least the invite not being redeemed.

This PR fixes that behavior by replacing the earlier `FutureProvider` with a more actively listening `Notifier` that will be stay in `loading` (and return the same inner `Future`) until there is a `Client` available. Removing the need for `NoClientException` altogether, as all other code will just `await` forever in that case now.

It also comes with tests showing that this new behavior is working es expected, also when clients are switched and reset to ensure we didn't introduce further issues in that logic.

