### PR TITLE
Solve Boost UI issue

### DIFF
--- a/.changes/2605-boost-loading-error-ui.md
+++ b/.changes/2605-boost-loading-error-ui.md
@@ -1,1 +1,1 @@
-- [Fix] - Resolve UI rendering issue on Space Detail and Boost List pages during media reload.
+- [Fix] - Resolve Boost List UI rendering issue on Space Detail when Image/video failed to load content.

--- a/.changes/2605-boost-loading-error-ui.md
+++ b/.changes/2605-boost-loading-error-ui.md
@@ -1,0 +1,1 @@
+- [Fix] - Resolve UI rendering issue on Space Detail and Boost List pages during media reload.

--- a/app/lib/common/toolkit/errors/util.dart
+++ b/app/lib/common/toolkit/errors/util.dart
@@ -20,7 +20,7 @@ enum ErrorCode {
   }
 }
 
-enum NewsLoadingState{
+enum NewsMediaErrorState{
   showErrorImageOnly,
   showErrorImageWithText,
   showErrorWithTryAgain,

--- a/app/lib/common/toolkit/errors/util.dart
+++ b/app/lib/common/toolkit/errors/util.dart
@@ -19,3 +19,9 @@ enum ErrorCode {
     return ErrorCode.other;
   }
 }
+
+enum NewsLoadingState{
+  showErrorImageOnly,
+  showErrorImageWithText,
+  showErrorWithTryAgain,
+}

--- a/app/lib/features/news/widgets/news_grid_view.dart
+++ b/app/lib/features/news/widgets/news_grid_view.dart
@@ -57,7 +57,7 @@ class NewsGridView extends StatelessWidget {
       margin: const EdgeInsets.all(6),
       child: Stack(
         children: [
-          NewsSlideItem(slide: slide, showRichContent: false, errorState: NewsLoadingState.showErrorImageWithText,),
+          NewsSlideItem(slide: slide, showRichContent: false, errorState: NewsMediaErrorState.showErrorImageWithText,),
           if (slideCount > 1) slideStackCountView(slideCount),
           newsPostTime(newsEntry.originServerTs()),
         ],

--- a/app/lib/features/news/widgets/news_grid_view.dart
+++ b/app/lib/features/news/widgets/news_grid_view.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:acter/common/extensions/options.dart';
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/widgets/news_item/news_post_time_widget.dart';
 import 'package:acter/features/news/widgets/news_item_slide/news_slide_item.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -56,7 +57,7 @@ class NewsGridView extends StatelessWidget {
       margin: const EdgeInsets.all(6),
       child: Stack(
         children: [
-          NewsSlideItem(slide: slide, showRichContent: false),
+          NewsSlideItem(slide: slide, showRichContent: false, errorState: NewsLoadingState.showErrorImageWithText,),
           if (slideCount > 1) slideStackCountView(slideCount),
           newsPostTime(newsEntry.originServerTs()),
         ],

--- a/app/lib/features/news/widgets/news_item/news_item.dart
+++ b/app/lib/features/news/widgets/news_item/news_item.dart
@@ -1,5 +1,6 @@
 import 'dart:core';
 
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/common/widgets/space_name_widget.dart';
 import 'package:acter/features/news/widgets/news_item/news_post_time_widget.dart';
 import 'package:acter/features/news/widgets/news_item/news_side_bar.dart';
@@ -64,7 +65,7 @@ class _NewsItemState extends ConsumerState<NewsItem> {
       itemCount: slides.length,
       preloadPagesCount: slides.length,
       onPageChanged: (page) =>  currentSlideIndex.value = page,
-      itemBuilder: (context, index) => NewsSlideItem(slide: slides[index]),
+      itemBuilder: (context, index) => NewsSlideItem(slide: slides[index],errorState: NewsLoadingState.showErrorWithTryAgain,),
     );
   }
 

--- a/app/lib/features/news/widgets/news_item/news_item.dart
+++ b/app/lib/features/news/widgets/news_item/news_item.dart
@@ -65,7 +65,7 @@ class _NewsItemState extends ConsumerState<NewsItem> {
       itemCount: slides.length,
       preloadPagesCount: slides.length,
       onPageChanged: (page) =>  currentSlideIndex.value = page,
-      itemBuilder: (context, index) => NewsSlideItem(slide: slides[index],errorState: NewsLoadingState.showErrorWithTryAgain,),
+      itemBuilder: (context, index) => NewsSlideItem(slide: slides[index],errorState: NewsMediaErrorState.showErrorWithTryAgain,),
     );
   }
 

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/model/keys.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -11,10 +12,12 @@ final _log = Logger('a3::news::image_slide');
 
 class ImageSlide extends StatefulWidget {
   final NewsSlide slide;
+  final NewsLoadingState errorState;  // Add the enum as a parameter
 
   const ImageSlide({
     super.key,
     required this.slide,
+    required this.errorState,
   });
 
   @override
@@ -73,29 +76,56 @@ class _ImageSlideState extends State<ImageSlide> {
     StackTrace? stackTrace,
   ) {
     _log.severe('Failed to load image of slide', error, stackTrace);
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            PhosphorIcons.imageBroken(),
-            size: 100,
-          ),
-          SizedBox(height: 10),
-          Text(L10n.of(context).unableToLoadImage),
-          SizedBox(height: 20),
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.white, width: 1),
-              borderRadius: const BorderRadius.all(Radius.circular(10)),
-            ),
-            child: TextButton(
-              onPressed: () => setState(() {}),
-              child: Text(L10n.of(context).tryAgain),
-            ),
-          ),
-        ],
+
+    Widget errorIcon = Icon(
+      PhosphorIcons.imageBroken(),
+      size: 100,
+    );
+
+    Widget errorText = Text(
+      L10n.of(context).unableToLoadImage,
+    );
+
+    Widget tryAgainButton = Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.white, width: 1),
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: TextButton(
+        onPressed: () {
+          setState(() {}); // Trigger reload of the image
+        },
+        child: Text(L10n.of(context).tryAgain,),
       ),
     );
