### PR TITLE
Fix encryption backup

### DIFF
--- a/.changes/26660-encryption-backup-fix.md
+++ b/.changes/26660-encryption-backup-fix.md
@@ -1,0 +1,1 @@
+- [Labs: Encryption Backup] fix for the backup not being published properly and reported as "incomplete" despite having fully completed

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -3,6 +3,7 @@ use anyhow::{bail, Context, Result};
 use lazy_static::lazy_static;
 use matrix_sdk::{
     authentication::matrix::{MatrixSession, MatrixSessionTokens},
+    encryption::{BackupDownloadStrategy, EncryptionSettings},
     reqwest::{ClientBuilder as ReqClientBuilder, StatusCode},
     Client as SdkClient, ClientBuilder as SdkClientBuilder,
 };
@@ -87,7 +88,12 @@ pub async fn make_client_config(
         db_passphrase,
         reset_if_existing,
     )
-    .await?;
+    .await?
+    .with_encryption_settings(EncryptionSettings {
+        auto_enable_cross_signing: true,
+        backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
+        auto_enable_backups: true,
+    });
 
     if let Some(proxy) = PROXY_URL.read().expect("Reading PROXY_URL failed").clone() {
         builder = builder.proxy(proxy);

--- a/native/acter/src/api/backup.rs
+++ b/native/acter/src/api/backup.rs
@@ -23,8 +23,9 @@ impl BackupManager {
         let inner = self.inner.clone();
         RUNTIME
             .spawn(async move {
+                inner.wait_for_e2ee_initialization_tasks().await;
                 let recovery = inner.recovery();
-                Ok(recovery.enable().await?)
+                Ok(recovery.enable().wait_for_backups_to_upload().await?)
             })
             .await?
     }

--- a/native/acter/src/testing.rs
+++ b/native/acter/src/testing.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use core::{future::Future, time::Duration};
 use matrix_sdk::config::RequestConfig;
+use matrix_sdk::encryption::{BackupDownloadStrategy, EncryptionSettings};
 use matrix_sdk::{Client as SdkClient, ClientBuilder};
 use matrix_sdk_base::store::StoreConfig;
 use tokio::time::sleep;
@@ -58,7 +59,12 @@ pub async fn default_client_config(
         .user_agent(user_agent)
         .store_config(store_cfg)
         .homeserver_url(homeserver)
-        .request_config(config);
+        .request_config(config)
+        .with_encryption_settings(EncryptionSettings {
+            auto_enable_cross_signing: true,
+            backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
+            auto_enable_backups: true,
+        });
     if let Some(http_proxy) = option_env!("HTTP_PROXY") {
         println!("Setting http proxy to {http_proxy}");
         builder = builder.proxy(http_proxy);

--- a/native/test/src/tests.rs
+++ b/native/test/src/tests.rs
@@ -1,5 +1,6 @@
 mod activities;
 mod auth;
+mod backup;
 mod blurhash;
 mod bookmarks;
 mod calendar;

--- a/native/test/src/tests/backup.rs
+++ b/native/test/src/tests/backup.rs
@@ -1,0 +1,144 @@
+use anyhow::{bail, Result};
+
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::{login_test_user, random_user_with_random_convo};
+
+#[tokio::test]
+async fn can_recover_and_read_message() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    // enable backup on a)
+    let (user_id, room_id, backup_pass) = {
+        let (mut user, room_id) = random_user_with_random_convo("recovering_message").await?;
+        let state_sync = user.start_sync();
+
+        // wait for sync to catch up
+        let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+        let fetcher_client = user.clone();
+        let target_id = room_id.clone();
+        Retry::spawn(retry_strategy.clone(), move || {
+            let client = fetcher_client.clone();
+            let room_id = target_id.clone();
+            async move { client.convo(room_id.to_string()).await }
+        })
+        .await?;
+
+        let convo = user.convo(room_id.to_string()).await?;
+        let timeline = convo.timeline_stream();
+
+        let draft = user.text_plain_draft("Hi, everyone".to_string());
+        timeline.send_message(Box::new(draft)).await?;
+
+        let convo_loader = convo.clone();
+
+        let msg = Retry::spawn(retry_strategy, move || {
+            let convo = convo_loader.clone();
+            async move {
+                let Some(msg) = convo.latest_message() else {
+                    bail!("No message found")
+                };
+                Ok(msg)
+            }
+        })
+        .await?;
+
+        assert_eq!(
+            msg.event_item()
+                .expect("has messsage")
+                .msg_content()
+                .expect("is message")
+                .body(),
+            "Hi, everyone"
+        );
+
+        let backup_manager = user.backup_manager();
+        let backup_pass = backup_manager.enable().await?;
+        assert_eq!(backup_manager.state_str(), "enabled");
+
+        // let's wind down
+        state_sync.cancel();
+        let user_id = user.user_id()?;
+        user.logout().await?;
+
+        // pass over for testing
+        (user_id, room_id, backup_pass)
+    };
+
+    // -- END setup
+
+    // now try to login and recover.
+
+    let mut user = login_test_user(user_id.localpart().to_string()).await?;
+
+    let _state_sync = user.start_sync();
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    let target_id = room_id.clone();
+    Retry::spawn(retry_strategy.clone(), move || {
+        let client = fetcher_client.clone();
+        let room_id = target_id.clone();
+        async move { client.convo(room_id.to_string()).await }
+    })
+    .await?;
+
+    let convo = user.convo(room_id.to_string()).await?;
+
+    let convo_loader = convo.clone();
+
+    let msg = Retry::spawn(retry_strategy.clone(), move || {
+        let convo = convo_loader.clone();
+        async move {
+            let Some(msg) = convo.latest_message() else {
+                bail!("No message found")
+            };
+            Ok(msg)
+        }
+    })
+    .await?;
+
+    // as expected: we can not read the message
+    assert_eq!(
+        msg.event_item().expect("exists").event_type(),
+        "m.room.encrypted"
+    );
+
+    // let's try to enable backuo
+    let backup = user.backup_manager();
+    backup.recover(backup_pass).await?;
+    assert_eq!(backup.state_str(), "enabled");
+
+    // and try again to read the message.
+
+    let convo_loader = convo.clone();
+    let msg = Retry::spawn(retry_strategy.clone(), move || {
+        let convo = convo_loader.clone();
+        async move {
+            let Some(msg) = convo.latest_message() else {
+                bail!("No message found")
+            };
+            if msg.event_item().expect("exists").event_type() == "m.room.encrypted" {
+                bail!("Message is still encrypted.")
+            }
+            Ok(msg)
+        }
+    })
+    .await?;
+
+    // as expected: we CAN read the message
+    assert_eq!(
+        msg.event_item()
+            .expect("has messsage")
+            .msg_content()
+            .expect("is message")
+            .body(),
+        "Hi, everyone" // WE CAN READ IT AGAIN
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
After a lot of debugging and fiddling and code reading (of the android version, as well as the matrix rust sdk tests), I am proud to preset: A fix for the "incomplete"-backup-state setting when using the recovery keys.

It comes with a test that shows the process and ensures the following properties:
1. logs in, sends a message to a channel,
2. creates a backup, ensures it is all enabled
3. drops the client, logs in again, syncs up
4. it can't read the old message
5. re-enables backup with the previous key, ensures the state is reported correctly
6. tries to read the message again: works!