### PR TITLE
fix global keys used twice when switching bottom nav / side bar view

### DIFF
--- a/app/lib/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart
+++ b/app/lib/common/tutorial_dialogs/bottom_navigation_tutorials/bottom_navigation_tutorials.dart
@@ -7,11 +7,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
-final dashboardKey = GlobalKey(debugLabel: 'dashboard');
-final updateKey = GlobalKey(debugLabel: 'updae');
-final chatsKey = GlobalKey(debugLabel: 'chats');
-final activityKey = GlobalKey(debugLabel: 'activities');
-final jumpToKey = GlobalKey(debugLabel: 'jump to key');
+// Keys for Sidebar navigation
+final sidebarDashboardKey = GlobalKey(debugLabel: 'sidebar-dashboard');
+final sidebarUpdateKey = GlobalKey(debugLabel: 'sidebar-update');
+final sidebarChatsKey = GlobalKey(debugLabel: 'sidebar-chats');
+final sidebarActivityKey = GlobalKey(debugLabel: 'sidebar-activities');
+final sidebarJumpToKey = GlobalKey(debugLabel: 'sidebar-jump-to');
+
+// Keys for Bottom navigation
+final bottomDashboardKey = GlobalKey(debugLabel: 'bottom-dashboard');
+final bottomUpdateKey = GlobalKey(debugLabel: 'bottom-update');
+final bottomChatsKey = GlobalKey(debugLabel: 'bottom-chats');
+final bottomActivityKey = GlobalKey(debugLabel: 'bottom-activities');
+final bottomJumpToKey = GlobalKey(debugLabel: 'bottom-jump-to');
 
 const bottomNavigationPrefKey = 'bottomNavigationPrefKey';
 