+
+    switch (widget.errorState) {
+      case NewsLoadingState.showErrorImageOnly:
+        return Center(child: errorIcon);
+      case NewsLoadingState.showErrorImageWithText:
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              errorIcon,
+              SizedBox(height: 10),
+              errorText,
+            ],
+          ),
+        );
+      case NewsLoadingState.showErrorWithTryAgain:
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              errorIcon,
+              SizedBox(height: 10),
+              errorText,
+              SizedBox(height: 20),
+              tryAgainButton,
+            ],
+          ),
+        );
+    }
   }
 }

--- a/app/lib/features/news/widgets/news_item_slide/image_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/image_slide.dart
@@ -2,9 +2,9 @@ import 'dart:typed_data';
 
 import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/model/keys.dart';
+import 'package:acter/features/news/widgets/news_item_slide/news_media_error_widget.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:logging/logging.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -12,7 +12,7 @@ final _log = Logger('a3::news::image_slide');
 
 class ImageSlide extends StatefulWidget {
   final NewsSlide slide;
-  final NewsLoadingState errorState;  // Add the enum as a parameter
+  final NewsMediaErrorState errorState;  // Add the enum as a parameter
 
   const ImageSlide({
     super.key,
@@ -77,55 +77,12 @@ class _ImageSlideState extends State<ImageSlide> {
   ) {
     _log.severe('Failed to load image of slide', error, stackTrace);
 
-    Widget errorIcon = Icon(
-      PhosphorIcons.imageBroken(),
-      size: 100,
+    return NewsMediaErrorWidget(
+      errorState: widget.errorState,
+      onTryAgain: () {
+        setState(() {}); // Trigger reload of the image
+      },
+      mediaType: widget.slide.typeStr(),  // Specify it's an image
     );
-
-    Widget errorText = Text(
-      L10n.of(context).unableToLoadImage,
-    );
-
-    Widget tryAgainButton = Container(
-      decoration: BoxDecoration(
-        border: Border.all(color: Colors.white, width: 1),
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
-      ),
-      child: TextButton(
-        onPressed: () {
-          setState(() {}); // Trigger reload of the image
-        },
-        child: Text(L10n.of(context).tryAgain,),
-      ),
-    );
-
-    switch (widget.errorState) {
-      case NewsLoadingState.showErrorImageOnly:
-        return Center(child: errorIcon);
-      case NewsLoadingState.showErrorImageWithText:
-        return Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              errorIcon,
-              SizedBox(height: 10),
-              errorText,
-            ],
-          ),
-        );
-      case NewsLoadingState.showErrorWithTryAgain:
-        return Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              errorIcon,
-              SizedBox(height: 10),
-              errorText,
-              SizedBox(height: 20),
-              tryAgainButton,
-            ],
-          ),
-        );
-    }
   }
 }

