### PR TITLE
Fix bug that could not find replied_to event outside of page

### DIFF
--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -5,8 +5,11 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/models/sync_state/sync_state.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
+import 'package:logging/logging.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+
+final _log = Logger('a3::common::sync_notifier');
 
 // ignore_for_file: avoid_print
 class SyncNotifier extends Notifier<SyncState> {
@@ -69,6 +72,7 @@ class SyncNotifier extends Notifier<SyncState> {
     _syncPoller?.cancel();
     _errorPoller?.cancel();
 
+    _log.info('================= startSync ====================');
     final sync = syncState = client.startSync();
 
     _syncListener = sync.firstSyncedRx(); // keep it resident in memory

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -26,7 +26,7 @@ class SyncNotifier extends Notifier<SyncState> {
   @override
   SyncState build() {
     _providerSubscription = ref.listen<AsyncValue<ffi.Client?>>(
-      alwaysClientProvider,
+      clientProvider,
       (AsyncValue<ffi.Client?>? oldVal, AsyncValue<ffi.Client?> newVal) {
         final newClient = newVal.valueOrNull;
         if (newClient == null) {

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -5,11 +5,8 @@ import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/models/sync_state/sync_state.dart';
 import 'package:acter/features/home/providers/client_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' as ffi;
-import 'package:logging/logging.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
-
-final _log = Logger('a3::common::sync_notifier');
 
 // ignore_for_file: avoid_print
 class SyncNotifier extends Notifier<SyncState> {
@@ -72,7 +69,6 @@ class SyncNotifier extends Notifier<SyncState> {
     _syncPoller?.cancel();
     _errorPoller?.cancel();
 
-    _log.info('================= startSync ====================');
     final sync = syncState = client.startSync();
 
     _syncListener = sync.firstSyncedRx(); // keep it resident in memory

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -26,7 +26,7 @@ class SyncNotifier extends Notifier<SyncState> {
   @override
   SyncState build() {
     _providerSubscription = ref.listen<AsyncValue<ffi.Client?>>(
-      clientProvider,
+      alwaysClientProvider,
       (AsyncValue<ffi.Client?>? oldVal, AsyncValue<ffi.Client?> newVal) {
         final newClient = newVal.valueOrNull;
         if (newClient == null) {

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -39,10 +39,10 @@ class SyncNotifier extends Notifier<SyncState> {
         // hack unfortunately means we have two wait a bit but that means
         // we get past the threshold where it is okay to schedule...
         client = newClient;
-        Future.delayed(
-          const Duration(milliseconds: 1500),
-          () => _restartSync(),
-        );
+        Future.delayed(const Duration(milliseconds: 1500), () {
+          _log.info('**************** _restartSync 1 *****************');
+          _restartSync();
+        });
       },
       fireImmediately: true,
     );
@@ -54,13 +54,17 @@ class SyncNotifier extends Notifier<SyncState> {
     state.countDown.map(
       (countDown) {
         if (countDown == 0) {
+          _log.info('**************** _restartSync 2 *****************');
           _restartSync();
         } else {
           // just count down.
           state = state.copyWith(countDown: countDown - 1);
         }
       },
-      orElse: () => _restartSync(),
+      orElse: () {
+        _log.info('**************** _restartSync 3 *****************');
+        _restartSync();
+      },
     );
   }
 

--- a/app/lib/common/providers/notifiers/sync_notifier.dart
+++ b/app/lib/common/providers/notifiers/sync_notifier.dart
@@ -39,10 +39,10 @@ class SyncNotifier extends Notifier<SyncState> {
         // hack unfortunately means we have two wait a bit but that means
         // we get past the threshold where it is okay to schedule...
         client = newClient;
-        Future.delayed(const Duration(milliseconds: 1500), () {
-          _log.info('**************** _restartSync 1 *****************');
-          _restartSync();
-        });
+        Future.delayed(
+          const Duration(milliseconds: 1500),
+          () => _restartSync(),
+        );
       },
       fireImmediately: true,
     );
@@ -54,17 +54,13 @@ class SyncNotifier extends Notifier<SyncState> {
     state.countDown.map(
       (countDown) {
         if (countDown == 0) {
-          _log.info('**************** _restartSync 2 *****************');
           _restartSync();
         } else {
           // just count down.
           state = state.copyWith(countDown: countDown - 1);
         }
       },
-      orElse: () {
-        _log.info('**************** _restartSync 3 *****************');
-        _restartSync();
-      },
+      orElse: () => _restartSync(),
     );
   }
 

--- a/app/test/helpers/mock_chat_providers.dart
+++ b/app/test/helpers/mock_chat_providers.dart
@@ -12,6 +12,7 @@ import 'package:acter/features/chat/providers/notifiers/chat_room_notifier.dart'
 import 'package:acter/features/chat/providers/room_list_filter_provider.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_types/src/message.dart';
 import 'package:flutter_chat_types/src/messages/text_message.dart';
 import 'package:flutter_chat_types/src/preview_data.dart';
@@ -46,7 +47,11 @@ class MockChatRoomNotifier extends StateNotifier<ChatRoomState>
   }
 
   @override
-  Future<void> fetchOriginalContent(String originalId, String replyId) {
+  Future<void> fetchOriginalContent(
+    String originalId,
+    RoomMessage originalRoomMsg,
+    types.Message msg,
+  ) {
     // TODO: implement fetchOriginalContent
     throw UnimplementedError();
   }

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -989,6 +989,18 @@ object RoomEventItem {
     /// original event id, if this msg is reply to another msg
     fn in_reply_to() -> Option<string>;
 
+    /// original sender id, if this msg is reply to another msg
+    fn replied_to_sender() -> Option<string>;
+
+    /// original msg body, if this msg is reply to another msg
+    fn replied_to_body() -> Option<string>;
+
+    /// original msg type, if this msg is reply to another msg
+    fn replied_to_msgtype() -> Option<string>;
+
+    /// original msg content, if this msg is reply to another msg
+    fn replied_to_content() -> Option<MsgContent>;
+
     /// the list of users that read this message
     fn read_users() -> Vec<string>;
 

--- a/native/acter/src/api/message.rs
+++ b/native/acter/src/api/message.rs
@@ -8,8 +8,8 @@ use matrix_sdk_base::ruma::{
     OwnedEventId, OwnedTransactionId, OwnedUserId,
 };
 use matrix_sdk_ui::timeline::{
-    EventSendState as SdkEventSendState, EventTimelineItem, MembershipChange, TimelineEventItemId,
-    TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
+    EventSendState as SdkEventSendState, EventTimelineItem, MembershipChange, TimelineDetails,
+    TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -97,6 +97,14 @@ pub struct RoomEventItem {
     #[builder(default)]
     in_reply_to: Option<OwnedEventId>,
     #[builder(default)]
+    replied_to_sender: Option<OwnedUserId>,
+    #[builder(default)]
+    replied_to_body: Option<String>,
+    #[builder(default)]
+    replied_to_msgtype: Option<String>,
+    #[builder(default)]
+    replied_to_content: Option<MsgContent>,
+    #[builder(default)]
     read_receipts: IndexMap<String, Receipt>,
     #[builder(default)]
     reactions: IndexMap<String, Vec<ReactionRecord>>,
@@ -162,7 +170,27 @@ impl RoomEventItem {
                     _ => None,
                 });
                 if let Some(in_reply_to) = msg.in_reply_to() {
-                    me.in_reply_to(Some(in_reply_to.clone().event_id));
+                    me.in_reply_to(Some(in_reply_to.event_id.clone()));
+                    // fetch_details_for_event
+                    if let TimelineDetails::Ready(replied_to) = in_reply_to.event.clone() {
+                        me.replied_to_sender(Some(replied_to.sender().to_owned()));
+                        if let Some(m) = replied_to.content().as_message() {
+                            me.replied_to_body(Some(m.body().to_owned()));
+                            let msgtype = m.msgtype();
+                            me.replied_to_msgtype(Some(msgtype.msgtype().to_owned()));
+                            let content = match msgtype {
+                                MessageType::Text(content) => Some(MsgContent::from(content)),
+                                MessageType::Emote(content) => Some(MsgContent::from(content)),
+                                MessageType::Image(content) => Some(MsgContent::from(content)),
+                                MessageType::Audio(content) => Some(MsgContent::from(content)),
+                                MessageType::Video(content) => Some(MsgContent::from(content)),
+                                MessageType::File(content) => Some(MsgContent::from(content)),
+                                MessageType::Location(content) => Some(MsgContent::from(content)),
+                                _ => None,
+                            };
+                            me.replied_to_content(content);
+                        }
+                    }
                 }
                 me.edited(msg.is_edited());
             }
@@ -344,7 +372,23 @@ impl RoomEventItem {
     }
 
     pub fn in_reply_to(&self) -> Option<String> {
-        self.in_reply_to.as_ref().map(|x| x.to_string())
+        self.in_reply_to.as_ref().map(ToString::to_string)
+    }
+
+    pub fn replied_to_sender(&self) -> Option<String> {
+        self.replied_to_sender.as_ref().map(ToString::to_string)
+    }
+
+    pub fn replied_to_body(&self) -> Option<String> {
+        self.replied_to_body.clone()
+    }
+
+    pub fn replied_to_msgtype(&self) -> Option<String> {
+        self.replied_to_msgtype.clone()
+    }
+
+    pub fn replied_to_content(&self) -> Option<MsgContent> {
+        self.replied_to_content.clone()
     }
 
     pub fn read_users(&self) -> Vec<String> {

--- a/native/acter/src/api/utils.rs
+++ b/native/acter/src/api/utils.rs
@@ -1,10 +1,10 @@
 use matrix_sdk_ui::eyeball_im::VectorDiff;
 
 pub struct ApiVectorDiff<T> {
-    action: String,
-    values: Option<Vec<T>>,
-    index: Option<usize>,
-    value: Option<T>,
+    pub(crate) action: String,
+    pub(crate) values: Option<Vec<T>>,
+    pub(crate) index: Option<usize>,
+    pub(crate) value: Option<T>,
 }
 
 impl<T> ApiVectorDiff<T>

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -20935,6 +20935,50 @@ class Api {
       _RoomEventItemInReplyToReturn Function(
         int,
       )>();
+  late final _roomEventItemRepliedToSenderPtr = _lookup<
+      ffi.NativeFunction<
+          _RoomEventItemRepliedToSenderReturn Function(
+            ffi.IntPtr,
+          )>>("__RoomEventItem_replied_to_sender");
+
+  late final _roomEventItemRepliedToSender =
+      _roomEventItemRepliedToSenderPtr.asFunction<
+          _RoomEventItemRepliedToSenderReturn Function(
+            int,
+          )>();
+  late final _roomEventItemRepliedToBodyPtr = _lookup<
+      ffi.NativeFunction<
+          _RoomEventItemRepliedToBodyReturn Function(
+            ffi.IntPtr,
+          )>>("__RoomEventItem_replied_to_body");
+
+  late final _roomEventItemRepliedToBody =
+      _roomEventItemRepliedToBodyPtr.asFunction<
+          _RoomEventItemRepliedToBodyReturn Function(
+            int,
+          )>();
+  late final _roomEventItemRepliedToMsgtypePtr = _lookup<
+      ffi.NativeFunction<
+          _RoomEventItemRepliedToMsgtypeReturn Function(
+            ffi.IntPtr,
+          )>>("__RoomEventItem_replied_to_msgtype");
+
+  late final _roomEventItemRepliedToMsgtype =
+      _roomEventItemRepliedToMsgtypePtr.asFunction<
+          _RoomEventItemRepliedToMsgtypeReturn Function(
+            int,
+          )>();
+  late final _roomEventItemRepliedToContentPtr = _lookup<
+      ffi.NativeFunction<
+          _RoomEventItemRepliedToContentReturn Function(
+            ffi.IntPtr,
+          )>>("__RoomEventItem_replied_to_content");
+
+  late final _roomEventItemRepliedToContent =
+      _roomEventItemRepliedToContentPtr.asFunction<
+          _RoomEventItemRepliedToContentReturn Function(
+            int,
+          )>();
   late final _roomEventItemReadUsersPtr = _lookup<
       ffi.NativeFunction<
           ffi.IntPtr Function(
@@ -44351,6 +44395,127 @@ class RoomEventItem {
     return tmp2;
   }
 
+  /// original sender id, if this msg is reply to another msg
+  String? repliedToSender() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomEventItemRepliedToSender(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// original msg body, if this msg is reply to another msg
+  String? repliedToBody() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomEventItemRepliedToBody(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// original msg type, if this msg is reply to another msg
+  String? repliedToMsgtype() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomEventItemRepliedToMsgtype(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// original msg content, if this msg is reply to another msg
+  MsgContent? repliedToContent() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomEventItemRepliedToContent(
+      tmp0,
+    );
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_MsgContent");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = MsgContent._(_api, tmp4_1);
+    return tmp2;
+  }
+
   /// the list of users that read this message
   FfiListFfiString readUsers() {
     var tmp0 = 0;
@@ -65791,6 +65956,46 @@ class _RoomEventItemInReplyToReturn extends ffi.Struct {
   external int arg2;
   @ffi.UintPtr()
   external int arg3;
+}
+
+class _RoomEventItemRepliedToSenderReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomEventItemRepliedToBodyReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomEventItemRepliedToMsgtypeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomEventItemRepliedToContentReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
 }
 
 class _RoomEventItemReceiptTsReturn extends ffi.Struct {


### PR DESCRIPTION
We are facing this error log.
`[2025-02-26][13:42:37.387603][a3::chat::room_notifier][ERROR] Failing to load reference $eZQvskOrFiumOJhfHLtbNCjLH7vi8qAGV0037npDcOg (from $fsm-GcMno7rnqMOFmgpyZKEZsUGToPKKDDGSLNo3LWk) Event not found null`
Because original message in `replied_to` feature cannot be fetched.
Will fix it here.

Fixes [#meta-740](https://github.com/acterglobal/a3-meta/issues/740)