### PR TITLE
Flutter upgrade 3.27

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -204,7 +204,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
 
       - name: Flutter info

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
 
       - name: Install supported toolchain

--- a/.github/workflows/check-flutter-integration-tests.yml
+++ b/.github/workflows/check-flutter-integration-tests.yml
@@ -71,7 +71,7 @@ jobs:
   #     - uses: subosito/flutter-action@v2
   #       name: Set up flutter
   #       with:
-  #         flutter-version: '3.24'
+  #         flutter-version: '3.27.4'
   #         channel: 'stable'
 
   #     - uses: actions/setup-python@v4
@@ -184,7 +184,7 @@ jobs:
   #     - uses: subosito/flutter-action@v2
   #       name: Set up flutter
   #       with:
-  #         flutter-version: '3.24'
+  #         flutter-version: '3.27.4'
   #         channel: 'stable'
 
   #     - uses: actions/setup-python@v4
@@ -273,7 +273,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
       - uses: actions/setup-java@v4
         with:
@@ -357,7 +357,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
 
       - uses: actions/setup-python@v4
@@ -508,7 +508,7 @@ jobs:
   #     - uses: subosito/flutter-action@v2
   #       name: Set up flutter
   #       with:
-  #         flutter-version: '3.24'
+  #         flutter-version: '3.27.4'
   #         channel: 'stable'
 
   #     - uses: actions/setup-python@v4

--- a/.github/workflows/check-flutter-unittest.yml
+++ b/.github/workflows/check-flutter-unittest.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         name: Set up flutter
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
       - name: Generate env
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/check-native.yml
+++ b/.github/workflows/check-native.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: ${{matrix.needs_flutter}}
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
       - name: Run Clippy
         run: cargo clippy  -p ${{matrix.package}} ${{matrix.clippy_extras}} -- -D warnings
@@ -90,7 +90,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: ${{matrix.needs_flutter}}
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
       - name: Release Build
         run: cargo build -p ${{matrix.package}} --release
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
       - name: Install supported rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/check-styles.yml
+++ b/.github/workflows/check-styles.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.27.4'
           channel: 'stable'
 
       - name: Generate env

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -148,3 +148,14 @@ String formatBytes(int bytes) {
     return '${size.toStringAsFixed(2)} ${suffixes[i]}';
   }
 }
+
+extension ColorUtils on Color {
+  int toInt() {
+    final alpha = (a * 255).toInt();
+    final red = (r * 255).toInt();
+    final green = (g * 255).toInt();
+    final blue = (b * 255).toInt();
+    // Combine the components into a single int using bit shifting
+    return (alpha << 24) | (red << 16) | (green << 8) | blue;
+  }
+}

--- a/app/lib/common/widgets/add_button_with_can_permission.dart
+++ b/app/lib/common/widgets/add_button_with_can_permission.dart
@@ -41,7 +41,7 @@ class AddButtonWithCanPermission extends ConsumerWidget {
       icon: Container(
         padding: const EdgeInsets.all(6),
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.8),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.8),
           borderRadius: const BorderRadius.all(Radius.circular(100)),
         ),
         child: const Icon(Icons.add),

--- a/app/lib/common/widgets/like_button.dart
+++ b/app/lib/common/widgets/like_button.dart
@@ -236,7 +236,7 @@ class _SmallHeartWidget extends StatelessWidget {
       color: Theme.of(context)
           .colorScheme
           .tertiary
-          .withOpacity(smallHeartOpacity.value * 0.8),
+          .withValues(alpha:smallHeartOpacity.value * 0.8),
       size: 12,
     );
   }