@@ -47,7 +55,7 @@ void bottomNavigationTutorials({required BuildContext context}) async {
       targets: [
         targetFocus(
           identify: 'dashboardKey',
-          keyTarget: dashboardKey,
+          keyTarget: bottomDashboardKey,
           contentAlign: isDesktop ? ContentAlign.right : ContentAlign.top,
           contentImageUrl: 'assets/images/empty_home.svg',
           contentTitle: lang.homeTabTutorialTitle,
@@ -57,7 +65,7 @@ void bottomNavigationTutorials({required BuildContext context}) async {
         if (!isDesktop)
           targetFocus(
             identify: 'updateKey',
-            keyTarget: updateKey,
+            keyTarget: bottomUpdateKey,
             contentAlign: ContentAlign.top,
             contentImageUrl: 'assets/images/empty_updates.svg',
             contentTitle: lang.updatesTabTutorialTitle,
@@ -65,7 +73,7 @@ void bottomNavigationTutorials({required BuildContext context}) async {
           ),
         targetFocus(
           identify: 'chatsKey',
-          keyTarget: chatsKey,
+          keyTarget: bottomChatsKey,
           contentAlign: isDesktop ? ContentAlign.right : ContentAlign.top,
           contentImageUrl: 'assets/images/empty_chat.svg',
           contentTitle: lang.chatsTabTutorialTitle,
@@ -73,7 +81,7 @@ void bottomNavigationTutorials({required BuildContext context}) async {
         ),
         targetFocus(
           identify: 'activityKey',
-          keyTarget: activityKey,
+          keyTarget: bottomActivityKey,
           contentAlign: isDesktop ? ContentAlign.right : ContentAlign.top,
           contentImageUrl: 'assets/images/empty_activity.svg',
           contentTitle: lang.activityTabTutorialTitle,
@@ -81,7 +89,7 @@ void bottomNavigationTutorials({required BuildContext context}) async {
         ),
         targetFocus(
           identify: 'jumpToKey',
-          keyTarget: jumpToKey,
+          keyTarget: bottomJumpToKey,
           contentAlign: isDesktop ? ContentAlign.right : ContentAlign.top,
           iconData: Icons.search,
           contentTitle: lang.jumpToTabTutorialTitle,

--- a/app/lib/features/home/providers/navigation.dart
+++ b/app/lib/features/home/providers/navigation.dart
@@ -23,7 +23,7 @@ final bottomBarItems = [
     ),
     label: 'Dashboard',
     initialLocation: Routes.dashboard.route,
-    tutorialGlobalKey: dashboardKey,
+    tutorialGlobalKey: bottomDashboardKey,
   ),
   BottomBarNavigationItem(
     icon: const Icon(
@@ -39,14 +39,14 @@ final bottomBarItems = [
     ),
     label: 'Updates',
     initialLocation: Routes.updates.route,
-    tutorialGlobalKey: updateKey,
+    tutorialGlobalKey: bottomUpdateKey,
   ),
   BottomBarNavigationItem(
     icon: const ChatsIcon(),
     activeIcon: const CustomSelectedIcon(icon: ChatsIcon()),
     label: 'Chat',
     initialLocation: Routes.chat.route,
-    tutorialGlobalKey: chatsKey,
+    tutorialGlobalKey: bottomChatsKey,
   ),
   BottomBarNavigationItem(
     icon: const ActivitiesIcon(),
@@ -55,7 +55,7 @@ final bottomBarItems = [
     ),
     label: 'Activities',
     initialLocation: Routes.activities.route,
-    tutorialGlobalKey: activityKey,
+    tutorialGlobalKey: bottomActivityKey,
   ),
   BottomBarNavigationItem(
     icon: const Icon(
@@ -70,6 +70,6 @@ final bottomBarItems = [
     ),
     label: 'Search',
     initialLocation: Routes.search.route,
-    tutorialGlobalKey: jumpToKey,
+    tutorialGlobalKey: bottomJumpToKey,
   ),
 ];

--- a/app/lib/features/home/widgets/sidebar_widget.dart
+++ b/app/lib/features/home/widgets/sidebar_widget.dart
@@ -375,7 +375,7 @@ class SidebarWidget extends ConsumerWidget {
           softWrap: false,
         ),
         onTap: () => goToBranch(ShellBranch.searchShell),
-        tutorialGlobalKey: jumpToKey,
+        tutorialGlobalKey: sidebarJumpToKey,
         indicator: const _SidebarItemIndicator(routes: [Routes.search]),
       ),
       _SidebarItem(
@@ -390,7 +390,7 @@ class SidebarWidget extends ConsumerWidget {
           softWrap: false,
         ),
         onTap: () => goToBranch(ShellBranch.homeShell),
-        tutorialGlobalKey: dashboardKey,
+        tutorialGlobalKey: sidebarDashboardKey,
         indicator: const _SidebarItemIndicator(
           reversed: true,
           routes: [
@@ -409,7 +409,7 @@ class SidebarWidget extends ConsumerWidget {
         ),
         onTap: () => goToBranch(ShellBranch.chatsShell),
         indicator: const _SidebarItemIndicator(routes: [Routes.chat]),
-        tutorialGlobalKey: chatsKey,
+        tutorialGlobalKey: sidebarChatsKey,
       ),
       _SidebarItem(
         icon: const ActivitiesIcon(),
@@ -429,7 +429,7 @@ class SidebarWidget extends ConsumerWidget {
         ),
         onTap: () => goToBranch(ShellBranch.activitiesShell),
         indicator: const _SidebarItemIndicator(routes: [Routes.activities]),
-        tutorialGlobalKey: activityKey,
+        tutorialGlobalKey: sidebarActivityKey,
       ),
     ];
   }
@@ -445,6 +445,7 @@ class SidebarWidget extends ConsumerWidget {
           ref.watch(parentAvatarInfosProvider(roomId)).valueOrNull;
 
       return _SidebarItem(
+        tutorialGlobalKey: ValueKey('space-sidebar-$roomId'),
         icon: ActerAvatar(
           options: AvatarOptions(
             AvatarInfo(


### PR DESCRIPTION
- Coming the sentry log exceptions `Multiple widgets used same GlobalKeys` when switching to bottom navigation / sidebar view, this fixes by assigning separate global keys to each navigation handlers to ensure we don't pass it simultaneously in one frame of UI.

```
════════ Exception caught by widgets library ═══════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
Multiple widgets used the same GlobalKey.
The key [GlobalKey#141be chats] was used by 2 widgets:
    : SizedBox-[GlobalKey#141be chats]
        width: 40.0
        height: 40.0
        renderObject: RenderConstrainedBox#d6097 relayoutBoundary=up10
    : Container-[GlobalKey#141be chats]
        constraints: BoxConstraints(w=40.0, h=40.0)
        margin: EdgeInsets(12.0, 8.0, 12.0, 8.0)
The key [GlobalKey#7132c activities] was used by 2 widgets:
    : SizedBox-[GlobalKey#7132c activities]
        width: 40.0
        height: 40.0
        renderObject: RenderConstrainedBox#f4fc8 relayoutBoundary=up10
    : Container-[GlobalKey#7132c activities]
        constraints: BoxConstraints(w=40.0, h=40.0)
        margin: EdgeInsets(12.0, 8.0, 12.0, 8.0)
The key [GlobalKey#b4642 dashboard] was used by 2 widgets:
    : SizedBox-[GlobalKey#b4642 dashboard]
        width: 40.0
        height: 40.0
        renderObject: RenderConstrainedBox#b97d7 relayoutBoundary=up10
    : Container-[GlobalKey#b4642 dashboard]
        constraints: BoxConstraints(w=40.0, h=40.0)
        margin: EdgeInsets(12.0, 8.0, 12.0, 8.0)
The key [GlobalKey#9ed91 jump to key] was used by 2 widgets:
    : SizedBox-[GlobalKey#9ed91 jump to key]
        width: 40.0
        height: 40.0
        renderObject: RenderConstrainedBox#fd5e3 relayoutBoundary=up10
    : Container-[GlobalKey#9ed91 jump to key]
        constraints: BoxConstraints(w=40.0, h=40.0)
        margin: EdgeInsets(12.0, 8.0, 12.0, 8.0)
A GlobalKey can only be specified on one widget at a time in the widget tree.
```

## Fix Preview:

### Before when throwing exception:

https://github.com/user-attachments/assets/5554a0ac-7d4a-4cd7-aeaf-f3f5dbdd95e2

### After :

https://github.com/user-attachments/assets/f4a7f683-ad4f-4bd1-9a4a-6f6065f4d4f2