--- a/app/lib/features/news/widgets/news_item_slide/news_media_error_widget.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_media_error_widget.dart
@@ -28,13 +28,21 @@ class NewsMediaErrorWidget extends StatelessWidget {
       errorText = Text(
         L10n.of(context).unableToLoadImage,
       );
-    } else {
+    } else if(mediaType == 'video'){
       errorIcon = Icon(
         Icons.videocam_off_outlined,
         size: 100,
       );
       errorText = Text(
         L10n.of(context).unableToLoadVideo,
+      );
+    }else{
+      errorIcon = Icon(
+        Icons.file_download_off,
+        size: 100,
+      );
+      errorText = Text(
+        L10n.of(context).unableToLoadFile,
       );
     }
 

--- a/app/lib/features/news/widgets/news_item_slide/news_media_error_widget.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_media_error_widget.dart
@@ -1,0 +1,82 @@
+import 'package:acter/common/toolkit/errors/util.dart';
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+class NewsMediaErrorWidget extends StatelessWidget {
+  final NewsMediaErrorState errorState;
+  final VoidCallback onTryAgain;
+  final String mediaType;
+
+  const NewsMediaErrorWidget({
+    super.key,
+    required this.errorState,
+    required this.onTryAgain,
+    required this.mediaType,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget errorIcon;
+    Widget errorText;
+
+    if (mediaType == 'image') {
+      errorIcon = Icon(
+        PhosphorIcons.imageBroken(),
+        size: 100,
+      );
+      errorText = Text(
+        L10n.of(context).unableToLoadImage,
+      );
+    } else {
+      errorIcon = Icon(
+        Icons.videocam_off_outlined,
+        size: 100,
+      );
+      errorText = Text(
+        L10n.of(context).unableToLoadVideo,
+      );
+    }
+
+    // Try again button
+    Widget tryAgainButton = Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.white, width: 1),
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: TextButton(
+        onPressed: onTryAgain,
+        child: Text(L10n.of(context).tryAgain),
+      ),
+    );
+
+    switch (errorState) {
+      case NewsMediaErrorState.showErrorImageOnly:
+        return Center(child: errorIcon);
+      case NewsMediaErrorState.showErrorImageWithText:
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              errorIcon,
+              SizedBox(height: 10),
+              errorText,
+            ],
+          ),
+        );
+      case NewsMediaErrorState.showErrorWithTryAgain:
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              errorIcon,
+              SizedBox(height: 10),
+              errorText,
+              SizedBox(height: 20),
+              tryAgainButton,
+            ],
+          ),
+        );
+    }
+  }
+}

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_item.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_item.dart
@@ -1,3 +1,4 @@
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/news_utils/news_utils.dart';
 import 'package:acter/features/news/widgets/news_item_slide/image_slide.dart';
 import 'package:acter/features/news/widgets/news_item_slide/news_slide_actions.dart';