--- a/app/lib/common/widgets/plus_icon_widget.dart
+++ b/app/lib/common/widgets/plus_icon_widget.dart
@@ -15,7 +15,7 @@ class PlusIconWidget extends StatelessWidget {
       icon: Container(
         padding: const EdgeInsets.all(6),
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.8),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha:0.8),
           borderRadius: const BorderRadius.all(Radius.circular(100)),
         ),
         child: const Icon(

--- a/app/lib/common/widgets/visibility/shadow_effect_widget.dart
+++ b/app/lib/common/widgets/visibility/shadow_effect_widget.dart
@@ -13,7 +13,7 @@ class ShadowEffectWidget extends StatelessWidget {
         borderRadius: BorderRadius.circular(20),
         boxShadow: [
           BoxShadow(
-            color: Theme.of(context).shadowColor.withOpacity(0.3), // Shadow color
+            color: Theme.of(context).shadowColor.withValues(alpha: 0.3), // Shadow color
             spreadRadius: 1, // How much the shadow spreads
             blurRadius: 15, // How much the shadow blurs
             offset: const Offset(0, 4), // Adjust the shadow to be slightly below the icon

--- a/app/lib/features/categories/actions/save_categories.dart
+++ b/app/lib/features/categories/actions/save_categories.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/categories/model/CategoryModelLocal.dart';
 import 'package:acter/features/categories/providers/categories_providers.dart';
 import 'package:acter/features/categories/utils/category_utils.dart';
@@ -48,7 +49,7 @@ Future<void> saveCategories(
 
       //ADD COLOR AND ICON
       category.color.map((color) {
-        displayBuilder.color(color.value);
+        displayBuilder.color(color.toInt());
       });
       category.icon.map((icon) {
         displayBuilder.icon('acter-icon', icon.name);

--- a/app/lib/features/categories/organize_categories_page.dart
+++ b/app/lib/features/categories/organize_categories_page.dart
@@ -83,7 +83,7 @@ class _DraggableCategoriesListState
         categoryModelLocal: categoryList[categoryIndex],
         isShowDragHandle: true,
         headerBackgroundColor:
-            Theme.of(context).unselectedWidgetColor.withOpacity(0.7),
+            Theme.of(context).unselectedWidgetColor.withValues(alpha: 0.7),
         onClickEditCategory: () => callEditCategory(categoryIndex),
         onClickDeleteCategory: () => callDeleteCategory(categoryIndex),
       ),

--- a/app/lib/features/chat/widgets/bubble_builder.dart
+++ b/app/lib/features/chat/widgets/bubble_builder.dart
@@ -162,8 +162,8 @@ class _ChatBubble extends ConsumerWidget {
               Container(
                 decoration: BoxDecoration(
                   color: isAuthor
-                      ? colorScheme.surface.withOpacity(0.3)
-                      : colorScheme.onSurface.withOpacity(0.2),
+                      ? colorScheme.surface.withValues(alpha:0.3)
+                      : colorScheme.onSurface.withValues(alpha:0.2),
                   borderRadius: BorderRadius.circular(22),
                 ),
                 child: Column(

--- a/app/lib/features/chat/widgets/custom_input.dart
+++ b/app/lib/features/chat/widgets/custom_input.dart
@@ -132,7 +132,7 @@ class CustomChatInput extends ConsumerWidget {
                         prefixIcon: Icon(
                           Icons.shield,
                           size: 18,
-                          color: colorScheme.primary.withOpacity(0.8),
+                          color: colorScheme.primary.withValues(alpha:0.8),
                         ),
                         suffixIcon: const Icon(Icons.emoji_emotions),
                         border: OutlineInputBorder(
@@ -875,7 +875,7 @@ class _TextInputWidgetConsumerState extends ConsumerState<_TextInputWidget> {
         onSubmitted: (_) => widget.onSendButtonPressed(),
         style: Theme.of(context).textTheme.bodyMedium,
         decoration: InputDecoration(
-          fillColor: Theme.of(context).unselectedWidgetColor.withOpacity(0.5),
+          fillColor: Theme.of(context).unselectedWidgetColor.withValues(alpha:0.5),
           contentPadding: const EdgeInsets.all(15),
           isCollapsed: true,
           prefixIcon: InkWell(

--- a/app/lib/features/chat/widgets/text_message_builder.dart
+++ b/app/lib/features/chat/widgets/text_message_builder.dart
@@ -158,7 +158,7 @@ class _TextWidget extends ConsumerWidget {
                   defaultTextStyle: textTheme.bodySmall?.copyWith(
                     overflow: isReply ? TextOverflow.ellipsis : null,
                     color: isNotice
-                        ? colorScheme.onSurface.withOpacity(0.5)
+                        ? colorScheme.onSurface.withValues(alpha:0.5)
                         : null,
                   ),
                   maxLines: isReply ? 3 : null,

--- a/app/lib/features/chat_ng/dialogs/message_actions.dart
+++ b/app/lib/features/chat_ng/dialogs/message_actions.dart
@@ -93,7 +93,7 @@ class _BlurOverlay extends StatelessWidget {
               sigmaY: 8 * animation.value,
             ),
             child: Container(
-              color: Colors.black.withOpacity(0.1 * animation.value),
+              color: Colors.black.withValues(alpha:(0.1 * animation.value)),
               child: child,
             ),
           );

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_loading.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_loading.dart
@@ -25,7 +25,7 @@ class ChatEditorLoading extends StatelessWidget {
                   decoration: BoxDecoration(
                     color: Theme.of(context)
                         .unselectedWidgetColor
-                        .withOpacity(0.5),
+                        .withValues(alpha:0.5),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: const SingleChildScrollView(

--- a/app/lib/features/chat_ng/widgets/events/text_message_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/text_message_event.dart
@@ -125,7 +125,7 @@ class TextMessageEvent extends StatelessWidget {
       maxLines: _type == TextMessageType.reply ? 2 : null,
       defaultTextStyle: textTheme.bodySmall?.copyWith(
         color: _type == TextMessageType.notice
-            ? colorScheme.onSurface.withOpacity(0.5)
+            ? colorScheme.onSurface.withValues(alpha:0.5)
             : null,
         overflow: _type == TextMessageType.reply ? TextOverflow.ellipsis : null,
       ),

--- a/app/lib/features/chat_ng/widgets/message_actions_widget.dart
+++ b/app/lib/features/chat_ng/widgets/message_actions_widget.dart
@@ -37,7 +37,7 @@ class MessageActionsWidget extends ConsumerWidget {
       ),
       decoration: BoxDecoration(
         borderRadius: const BorderRadius.all(Radius.circular(5)),
-        color: Theme.of(context).colorScheme.surface.withOpacity(0.8),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
       ),
       child: Column(
         children: menuItems(context, ref, lang).map((e) => e).toList(),

--- a/app/lib/features/chat_ng/widgets/reactions/reaction_selector.dart
+++ b/app/lib/features/chat_ng/widgets/reactions/reaction_selector.dart
@@ -33,7 +33,7 @@ class ReactionSelector extends ConsumerWidget {
         ),
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(20)),
-          color: Theme.of(context).colorScheme.surface.withOpacity(0.8),
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
         ),
         child: _buildEmojiRow(context, ref),
       ),

--- a/app/lib/features/chat_ng/widgets/replied_to_preview.dart
+++ b/app/lib/features/chat_ng/widgets/replied_to_preview.dart
@@ -74,8 +74,8 @@ class RepliedToPreview extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
       decoration: BoxDecoration(
         color: isUser
-            ? colorScheme.surface.withOpacity(0.3)
-            : colorScheme.onSurface.withOpacity(0.2),
+            ? colorScheme.surface.withValues(alpha:0.3)
+            : colorScheme.onSurface.withValues(alpha:0.2),
         borderRadius: BorderRadius.circular(22),
       ),
       child: child,

--- a/app/lib/features/news/actions/submit_news.dart
+++ b/app/lib/features/news/actions/submit_news.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/utils/routes.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/spaces/space_selector_drawer.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter/features/news/model/news_slide_model.dart';
@@ -37,7 +38,7 @@ Future<NewsSlideDraft> _makeTextSlide(
   final textSlideDraft = textDraft.intoNewsSlideDraft();
 
   textSlideDraft.color(
-    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.value),
+    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.toInt()),
   );
 
   final refDetails = slidePost.refDetails;
@@ -75,7 +76,7 @@ Future<NewsSlideDraft> _makeImageSlide(
       .height(decodedImage.height);
   final imageSlideDraft = imageDraft.intoNewsSlideDraft();
   imageSlideDraft.color(
-    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.value),
+    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.toInt()),
   );
 
   final refDetails = slidePost.refDetails;
@@ -107,7 +108,7 @@ Future<NewsSlideDraft> _makeVideoSlide(
   final videoDraft = client.videoDraft(file.path, mimeType).size(bytes.length);
   final videoSlideDraft = videoDraft.intoNewsSlideDraft();
   videoSlideDraft.color(
-    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.value),
+    sdk.api.newColorizeBuilder(null, slidePost.backgroundColor?.toInt()),
   );
   final refDetails = slidePost.refDetails;
   if (refDetails != null) {

--- a/app/lib/features/pins/actions/pin_update_actions.dart
+++ b/app/lib/features/pins/actions/pin_update_actions.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:acter/common/providers/sdk_provider.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
 import 'package:acter/features/pins/providers/pins_provider.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -106,7 +107,7 @@ Future<void> updatePinIcon(
     // Pin IconData
     final sdk = await ref.watch(sdkProvider.future);
     final displayBuilder = sdk.api.newDisplayBuilder();
-    displayBuilder.color(color.value);
+    displayBuilder.color(color.toInt());
     displayBuilder.icon('acter-icon', acterIcon.name);
 
     final updateBuilder = pin.updateBuilder();

--- a/app/lib/features/pins/pages/create_pin_page.dart
+++ b/app/lib/features/pins/pages/create_pin_page.dart
@@ -338,7 +338,7 @@ class _CreatePinConsumerState extends ConsumerState<CreatePinPage> {
       if (pinIconColor != null || pinIcon != null) {
         final sdk = await ref.watch(sdkProvider.future);
         final displayBuilder = sdk.api.newDisplayBuilder();
-        pinIconColor.map((color) => displayBuilder.color(color.value));
+        pinIconColor.map((color) => displayBuilder.color(color.toInt()));
         pinIcon.map((icon) => displayBuilder.icon('acter-icon', icon.name));
         pinDraft.display(displayBuilder.build());
       }

--- a/app/lib/features/share/widgets/attach_options.dart
+++ b/app/lib/features/share/widgets/attach_options.dart
@@ -104,7 +104,7 @@ class AttachOptions extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(14),
               decoration: BoxDecoration(
-                color: color.withOpacity(0.3),
+                color: color.withValues(alpha:0.3),
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
                   color: color,

--- a/app/lib/features/space/actions/set_acter_feature.dart
+++ b/app/lib/features/space/actions/set_acter_feature.dart
@@ -40,8 +40,6 @@ extension SpaceFeatureActivator on ActerAppSettings {
         updated.active(newVal);
         builder.tasks(updated.build());
         break;
-      default:
-        throw 'Unsupported SpaceFeature Type';
     }
     return builder;
   }

--- a/app/lib/features/space/pages/space_details_page.dart
+++ b/app/lib/features/space/pages/space_details_page.dart
@@ -110,9 +110,9 @@ class _SpaceDetailsPageState extends ConsumerState<SpaceDetailsPage> {
         decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [
-              colorScheme.primary.withOpacity(0.7),
-              colorScheme.surface.withOpacity(0.5),
-              colorScheme.surface.withOpacity(0.1),
+              colorScheme.primary.withValues(alpha:0.7),
+              colorScheme.surface.withValues(alpha:0.5),
+              colorScheme.surface.withValues(alpha:0.1),
               colorScheme.secondaryContainer,
             ],
             begin: Alignment.topCenter,

--- a/app/lib/features/space/widgets/space_sections/section_header.dart
+++ b/app/lib/features/space/widgets/space_sections/section_header.dart
@@ -40,9 +40,9 @@ class SectionHeader extends StatelessWidget {
             ? BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
-                    colorScheme.surface.withOpacity(0.9),
-                    colorScheme.surface.withOpacity(0.3),
-                    colorScheme.secondaryContainer.withOpacity(0.1),
+                    colorScheme.surface.withValues(alpha:0.9),
+                    colorScheme.surface.withValues(alpha:0.3),
+                    colorScheme.secondaryContainer.withValues(alpha: 0.1),
                   ],
                   begin: Alignment.topLeft,
                   end: Alignment.topRight,

--- a/app/lib/features/tasks/actions/update_tasklist.dart
+++ b/app/lib/features/tasks/actions/update_tasklist.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/providers/sdk_provider.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -23,7 +24,7 @@ Future<void> updateTaskListIcon(
   // TaskList IconData
   final sdk = await ref.watch(sdkProvider.future);
   final displayBuilder = sdk.api.newDisplayBuilder();
-  displayBuilder.color(color.value);
+  displayBuilder.color(color.toInt());
   displayBuilder.icon('acter-icon', acterIcon.name);
 
   final updateBuilder = taskList.updateBuilder();

--- a/app/lib/features/tasks/sheets/create_update_task_list.dart
+++ b/app/lib/features/tasks/sheets/create_update_task_list.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/providers/sdk_provider.dart';
 import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
 import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
 import 'package:acter/common/widgets/html_editor/html_editor.dart';
@@ -218,7 +219,7 @@ class _CreateUpdateTaskListConsumerState
       if (taskListIconColor != null || taskListIcon != null) {
         final sdk = await ref.read(sdkProvider.future);
         final displayBuilder = sdk.api.newDisplayBuilder();
-        taskListIconColor.map((color) => displayBuilder.color(color.value));
+        taskListIconColor.map((color) => displayBuilder.color(color.toInt()));
         taskListIcon
             .map((icon) => displayBuilder.icon('acter-icon', icon.name));
         taskListDraft.display(displayBuilder.build());

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -5,15 +5,15 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   acter_avatar:
     dependency: "direct main"
     description:
@@ -48,10 +48,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   android_intent_plus:
     dependency: "direct main"
     description:
@@ -416,10 +416,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -985,10 +985,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_math_fork
-      sha256: "94bee4642892a94939af0748c6a7de0ff8318feee588379dcdfea7dc5cba06c8"
+      sha256: "284bab89b2fbf1bc3a0baf13d011c1dd324d004e35d177626b77f2fc056366ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   flutter_matrix_html:
     dependency: "direct main"
     description:
@@ -1446,18 +1446,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1502,10 +1502,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   markdown:
     dependency: transitive
     description:
@@ -2430,7 +2430,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   sliver_tools:
     dependency: transitive
     description:
@@ -2523,10 +2523,10 @@ packages:
     dependency: "direct main"
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -2555,10 +2555,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   string_validator:
     dependency: transitive
     description:
@@ -2611,26 +2611,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   timeago:
     dependency: transitive
     description:
@@ -2891,10 +2891,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   volume_controller:
     dependency: transitive
     description:
@@ -2947,10 +2947,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -3025,5 +3025,5 @@ packages:
     source: hosted
     version: "1.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.6.2 <4.0.0"
+  flutter: ">=3.27.4"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 0.0.1+1
 
 environment:
-  sdk: ">=3.5.0"
-  flutter: ^3.24.0
+  sdk: ">=3.6.2"
+  flutter: ^3.27.4
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -103,7 +103,7 @@ dependencies:
   screenshot: ^3.0.0
   http: ^1.0.0
   crypto: ^3.0.2
-  flutter_math_fork: ^0.7.2
+  flutter_math_fork: ^0.7.3
   shared_preferences: ^2.2.0
   image_picker_for_web: ^3.0.1
   riverpod_infinite_scroll:

--- a/packages/rust_sdk/lib/acter_flutter_sdk.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk.dart
@@ -28,7 +28,7 @@ RegExp logFileRegExp = RegExp('app_.*log');
 RegExp screenshotFileRegExp = RegExp('screenshot_.*png');
 
 Color convertColor(int? primary, Color fallback) =>
-    Color(primary ?? fallback.value);
+    primary != null ? Color(primary) : fallback;
 
 Completer<SharedPreferences>? _sharedPrefCompl;
 Completer<String>? _appDirCompl;


### PR DESCRIPTION
### 1.  The `withOpacity`  is deprecated:
Commit : https://github.com/acterglobal/a3/pull/2577/commits/ab9c1ed815ecb55a0d82699a8204a65f72d05f3a

- With new flutter version 3.27.4 `withOpacity` is deprecated so based on that  changed it to `withValues`.
- Reference  :  **https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity**

### 2.  The `color.value`  is deprecated:
Commit : https://github.com/acterglobal/a3/pull/2577/commits/a4232c6d9efc0136c57b0a4385be2c1d44230aa5

- With new flutter version 3.27.4 the `color.value` is deprecated so based on that changed it to `color.toInt()`.
- The `color.toInt()`  is an extension function that created from Color class as there were no default alternative option I found.
- Reference : https://github.com/flutter/flutter/issues/160184

### 3. Removed `default` clause from switch case:
commit: https://github.com/acterglobal/a3/pull/2577/commits/db5a83116feb4ba876790828d009ae1c7a6b402d

- The default clause is removed from the switch statement because the previous cases already cover all possible enum values, meaning there is no need for a fallback.

### 4. Update flutter version in `pubspec.yaml` file:
commit : https://github.com/acterglobal/a3/pull/2577/commits/e24342698106c2359e11967de51cc7e0043c8638

- Update the flutter version from `flutter: ^3.24.0` to `flutter:^3.27.4` and also update sdk from `sdk: >=3.5.0` to` sdk: >=3.6.2`.
- After version updated there is an issue of `flutter_math_fork` plugin so, that  need to update from `flutter_math_fork: ^0.7.2` to `flutter_math_fork: ^0.7.3`.

### 5. Update flutter version in github workflow files:
commit : https://github.com/acterglobal/a3/pull/2577/commits/ff80a6d07a40d1a69d3881897cc040d7a971b54c
