### PR TITLE
Solved manage button issue of Invite Page.

### DIFF
--- a/.changes/2629-manage-button-issue-resolved.md
+++ b/.changes/2629-manage-button-issue-resolved.md
@@ -1,0 +1,1 @@
+ - [Fix] : Resolved issue with 'Manage' button not opening Edit Invite Code on the Invite Page.

--- a/app/lib/features/invite_members/widgets/invite_code_ui.dart
+++ b/app/lib/features/invite_members/widgets/invite_code_ui.dart
@@ -123,11 +123,10 @@ class _InviteCodeUIState extends ConsumerState<InviteCodeUI> {
           alignment: Alignment.centerRight,
           child: ActerInlineTextButton(
             onPressed: () async {
-              final token =
-                  await ref.read(superInviteTokenProvider(inviteCode).future);
+              final token = await ref.read(superInviteTokenProvider(inviteCode).future);
               if (!context.mounted) return;
               context.pushNamed(
-                Routes.actionCreateSuperInvite.name,
+                Routes.createSuperInvite.name,
                 extra: token,
               );
             },


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2625,

This PR resolves the routing issue that prevented access to the 'Manage' button for opening the Edit Invite Page.

Reference video : 

https://github.com/user-attachments/assets/c13832c8-9777-493f-b7f3-97096e121d94

