### PR TITLE
showReedemTokenDialog added for super invite action.

### DIFF
--- a/.changes/2647-redeem-token-dialog-added.md
+++ b/.changes/2647-redeem-token-dialog-added.md
@@ -1,1 +1,1 @@
-- [improvement] : If user don't own the code, they can now redeem it directly instead of copying it.
+- [improvement] : Simplified invite code redemption from some-one clicks on invite code from Boost Action post.

--- a/.changes/2647-redeem-token-dialog-added.md
+++ b/.changes/2647-redeem-token-dialog-added.md
@@ -1,0 +1,1 @@
+- [improvement] : If user don't own the code, they can now redeem it directly instead of copying it.

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
@@ -5,6 +5,7 @@ import 'package:acter/common/widgets/room/room_card.dart';
 import 'package:acter/features/events/widgets/event_item.dart';
 import 'package:acter/features/news/model/news_references_model.dart';
 import 'package:acter/features/pins/widgets/pin_list_item_widget.dart';
+import 'package:acter/features/super_invites/dialogs/redeem_dialog.dart';
 import 'package:acter/features/super_invites/providers/super_invites_providers.dart';
 import 'package:acter/features/tasks/widgets/task_list_item_card.dart';
 import 'package:acter/router/utils.dart';
@@ -144,8 +145,11 @@ class NewsSlideActions extends ConsumerWidget {
               extra: token,
             );
           } catch (e) {
-            await Clipboard.setData(ClipboardData(text: title));
-            EasyLoading.showToast(lang.messageCopiedToClipboard);
+            await showReedemTokenDialog(
+              context,
+              ref,
+              title,
+            );
           }
         },
         title: Text(

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
@@ -12,8 +12,6 @@ import 'package:acter/router/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -129,7 +127,6 @@ class NewsSlideActions extends ConsumerWidget {
     WidgetRef ref,
     RefDetails referenceDetails,
   ) {
-    final lang = L10n.of(context);
     final title = referenceDetails.title();
     if (title == null) return SizedBox.shrink();
     return Card(


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2645

Added a feature that allows users to directly redeem codes without needing to copy them if the user does not own the code. This simplifies the process and improves the user experience.

Reference Video :

https://github.com/user-attachments/assets/7575b4a4-a681-4980-96ab-db105080ed40