### PR TITLE
Ensure always client and sync runs only onces

### DIFF
--- a/.changes/2651.md
+++ b/.changes/2651.md
@@ -1,0 +1,1 @@
+- Fix double sync on startup which caused freezes and delayed execution for some people.

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -38,7 +38,7 @@ class SyncNotifier extends Notifier<SyncState> {
         client = newClient;
         Future.delayed(
           const Duration(milliseconds: 1500),
-          () => _restartSync(),
+          () => restartSync(),
         );
       },
       fireImmediately: true,
@@ -51,17 +51,17 @@ class SyncNotifier extends Notifier<SyncState> {
     state.countDown.map(
       (countDown) {
         if (countDown == 0) {
-          _restartSync();
+          restartSync();
         } else {
           // just count down.
           state = state.copyWith(countDown: countDown - 1);
         }
       },
-      orElse: () => _restartSync(),
+      orElse: () => restartSync(),
     );
   }
 
-  void _restartSync() {
+  void restartSync() {
     // reset states
     syncState?.cancel();
     _retryTimer?.cancel();

--- a/app/lib/features/home/providers/notifiers/always_client_notifier.dart
+++ b/app/lib/features/home/providers/notifiers/always_client_notifier.dart
@@ -32,6 +32,10 @@ class AlwaysClientNotifier extends AsyncNotifier<Client> {
         // we need to update to the new value
         state = AsyncData(newClient);
       }
+    } else if (old?.valueOrNull != null) {
+      // we had a value previously, but now we don't, go back to endlessly
+      // pending to stop all dependents in their track.
+      state = AsyncValue.loading();
     }
   }
 }

--- a/app/test/common/providers/client_providers_test.dart
+++ b/app/test/common/providers/client_providers_test.dart
@@ -90,5 +90,48 @@ void main() {
       expect(container.read(alwaysClientProvider).isLoading, true);
       await tester.pumpAndSettle();
     });
+
+    testWidgets('syncs with delay', (tester) async {
+      final provider = MockClientNotifier(client: null);
+      final syncNotifier = MockSyncNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          // no client
+          clientProvider.overrideWith(() => provider),
+          syncStateProvider.overrideWith(() => syncNotifier),
+        ],
+      );
+      expect(syncNotifier.clientSet, 0);
+      final cl = MockClient();
+      container.read(clientProvider);
+      provider.state = AsyncValue.data(cl);
+      expect(syncNotifier.restarted, 0);
+      expect(syncNotifier.clientSet, 0);
+      await tester.pumpAndSettle();
+      expect(container.read(isSyncingStateProvider), true); // read again
+      expect(syncNotifier.restarted, 0); // no sync yet
+      await tester
+          .pumpAndSettle(Duration(seconds: 3)); // sync state takes a moment;
+      expect(container.read(isSyncingStateProvider), true); // read again
+      expect(syncNotifier.restarted, 1);
+      expect(syncNotifier.clientSet, 1);
+    });
+
+    testWidgets('always client only sets once upon start', (tester) async {
+      final cl = MockClient();
+      final provider = PendingUntilFoundMockClientNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          // no client
+          clientProvider.overrideWith(() => provider),
+        ],
+      );
+      expect(container.read(alwaysClientProvider).isLoading, true);
+      int called = 0;
+      container.listen(alwaysClientProvider, (p, a) => called += 1);
+      provider.setClient(cl);
+      await tester.pumpAndSettle();
+      expect(called, 1);
+    });
   });
 }

--- a/app/test/common/providers/client_providers_test.dart
+++ b/app/test/common/providers/client_providers_test.dart
@@ -42,6 +42,7 @@ void main() {
       final cl = MockClient();
 
       provider.state = AsyncValue.data(cl);
+      await tester.pumpAndSettle();
       expect(container.read(alwaysClientProvider).isLoading, false);
       expect(container.read(alwaysClientProvider).value, cl);
 
@@ -63,6 +64,7 @@ void main() {
       final cl = MockClient();
 
       provider.state = AsyncValue.data(cl);
+      await tester.pumpAndSettle();
       expect(container.read(alwaysClientProvider).isLoading, false);
       expect(container.read(alwaysClientProvider).value, cl);
 
@@ -81,6 +83,7 @@ void main() {
 
       // user logs out, no client left
       provider.state = AsyncValue.data(null);
+      await tester.pumpAndSettle();
       expect(container.read(alwaysClientProvider).isLoading, true);
       await container.pump();
       await expectLater(

--- a/app/test/helpers/mock_client_provider.dart
+++ b/app/test/helpers/mock_client_provider.dart
@@ -1,17 +1,56 @@
 import 'dart:async';
 
+import 'package:acter/common/providers/notifiers/sync_notifier.dart';
 import 'package:acter/features/home/providers/notifiers/client_notifier.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
 import 'package:mocktail/mocktail.dart';
 import 'package:riverpod/riverpod.dart';
 
-class MockClientNotifier extends AsyncNotifier<Client?>
+class MockClientNotifier extends AsyncNotifier<ffi.Client?>
     with Mock
     implements ClientNotifier {
-  final Client? client;
+  final ffi.Client? client;
 
   MockClientNotifier({required this.client});
 
   @override
-  FutureOr<Client?> build() => client;
+  FutureOr<ffi.Client?> build() => client;
+}
+
+class PendingUntilFoundMockClientNotifier extends AsyncNotifier<ffi.Client?>
+    with Mock
+    implements ClientNotifier {
+  late Completer<ffi.Client> completer;
+
+  PendingUntilFoundMockClientNotifier() {
+    completer = Completer();
+  }
+
+  @override
+  FutureOr<ffi.Client?> build() => completer.future;
+
+  @override
+  void setClient(ffi.Client? client) {
+    completer.complete(client!);
+  }
+}
+
+class MockSyncNotifier extends SyncNotifier {
+  int restarted = 0;
+  int clientSet = 0;
+  ffi.Client? _client;
+
+  @override
+  set client(ffi.Client? value) {
+    clientSet += 1;
+    _client;
+  }
+
+  @override
+  ffi.Client get client => _client!;
+
+  @override
+  void restartSync() {
+    restarted += 1;
+  }
 }


### PR DESCRIPTION
The assumption of `alwaysClientProvider` is that it is only triggered _once_ per client. However, upon startup, under specific circumstances, we actually set it twice for the very first client created. This trickles down and leads to a double sync, which we believe is a problem for some users and leads to freeze and white UI screens.

This was due to a problem in the way the provider tried to early-quit and handle the completer future in those cases, leading to it being set once via the callback, but then also through the completing future. There are several tests added in e1234fdd5fc5e771507708659d9466c8ac8d8f30 , most notably the last one is able to show the problem by proofing it is being set twice. df5959613f209a92c53f4292426919d2dd6a841e fixes the problem by _always_ returning the future and _never_ setting the state if there is still a future pending but only completing that. Only sets the state locally if there is no more completer from `build` pending.

An additional debug sessions showed that https://github.com/acterglobal/a3/blob/df5959613f209a92c53f4292426919d2dd6a841e/app/lib/common/providers/notifiers/sync_notifier.dart#L38 which was called twice before the fix, is now only called once, as expected.


fixes https://github.com/acterglobal/a3-meta/issues/807, https://github.com/acterglobal/a3-meta/issues/804, https://github.com/acterglobal/a3-meta/issues/801, https://github.com/acterglobal/a3-meta/issues/800, https://github.com/acterglobal/a3-meta/issues/799, https://github.com/acterglobal/a3-meta/issues/798, https://github.com/acterglobal/a3-meta/issues/794