### PR TITLE
Disable verification sessions section on activities

### DIFF
--- a/app/lib/features/activities/pages/activities_page.dart
+++ b/app/lib/features/activities/pages/activities_page.dart
@@ -170,10 +170,11 @@ class ActivitiesPage extends ConsumerWidget {
       security.add(renderUnconfirmedEmailAddrs(context));
     }
 
-    final sessions = renderSessions(context, ref);
-    if (sessions != null) {
-      security.add(sessions);
-    }
+    // FIXME: disabled until this flow actually works well
+    // final sessions = renderSessions(context, ref);
+    // if (sessions != null) {
+    //   security.add(sessions);
+    // }
 
     final invitations = renderInvitations(context, ref);
     if (invitations != null && invitations.isNotEmpty) {


### PR DESCRIPTION
as it doesn't reliably work, it is just a nuisance to the users. Instead we want to push for the encryption key backup going forward.

![image](https://github.com/user-attachments/assets/737888ad-6054-404f-a752-03bd43b9ae76)
