### PR TITLE
Fix issue that sync callback is started twice

### DIFF
--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -5,8 +5,11 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/models/sync_state/sync_state.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
+import 'package:logging/logging.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+
+final _log = Logger('a3::common::sync_notifier');
 
 // ignore_for_file: avoid_print
 class SyncNotifier extends Notifier<SyncState> {
@@ -69,6 +72,7 @@ class SyncNotifier extends Notifier<SyncState> {
     _syncPoller?.cancel();
     _errorPoller?.cancel();
 
+    _log.info('================= startSync ====================');
     final sync = syncState = client.startSync();
 
     _syncListener = sync.firstSyncedRx(); // keep it resident in memory

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -26,7 +26,7 @@ class SyncNotifier extends Notifier<SyncState> {
   @override
   SyncState build() {
     _providerSubscription = ref.listen<AsyncValue<ffi.Client?>>(
-      alwaysClientProvider,
+      clientProvider,
       (AsyncValue<ffi.Client?>? oldVal, AsyncValue<ffi.Client?> newVal) {
         final newClient = newVal.valueOrNull;
         if (newClient == null) {

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -39,10 +39,10 @@ class SyncNotifier extends Notifier<SyncState> {
         // hack unfortunately means we have two wait a bit but that means
         // we get past the threshold where it is okay to schedule...
         client = newClient;
-        Future.delayed(
-          const Duration(milliseconds: 1500),
-          () => _restartSync(),
-        );
+        Future.delayed(const Duration(milliseconds: 1500), () {
+          _log.info('**************** _restartSync 1 *****************');
+          _restartSync();
+        });
       },
       fireImmediately: true,
     );
@@ -54,13 +54,17 @@ class SyncNotifier extends Notifier<SyncState> {
     state.countDown.map(
       (countDown) {
         if (countDown == 0) {
+          _log.info('**************** _restartSync 2 *****************');
           _restartSync();
         } else {
           // just count down.
           state = state.copyWith(countDown: countDown - 1);
         }
       },
-      orElse: () => _restartSync(),
+      orElse: () {
+        _log.info('**************** _restartSync 3 *****************');
+        _restartSync();
+      },
     );
   }
 


### PR DESCRIPTION
I found that sync callback is started twice.
This affects the initial loading time and probably may occur app crash due to too frequent mutex locks.