### PR TITLE
Fixes boost action dialog not closing issue in iOS

### DIFF
--- a/app/lib/features/news/pages/add_news_page.dart
+++ b/app/lib/features/news/pages/add_news_page.dart
@@ -205,6 +205,7 @@ class AddNewsState extends ConsumerState<AddNewsPage> {
   void selectActionItemDialog(BuildContext buildContext) {
     showAdaptiveDialog(
       context: context,
+      barrierDismissible: true,
       builder: (context) {
         final lang = L10n.of(context);
         return AlertDialog.adaptive(


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3-meta/issues/250

Reference:


https://github.com/user-attachments/assets/dfcd475f-2363-4c63-bb7e-856afd2f7551

