### PR TITLE
Properly inline chat mention

### DIFF
--- a/.changes/2672-inlined-mentions.md
+++ b/.changes/2672-inlined-mentions.md
@@ -1,0 +1,1 @@
+- Chat: fix alignment of mentions to be properly inline and not break the reading flow

--- a/app/lib/common/toolkit/buttons/user_chip.dart
+++ b/app/lib/common/toolkit/buttons/user_chip.dart
@@ -1,5 +1,4 @@
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/toolkit/buttons/inline_text_button.dart';
 import 'package:acter/features/member/dialogs/show_member_info_drawer.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
@@ -20,18 +19,25 @@ class UserChip extends ConsumerWidget {
     final memberInfo = ref.watch(
       memberAvatarInfoProvider((roomId: roomId, userId: memberId)),
     );
-    final avatarSize = Theme.of(context).textTheme.bodySmall?.fontSize ?? 12.0;
+    final fontSize = Theme.of(context).textTheme.bodySmall?.fontSize ?? 12.0;
     return Tooltip(
       message: memberId,
-      child: ActerInlineTextButton.icon(
-        icon: ActerAvatar(
-          options: AvatarOptions.DM(
-            memberInfo,
-            size: avatarSize,
-          ),
+      child: InkWell(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ActerAvatar(
+              options: AvatarOptions.DM(
+                memberInfo,
+                size: fontSize / 2,
+              ),
+            ),
+            SizedBox(width: 4),
+            Text(memberInfo.displayName ?? memberId),
+            SizedBox(width: 4),
+          ],
         ),
-        label: Text(memberInfo.displayName ?? memberId),
-        onPressed: () async {
+        onTap: () async {
           await showMemberInfoDrawer(
             context: context,
             roomId: roomId,


### PR DESCRIPTION
Minor fix to remove the extra spacing around user mentions in the chat so that they don't increase the line-size but are actually "inlined":

![image](https://github.com/user-attachments/assets/44f2c659-f281-4f76-8085-f6f613dab22c)
