### PR TITLE
Add guardrule to fix runtime error on android

### DIFF
--- a/.changes/2547-fix-runtime-error.md
+++ b/.changes/2547-fix-runtime-error.md
@@ -1,0 +1,1 @@
+- Fix runtime error on certain notification calls

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -12,6 +12,11 @@
 -keep class org.xmlpull.** { *; }
 -keepclassmembers class org.xmlpull.** { *; }
 
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+# FIX for Notifications Plugin #2547: "RuntimeException: Missing type parameter."
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
 # -keep class io.flutter.app.** { *; }
 # -keep class io.flutter.**  { *; }
 # --- /end fix


### PR DESCRIPTION
uses https://github.com/MaikuB/flutter_local_notifications/issues/2223 to fix #2547 .