@@ -10,11 +11,13 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 class NewsSlideItem extends StatelessWidget {
   final NewsSlide slide;
   final bool showRichContent;
+  final NewsLoadingState errorState;
 
   const NewsSlideItem({
     super.key,
     required this.slide,
     this.showRichContent = true,
+    required this.errorState,
   });
 
   @override
@@ -32,8 +35,8 @@ class NewsSlideItem extends StatelessWidget {
           child: Container(
             color: slideBackgroundColor,
             child: switch (slideType) {
-              'image' => ImageSlide(slide: slide),
-              'video' => VideoSlide(slide: slide),
+              'image' => ImageSlide(slide: slide,errorState: errorState,),
+              'video' => VideoSlide(slide: slide,errorState: errorState,),
               'text' =>
                 showRichContent ? TextSlide(slide: slide) : normalTextSlide(),
               _ => notSupportedSlide(context, slideType),

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_item.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_item.dart
@@ -11,7 +11,7 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 class NewsSlideItem extends StatelessWidget {
   final NewsSlide slide;
   final bool showRichContent;
-  final NewsLoadingState errorState;
+  final NewsMediaErrorState errorState;
 
   const NewsSlideItem({
     super.key,

--- a/app/lib/features/news/widgets/news_item_slide/video_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/video_slide.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/common/widgets/acter_video_player.dart';
 import 'package:acter/features/news/model/keys.dart';
+import 'package:acter/features/news/widgets/news_item_slide/news_media_error_widget.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -14,7 +15,7 @@ final _log = Logger('a3::news::video_slide');
 
 class VideoSlide extends StatefulWidget {
   final NewsSlide slide;
-  final NewsLoadingState errorState; // Add the enum as a parameter
+  final NewsMediaErrorState errorState; // Add the enum as a parameter
 
   const VideoSlide({
     super.key,
@@ -87,57 +88,12 @@ class _VideoSlideState extends State<VideoSlide> {
   ) {
     _log.severe('Failed to load video of slide', error, stackTrace);
 
-    Widget errorIcon = Icon(
-      Icons.videocam_off_outlined,
-      size: 100,
+    return NewsMediaErrorWidget(
+      errorState: widget.errorState,
+      onTryAgain: () {
+        setState(() {}); // Trigger reload of the image
+      },
+      mediaType: widget.slide.typeStr(),  // Specify it's an image
     );
-
-    Widget errorText = Text(
-      L10n.of(context).unableToLoadVideo,
-    );
-
-    Widget tryAgainButton = Container(
-      decoration: BoxDecoration(
-        border: Border.all(color: Colors.white, width: 1),
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
-      ),
-      child: TextButton(
-        onPressed: () {
-          setState(() {}); // Trigger reload of the image
-        },
-        child: Text(
-          L10n.of(context).tryAgain,
-        ),
-      ),
-    );
-
-    switch (widget.errorState) {
-      case NewsLoadingState.showErrorImageOnly:
-        return Center(child: errorIcon);
-      case NewsLoadingState.showErrorImageWithText:
-        return Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              errorIcon,
-              SizedBox(height: 10),
-              errorText,
-            ],
-          ),
-        );
-      case NewsLoadingState.showErrorWithTryAgain:
-        return Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              errorIcon,
-              SizedBox(height: 10),
-              errorText,
-              SizedBox(height: 20),
-              tryAgainButton,
-            ],
-          ),
-        );
-    }
   }
 }

--- a/app/lib/features/news/widgets/news_item_slide/video_slide.dart
+++ b/app/lib/features/news/widgets/news_item_slide/video_slide.dart
@@ -5,7 +5,6 @@ import 'package:acter/features/news/model/keys.dart';
 import 'package:acter/features/news/widgets/news_item_slide/news_media_error_widget.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';

--- a/app/lib/features/space/widgets/space_sections/news_section.dart
+++ b/app/lib/features/space/widgets/space_sections/news_section.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/common/utils/routes.dart';
 import 'package:acter/features/news/providers/news_providers.dart';
 import 'package:acter/features/news/widgets/news_item_slide/news_slide_item.dart';
@@ -101,6 +102,7 @@ class NewsSection extends ConsumerWidget {
         child: NewsSlideItem(
           slide: slide,
           showRichContent: false,
+          errorState: NewsLoadingState.showErrorImageOnly,
         ),
       ),
     );

--- a/app/lib/features/space/widgets/space_sections/news_section.dart
+++ b/app/lib/features/space/widgets/space_sections/news_section.dart
@@ -102,7 +102,7 @@ class NewsSection extends ConsumerWidget {
         child: NewsSlideItem(
           slide: slide,
           showRichContent: false,
-          errorState: NewsLoadingState.showErrorImageOnly,
+          errorState: NewsMediaErrorState.showErrorImageOnly,
         ),
       ),
     );

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2344,5 +2344,6 @@
   "tryAgain": "Try Again",
   "unableToLoadVideo": "Unable to load video",
   "unableToLoadImage": "Unable to load image",
+  "unableToLoadFile": "Unable to load file",
   "@addComment": {}
 }

--- a/app/test/features/news/image_slide_widget_test.dart
+++ b/app/test/features/news/image_slide_widget_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/widgets/news_item_slide/image_slide.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -31,7 +32,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageOnly,)),
         ),
       );
 
@@ -47,7 +48,33 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(PhosphorIcons.imageBroken()), findsOneWidget);
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageWithText,)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unable to load image'), findsOneWidget);
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorWithTryAgain,)),
         ),
       );
 
@@ -61,7 +88,7 @@ void main() {
       await tester.tap(find.byType(TextButton));
       await tester.pumpAndSettle(); // Wait for the widget to rebuild
 
-      verify(() => mockSlide.sourceBinary(null)).called(2); // Called twice (1 for the initial error, 1 for retry)
+      verify(() => mockSlide.sourceBinary(null)).called(4);
     });
 
     testWidgets('shows image UI when data loading is successful',
@@ -80,7 +107,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: ImageSlide(slide: mockSlide)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
         ),
       );
 

--- a/app/test/features/news/image_slide_widget_test.dart
+++ b/app/test/features/news/image_slide_widget_test.dart
@@ -32,7 +32,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: ImageSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageOnly,)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide,errorState: NewsMediaErrorState.showErrorImageOnly,)),
         ),
       );
 
@@ -48,7 +48,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsMediaErrorState.showErrorImageOnly,)),
         ),
       );
 
@@ -61,7 +61,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageWithText,)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsMediaErrorState.showErrorImageWithText,)),
         ),
       );
 
