### PR TITLE
Generic info API for Activities (with tests)

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2201,12 +2201,26 @@ object MembershipChange {
 
 
 object Activity {
+    // generic
+
+    /// the event_id as a string
+    fn event_id_str() -> string;
+    /// the sender of this event as a string
+    fn sender_id_str() -> string;
+
+    /// the server receiving timestamp in milliseconds
+    fn origin_server_ts() -> u64;
+
+    /// the room_id of this event
+    fn room_id_str() -> string;
+
     /// the type of this activity as a string
     /// e.g. invited, invitationAccepted
     fn type_str() -> string;
 
     /// the details of this membership change activity
     fn membership_change() -> Option<MembershipChange>;
+
 
 }
 

--- a/native/acter/src/api/activities.rs
+++ b/native/acter/src/api/activities.rs
@@ -12,6 +12,8 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use super::{Client, RUNTIME};
 
+#[cfg(any(test, feature = "testing"))]
+use acter_core::activities::ActivityContent;
 #[derive(Clone, Debug)]
 pub struct MembershipChange(CoreMembershipChange);
 
@@ -38,12 +40,28 @@ pub struct Activity {
 
 impl Activity {
     #[cfg(any(test, feature = "testing"))]
-    pub fn inner(&self) -> CoreActivity {
-        self.inner.clone()
+    pub fn content(&self) -> &ActivityContent {
+        self.inner.content()
     }
 
     pub fn membership_change(&self) -> Option<MembershipChange> {
         self.inner.membership_change().map(MembershipChange)
+    }
+
+    pub fn sender_id_str(&self) -> String {
+        self.inner.event_meta().sender.to_string()
+    }
+
+    pub fn origin_server_ts(&self) -> u64 {
+        self.inner.event_meta().origin_server_ts.get().into()
+    }
+
+    pub fn room_id_str(&self) -> String {
+        self.inner.event_meta().room_id.to_string()
+    }
+
+    pub fn event_id_str(&self) -> String {
+        self.inner.event_meta().event_id.to_string()
     }
 }
 

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -25657,6 +25657,46 @@ class Api {
       _MembershipChangeReasonReturn Function(
         int,
       )>();
+  late final _activityEventIdStrPtr = _lookup<
+      ffi.NativeFunction<
+          _ActivityEventIdStrReturn Function(
+            ffi.IntPtr,
+          )>>("__Activity_event_id_str");
+
+  late final _activityEventIdStr = _activityEventIdStrPtr.asFunction<
+      _ActivityEventIdStrReturn Function(
+        int,
+      )>();
+  late final _activitySenderIdStrPtr = _lookup<
+      ffi.NativeFunction<
+          _ActivitySenderIdStrReturn Function(
+            ffi.IntPtr,
+          )>>("__Activity_sender_id_str");
+
+  late final _activitySenderIdStr = _activitySenderIdStrPtr.asFunction<
+      _ActivitySenderIdStrReturn Function(
+        int,
+      )>();
+  late final _activityOriginServerTsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Uint64 Function(
+            ffi.IntPtr,
+          )>>("__Activity_origin_server_ts");
+
+  late final _activityOriginServerTs = _activityOriginServerTsPtr.asFunction<
+      int Function(
+        int,
+      )>();
+  late final _activityRoomIdStrPtr = _lookup<
+      ffi.NativeFunction<
+          _ActivityRoomIdStrReturn Function(
+            ffi.IntPtr,
+          )>>("__Activity_room_id_str");
+
+  late final _activityRoomIdStr = _activityRoomIdStrPtr.asFunction<
+      _ActivityRoomIdStrReturn Function(
+        int,
+      )>();
   late final _activityTypeStrPtr = _lookup<
       ffi.NativeFunction<
           _ActivityTypeStrReturn Function(
@@ -53237,6 +53277,108 @@ class Activity {
 
   Activity._(this._api, this._box);
 
+  /// the event_id as a string
+  String eventIdStr() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._activityEventIdStr(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// the sender of this event as a string
+  String senderIdStr() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._activitySenderIdStr(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// the server receiving timestamp in milliseconds
+  int originServerTs() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._activityOriginServerTs(
+      tmp0,
+    );
+    final tmp3 = tmp1;
+    final tmp2 = tmp3;
+    return tmp2;
+  }
+
+  /// the room_id of this event
+  String roomIdStr() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._activityRoomIdStr(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
   /// the type of this activity as a string
   /// e.g. invited, invitationAccepted
   String typeStr() {
@@ -66229,6 +66371,33 @@ class _MembershipChangeReasonReturn extends ffi.Struct {
   external int arg2;
   @ffi.UintPtr()
   external int arg3;
+}
+
+class _ActivityEventIdStrReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _ActivitySenderIdStrReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _ActivityRoomIdStrReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
 }
 
 class _ActivityTypeStrReturn extends ffi.Struct {


### PR DESCRIPTION
As it says on the tin: expose the meta event info of an event via the API. Fully covered by tests