### PR TITLE
Solved the same text issue that shows while adding a new slide in the editor.

### DIFF
--- a/.changes/2553-solve-sametext-editor-bug.md
+++ b/.changes/2553-solve-sametext-editor-bug.md
@@ -1,2 +1,1 @@
 - [Fix] : Fix Issue with Same Content Displaying on Multiple Slides in Update Editor.
-- [Description] : This update addresses a bug in the update editor where adding a new slide, creating a new slide, or switching between slides results in the same content being shown across all slides. This makes it impossible for users to create and view unique slides, as each slide displays identical text.

--- a/.changes/2553-solve-sametext-editor-bug.md
+++ b/.changes/2553-solve-sametext-editor-bug.md
@@ -1,0 +1,2 @@
+- [Fix] : Fix Issue with Same Content Displaying on Multiple Slides in Update Editor.
+- [Description] : This update addresses a bug in the update editor where adding a new slide, creating a new slide, or switching between slides results in the same content being shown across all slides. This makes it impossible for users to create and view unique slides, as each slide displays identical text.

--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -66,7 +66,11 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
         setState(() {
           selectedNewsPost = nextSlide;
           if (!document.isEmpty) {
+            // If the slide has content, update the editor state with it
             textEditorState = EditorState(document: document);
+          } else {
+            // If no content, create a blank editor state
+            textEditorState = EditorState.blank();
           }
         });
 


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2236

This PR addresses a bug where switching between slides in the update editor results in the same text appearing on all slides. This prevents users from working with unique content for each slide and disrupts the expected behavior of the editor.

Key Changes : 

- Each new slide would be initialized with empty content, and switching between slides should show the correct content for each slide.

Reference Video : 

https://github.com/user-attachments/assets/4e86a7a1-ed9f-4fa2-a336-a307e0657719