@@ -74,7 +74,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorWithTryAgain,)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsMediaErrorState.showErrorWithTryAgain,)),
         ),
       );
 
@@ -107,7 +107,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
+          home: Scaffold(body: ImageSlide(slide: mockSlide, errorState: NewsMediaErrorState.showErrorImageOnly,)),
         ),
       );
 

--- a/app/test/features/news/image_slide_widget_test.dart
+++ b/app/test/features/news/image_slide_widget_test.dart
@@ -44,6 +44,8 @@ void main() {
         (tester) async {
       when(() => mockSlide.sourceBinary(null))
           .thenAnswer((_) async => Future.error('Failed to load image'));
+      // Mock the typeStr method to return a valid string
+      when(() => mockSlide.typeStr()).thenReturn('image');
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(

--- a/app/test/features/news/video_slide_widget_test.dart
+++ b/app/test/features/news/video_slide_widget_test.dart
@@ -32,7 +32,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: VideoSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide, errorState: NewsMediaErrorState.showErrorImageOnly,)),
         ),
       );
 
@@ -48,7 +48,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageOnly,)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsMediaErrorState.showErrorImageOnly,)),
         ),
       );
 
@@ -61,7 +61,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageWithText,)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsMediaErrorState.showErrorImageWithText,)),
         ),
       );
 
@@ -74,7 +74,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorWithTryAgain,)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsMediaErrorState.showErrorWithTryAgain,)),
         ),
       );
 

--- a/app/test/features/news/video_slide_widget_test.dart
+++ b/app/test/features/news/video_slide_widget_test.dart
@@ -44,6 +44,8 @@ void main() {
         (tester) async {
       when(() => mockSlide.sourceBinary(null))
           .thenAnswer((_) async => Future.error('Failed to load video'));
+      // Mock the typeStr method to return a valid string
+      when(() => mockSlide.typeStr()).thenReturn('video');
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(

--- a/app/test/features/news/video_slide_widget_test.dart
+++ b/app/test/features/news/video_slide_widget_test.dart
@@ -1,4 +1,5 @@
 
+import 'package:acter/common/toolkit/errors/util.dart';
 import 'package:acter/features/news/widgets/news_item_slide/video_slide.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
@@ -31,7 +32,7 @@ void main() {
       // Build the widget
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: VideoSlide(slide: mockSlide)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide, errorState: NewsLoadingState.showErrorImageOnly,)),
         ),
       );
 
@@ -47,7 +48,33 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: L10n.localizationsDelegates,
-          home: Scaffold(body: VideoSlide(slide: mockSlide)),
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageOnly,)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.videocam_off_outlined), findsOneWidget);
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorImageWithText,)),
+        ),
+      );
+
+      // Wait for Future to complete
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unable to load video'), findsOneWidget);
+
+      // Build the widget
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          home: Scaffold(body: VideoSlide(slide: mockSlide,errorState: NewsLoadingState.showErrorWithTryAgain,)),
         ),
       );
 
@@ -61,7 +88,7 @@ void main() {
       await tester.tap(find.byType(TextButton));
       await tester.pumpAndSettle(); // Wait for the widget to rebuild
 
-      verify(() => mockSlide.sourceBinary(null)).called(2); // Called twice (1 for the initial error, 1 for retry)
+      verify(() => mockSlide.sourceBinary(null)).called(4); // Called twice (1 for the initial error, 1 for retry)
     });
   });
 }


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2603

This update addresses UI issues related to media loading on the Space Detail page and Boost Grid view:

### 1. In case of any media loaded failure, an error image will be displayed, and the text "Unable to load image/video" will appear.

### Reference image ( Boost Grid View ) :
![finalboostgridview](https://github.com/user-attachments/assets/fd6efce6-8d0c-4799-83f2-993701954526)

### 2. If media fails to load in the news slide, a "Try Again" button will be shown, allowing users to attempt reloading the content.

### Reference image ( Boost Image View ):
![finalboostview](https://github.com/user-attachments/assets/594f41da-5ec8-485a-bcde-7643a80bb377)

### Reference video ( Boost Video View ) :
![finalboostvideoview](https://github.com/user-attachments/assets/de7e9d6e-040c-4a03-a740-ba6d6f45807f)

### 3. If media fails to load in the space detail page, it will now only display an error image.

### Reference Image ( Space Detail View ) :
![finalspacedetailboostview](https://github.com/user-attachments/assets/8e2d3b50-2de5-4dea-9fd5-e3fd2fc3e08c)
