### PR TITLE
Fix several minor Notification parsing issues

### DIFF
--- a/packages/acter_notifify/lib/matrix.dart
+++ b/packages/acter_notifify/lib/matrix.dart
@@ -55,6 +55,7 @@ Future<bool> handleMatrixMessage(
       'getting notification from message failed: %s - %s',
       params: [error, message],
     );
+    return false;
   }
   _log.info('got a notification');
 

--- a/packages/acter_notifify/lib/matrix.dart
+++ b/packages/acter_notifify/lib/matrix.dart
@@ -25,19 +25,23 @@ const bool isProduction = bool.fromEnvironment('dart.vm.product');
 Future<NotificationItem> _getNotificationItem(
   Map<String?, Object?> message,
 ) async {
-  final deviceId = message['device_id'] as String?;
+  final deviceId = message['device_id'] as String;
 
-  final mayBeRoomId = message['room_id'];
-  final mayBeEventId = message['event_id'];
-
-  if (mayBeEventId == null || mayBeRoomId == null || deviceId == null) {
-    throw 'Received unsupported notification without deviceId, eventId and/or room Id. Skipping. message: $message';
-  }
-  final roomId = mayBeRoomId as String;
-  final eventId = mayBeEventId as String;
+  final roomId = message['room_id'] as String;
+  final eventId = message['event_id'] as String;
   _log.info('Received msg $roomId: $eventId');
   final instance = await ActerSdk.instance;
   return await instance.getNotificationFor(deviceId, roomId, eventId);
+}
+
+Future<bool> _handleCountsUpdate(
+  Map<String?, Object?> message,
+) async {
+  final msg = message['count'] as Map? ?? message;
+  final totalCounts =
+      ((msg['unread'] as int?) ?? 0) + ((msg['missed_calls'] as int?) ?? 0);
+  await updateBadgeCount(totalCounts);
+  return false;
 }
 
 Future<bool> handleMatrixMessage(
@@ -46,6 +50,14 @@ Future<bool> handleMatrixMessage(
   ShouldShowCheck? shouldShowCheck,
 }) async {
   late NotificationItem notification;
+  if (message["event_id"] == null ||
+      message['room_id'] == null ||
+      message['device_id'] == null) {
+    // this message doesn't actually contain any regular information
+    // just badge counter updates.
+    return _handleCountsUpdate(message);
+  }
+
   try {
     notification = await _getNotificationItem(message);
   } catch (error, stack) {

--- a/packages/acter_notifify/test/message_format_test.dart
+++ b/packages/acter_notifify/test/message_format_test.dart
@@ -1,0 +1,45 @@
+import 'package:acter_notifify/matrix.dart';
+import 'package:acter_notifify/util.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+void main() {
+  setUp(() {});
+
+  group("Message Format tests ", () {
+    test("Ensure doesn't fail for empty", () async {
+      await handleMatrixMessage({});
+    });
+
+    test("Ensure doesn't fail for count update only", () async {
+      when(() => updateBadgeCount(any()));
+      await handleMatrixMessage({
+        // this comes on iOS
+        'sender': '',
+        'unread': 1,
+        'missed_calls': null,
+        'prio': 'high',
+        'device_id': 'JCQZTNXBDI',
+      });
+
+      // this comes through ntfy
+      await handleMatrixMessage({
+        'counts': {'unread': 12},
+        'devices': [
+          {
+            'app_id': 'global.acter.a3.linux',
+            'data': {
+              'default_payload': {'device_id': 'EACAZQUGOA'}
+            },
+            'pushkey': 'https://ntfy.XXX.global/XX',
+            'pushkey_ts': 1638600870
+          }
+        ],
+        'id': '',
+        'sender': '',
+        'type': null,
+        'device_id': 'EACXZQUGOA'
+      });
+    });
+  });
+}


### PR DESCRIPTION
[x] Fixes #2545 by returning if the notification couldn't be parsed.
[x] Fixes parsing of non matrix-event notifications -- which we get for the read counts.
[x] Tests for the formats