### PR TITLE
Activity Items : Replace emojis with Icons

### DIFF
--- a/app/lib/common/widgets/acter_icon_picker/utils.dart
+++ b/app/lib/common/widgets/acter_icon_picker/utils.dart
@@ -1,0 +1,50 @@
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/color_data.dart';
+import 'package:acter/features/pins/providers/pins_provider.dart';
+import 'package:acter/features/tasks/providers/tasklists_providers.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ActerIconWidgetFromObjectIdAndType extends ConsumerWidget {
+  final String? objectId;
+  final String? objectType;
+  final double? iconSize;
+  final Widget fallbackWidget;
+
+  const ActerIconWidgetFromObjectIdAndType({
+    super.key,
+    this.objectId,
+    this.objectType,
+    this.iconSize = 16,
+    required this.fallbackWidget,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (objectId == null || objectType == null) return fallbackWidget;
+
+    switch (objectType) {
+      case 'pin':
+        final pin = ref.watch(pinProvider(objectId!)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: iconSize,
+          color: convertColor(pin?.display()?.color(), iconPickerColors[0]),
+          icon: ActerIcon.iconForPin(pin?.display()?.iconStr()),
+        );
+      case 'task-list':
+        final taskList = ref.watch(taskListProvider(objectId!)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: iconSize,
+          color: convertColor(
+            taskList?.display()?.color(),
+            iconPickerColors[0],
+          ),
+          icon: ActerIcon.list,
+        );
+      default:
+        return fallbackWidget;
+    }
+  }
+}

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -104,7 +104,7 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
 
   IconData getActivityObjectIcon() {
     return switch (activityObject?.typeStr()) {
-      'news' => PhosphorIconsRegular.newspaper,
+      'news' => PhosphorIconsRegular.rocketLaunch,
       'story' => PhosphorIconsRegular.book,
       'event' => PhosphorIconsRegular.calendar,
       'pin' => PhosphorIconsRegular.pushPin,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -1,13 +1,17 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/features/comments/widgets/time_ago_widget.dart';
 import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 //Main container for all activity item widgets
 class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
+  final IconData actionIcon;
   final String actionTitle;
-  final String? actionObjectInfo;
+  final Color? actionIconColor;
+  final ActivityObject? activityObject;
   final String userId;
   final String roomId;
   final String? subtitle;
@@ -15,8 +19,10 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
 
   const ActivityUserCentricItemContainerWidget({
     super.key,
+    required this.actionIcon,
     required this.actionTitle,
-    this.actionObjectInfo,
+    this.actionIconColor,
+    this.activityObject,
     required this.userId,
     required this.roomId,
     this.subtitle,
@@ -50,31 +56,61 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.end,
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
+        Icon(actionIcon, size: 16, color: actionIconColor),
+        const SizedBox(width: 4),
         Text(actionTitle, style: actionTitleStyle),
-        if (actionObjectInfo != null) ...[
+        if (activityObject != null) ...[
           const SizedBox(width: 6),
-          Text(actionObjectInfo!, style: actionTitleStyle),
+          Row(
+            children: [
+              Icon(getActivityObjectIcon(), size: 16),
+              const SizedBox(width: 4),
+              Text(getActivityObjectTitle(), style: actionTitleStyle),
+            ],
+          ),
         ],
       ],
     );
   }
 
   Widget buildUserInfoUI(BuildContext context, WidgetRef ref) {
-    final memberInfo =
-        ref.watch(memberAvatarInfoProvider((roomId: roomId, userId: userId)));
+    final memberInfo = ref.watch(
+      memberAvatarInfoProvider((roomId: roomId, userId: userId)),
+    );
     return ListTile(
       horizontalTitleGap: 6,
       contentPadding: EdgeInsets.zero,
       leading: ActerAvatar(options: AvatarOptions.DM(memberInfo, size: 32)),
       title: Text(memberInfo.displayName ?? userId),
-      subtitle: subtitle != null
-          ? Text(
-              subtitle!,
-              style: Theme.of(context).textTheme.labelMedium,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            )
-          : const SizedBox.shrink(),
+      subtitle:
+          subtitle != null
+              ? Text(
+                subtitle!,
+                style: Theme.of(context).textTheme.labelMedium,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              )
+              : const SizedBox.shrink(),
     );
+  }
+
+  IconData getActivityObjectIcon() {
+    return switch (activityObject?.typeStr()) {
+      'news' => PhosphorIconsRegular.newspaper,
+      'story' => PhosphorIconsRegular.book,
+      'event' => PhosphorIconsRegular.calendar,
+      'pin' => PhosphorIconsRegular.pushPin,
+      'task-list' => PhosphorIconsRegular.listChecks,
+      'task' => PhosphorIconsRegular.check,
+      _ => PhosphorIconsRegular.question,
+    };
+  }
+
+  String getActivityObjectTitle() {
+    return switch (activityObject?.typeStr()) {
+      'news' => 'Boost',
+      'story' => 'Story',
+      _ => activityObject?.title() ?? '',
+    };
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -1,12 +1,7 @@
 import 'package:acter/common/providers/room_providers.dart';
-import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
-import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
-import 'package:acter/common/widgets/acter_icon_picker/model/color_data.dart';
+import 'package:acter/common/widgets/acter_icon_picker/utils.dart';
 import 'package:acter/features/comments/widgets/time_ago_widget.dart';
-import 'package:acter/features/pins/providers/pins_provider.dart';
-import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -76,7 +71,12 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
           ),
         ],
         Spacer(),
-        getActerIconWidget(ref),
+        ActerIconWidgetFromObjectIdAndType(
+          objectId: activityObject?.objectIdStr(),
+          objectType: activityObject?.typeStr(),
+          fallbackWidget: SizedBox.shrink(),
+          iconSize: 24,
+        ),
       ],
     );
   }
@@ -112,31 +112,5 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
       'story' => 'Story',
       _ => activityObject?.title() ?? '',
     };
-  }
-
-  Widget getActerIconWidget(WidgetRef ref) {
-    final objectId = activityObject?.objectIdStr();
-    if (objectId == null) return const SizedBox.shrink();
-    switch (activityObject?.typeStr()) {
-      case 'pin':
-        final pin = ref.watch(pinProvider(objectId)).valueOrNull;
-        return ActerIconWidget(
-          iconSize: 24,
-          color: convertColor(pin?.display()?.color(), iconPickerColors[0]),
-          icon: ActerIcon.iconForPin(pin?.display()?.iconStr()),
-        );
-      case 'task-list':
-        final taskList = ref.watch(taskListProvider(objectId)).valueOrNull;
-        return ActerIconWidget(
-          iconSize: 24,
-          color: convertColor(
-            taskList?.display()?.color(),
-            iconPickerColors[0],
-          ),
-          icon: ActerIcon.list,
-        );
-      default:
-        return const SizedBox.shrink();
-    }
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -101,7 +101,7 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
       'event' => PhosphorIconsRegular.calendar,
       'pin' => PhosphorIconsRegular.pushPin,
       'task-list' => PhosphorIconsRegular.listChecks,
-      'task' => PhosphorIconsRegular.check,
+      'task' => PhosphorIconsRegular.checkCircle,
       _ => PhosphorIconsRegular.question,
     };
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -20,7 +20,7 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
   final ActivityObject? activityObject;
   final String userId;
   final String roomId;
-  final String? subtitle;
+  final Widget? subtitle;
   final int originServerTs;
 
   const ActivityUserCentricItemContainerWidget({
@@ -90,15 +90,7 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
       contentPadding: EdgeInsets.zero,
       leading: ActerAvatar(options: AvatarOptions.DM(memberInfo, size: 32)),
       title: Text(memberInfo.displayName ?? userId),
-      subtitle:
-          subtitle != null
-              ? Text(
-                subtitle!,
-                style: Theme.of(context).textTheme.labelMedium,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              )
-              : const SizedBox.shrink(),
+      subtitle: subtitle ?? const SizedBox.shrink(),
     );
   }
 

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart
@@ -1,6 +1,12 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/color_data.dart';
 import 'package:acter/features/comments/widgets/time_ago_widget.dart';
+import 'package:acter/features/pins/providers/pins_provider.dart';
+import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:acter_avatar/acter_avatar.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -40,7 +46,7 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.end,
           mainAxisSize: MainAxisSize.min,
           children: [
-            buildActionInfoUI(context),
+            buildActionInfoUI(context, ref),
             const SizedBox(height: 6),
             buildUserInfoUI(context, ref),
             TimeAgoWidget(originServerTs: originServerTs),
@@ -50,10 +56,10 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
     );
   }
 
-  Widget buildActionInfoUI(BuildContext context) {
+  Widget buildActionInfoUI(BuildContext context, WidgetRef ref) {
     final actionTitleStyle = Theme.of(context).textTheme.labelMedium;
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         Icon(actionIcon, size: 16, color: actionIconColor),
@@ -69,6 +75,8 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
             ],
           ),
         ],
+        Spacer(),
+        getActerIconWidget(ref),
       ],
     );
   }
@@ -112,5 +120,31 @@ class ActivityUserCentricItemContainerWidget extends ConsumerWidget {
       'story' => 'Story',
       _ => activityObject?.title() ?? '',
     };
+  }
+
+  Widget getActerIconWidget(WidgetRef ref) {
+    final objectId = activityObject?.objectIdStr();
+    if (objectId == null) return const SizedBox.shrink();
+    switch (activityObject?.typeStr()) {
+      case 'pin':
+        final pin = ref.watch(pinProvider(objectId)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: 24,
+          color: convertColor(pin?.display()?.color(), iconPickerColors[0]),
+          icon: ActerIcon.iconForPin(pin?.display()?.iconStr()),
+        );
+      case 'task-list':
+        final taskList = ref.watch(taskListProvider(objectId)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: 24,
+          color: convertColor(
+            taskList?.display()?.color(),
+            iconPickerColors[0],
+          ),
+          icon: ActerIcon.list,
+        );
+      default:
+        return const SizedBox.shrink();
+    }
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
@@ -1,8 +1,8 @@
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivityAttachmentItemWidget extends StatelessWidget {
   final Activity activity;
@@ -13,13 +13,11 @@ class ActivityAttachmentItemWidget extends StatelessWidget {
     final activityObject = activity.object();
     final name = activity.name();
     final subType = activity.subTypeStr();
-    final objectEmoji = activityObject?.emoji();
-    final objectTitle = activityObject?.title();
 
     return ActivityUserCentricItemContainerWidget(
-      actionTitle:
-          '${PushStyles.attachment.emoji} ${L10n.of(context).addedAttachmentOn}',
-      actionObjectInfo: '$objectEmoji $objectTitle',
+      actionIcon: PhosphorIconsRegular.paperclip,
+      actionTitle: L10n.of(context).addedAttachmentOn,
+      activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       subtitle: '$subType : $name',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
@@ -20,7 +20,12 @@ class ActivityAttachmentItemWidget extends StatelessWidget {
       activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
-      subtitle: '$subType : $name',
+      subtitle: Text(
+        '$subType : $name',
+        style: Theme.of(context).textTheme.labelMedium,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
       originServerTs: activity.originServerTs(),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
@@ -1,8 +1,8 @@
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivityCommentItemWidget extends StatelessWidget {
   final Activity activity;
@@ -11,13 +11,11 @@ class ActivityCommentItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final activityObject = activity.object();
-    final objectEmoji = activityObject?.emoji();
-    final objectTitle = activityObject?.title();
 
     return ActivityUserCentricItemContainerWidget(
-      actionTitle:
-          '${PushStyles.comment.emoji} ${L10n.of(context).commentedOn}',
-      actionObjectInfo: '$objectEmoji $objectTitle',
+      actionIcon: PhosphorIconsRegular.chatCenteredDots,
+      actionTitle: L10n.of(context).commentedOn,
+      activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       subtitle: activity.msgContent()?.body() ?? '',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
@@ -18,7 +18,12 @@ class ActivityCommentItemWidget extends StatelessWidget {
       activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
-      subtitle: activity.msgContent()?.body() ?? '',
+      subtitle: Text(
+        activity.msgContent()?.body() ?? '',
+        style: Theme.of(context).textTheme.labelMedium,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
       originServerTs: activity.originServerTs(),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/reaction.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/reaction.dart
@@ -17,7 +17,6 @@ class ActivityReactionItemWidget extends StatelessWidget {
       activityObject: activity.object(),
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
-      subtitle: '',
       originServerTs: activity.originServerTs(),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/reaction.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/reaction.dart
@@ -1,8 +1,8 @@
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivityReactionItemWidget extends StatelessWidget {
   final Activity activity;
@@ -11,22 +11,14 @@ class ActivityReactionItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ActivityUserCentricItemContainerWidget(
-      actionTitle: '${PushStyles.reaction.emoji} ${L10n.of(context).reactedOn}',
-      actionObjectInfo: getObjectInfo(),
+      actionIcon: PhosphorIconsRegular.heart,
+      actionIconColor: Colors.red.shade400,
+      actionTitle: L10n.of(context).reactedOn,
+      activityObject: activity.object(),
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       subtitle: '',
       originServerTs: activity.originServerTs(),
     );
-  }
-
-  String getObjectInfo() {
-    final objectEmoji = activity.object()?.emoji();
-    final objectTitle = switch (activity.object()?.typeStr()) {
-      'news' => 'Boost',
-      'stories' => 'Story',
-      _ => activity.object()?.title(),
-    };
-    return '$objectEmoji $objectTitle';
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -1,11 +1,6 @@
-import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
-import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
-import 'package:acter/common/widgets/acter_icon_picker/model/color_data.dart';
+import 'package:acter/common/widgets/acter_icon_picker/utils.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart';
-import 'package:acter/features/pins/providers/pins_provider.dart';
-import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:acter/l10n/generated/l10n.dart';
-import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -70,44 +65,19 @@ class RefObjectWidget extends ConsumerWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        getRefIconWidget(context, ref),
+        ActerIconWidgetFromObjectIdAndType(
+          objectId: refDetails?.targetIdStr(),
+          objectType: refDetails?.typeStr(),
+          fallbackWidget: Icon(
+            objectDefaultIcon,
+            size: 16,
+            color: Theme.of(context).textTheme.labelMedium?.color,
+          ),
+        ),
         const SizedBox(width: 4),
         getRefTitleTextWidget(context),
       ],
     );
-  }
-
-  Widget getRefIconWidget(BuildContext context, WidgetRef ref) {
-    final defaultIconWidget = Icon(
-      objectDefaultIcon,
-      size: 16,
-      color: Theme.of(context).textTheme.labelMedium?.color,
-    );
-
-    final refObjectId = refDetails?.targetIdStr();
-    if (refObjectId == null) return defaultIconWidget;
-
-    switch (refDetails?.typeStr()) {
-      case 'pin':
-        final pin = ref.watch(pinProvider(refObjectId)).valueOrNull;
-        return ActerIconWidget(
-          iconSize: 16,
-          color: convertColor(pin?.display()?.color(), iconPickerColors[0]),
-          icon: ActerIcon.iconForPin(pin?.display()?.iconStr()),
-        );
-      case 'task-list':
-        final taskList = ref.watch(taskListProvider(refObjectId)).valueOrNull;
-        return ActerIconWidget(
-          iconSize: 16,
-          color: convertColor(
-            taskList?.display()?.color(),
-            iconPickerColors[0],
-          ),
-          icon: ActerIcon.list,
-        );
-      default:
-        return defaultIconWidget;
-    }
   }
 
   Widget getRefTitleTextWidget(BuildContext context) {

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -3,6 +3,7 @@ import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivityReferencesItemWidget extends StatelessWidget {
   final Activity activity;
@@ -11,13 +12,11 @@ class ActivityReferencesItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final activityObject = activity.object();
-    final objectEmoji = activityObject?.emoji();
-    final objectTitle = activityObject?.title();
 
     return ActivityUserCentricItemContainerWidget(
-      actionTitle:
-          '${PushStyles.references.emoji} ${L10n.of(context).addedReferencesOn}',
-      actionObjectInfo: '$objectEmoji $objectTitle',
+      actionIcon: PhosphorIconsRegular.link,
+      actionTitle: L10n.of(context).addedReferencesOn,
+      activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       subtitle: getRefPreview(),

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -73,6 +73,7 @@ class RefObjectWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     if (refDetails == null) return const SizedBox.shrink();
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         getRefIconWidget(context, ref),
         const SizedBox(width: 4),

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -83,8 +83,15 @@ class RefObjectWidget extends ConsumerWidget {
   }
 
   Widget getRefIconWidget(BuildContext context, WidgetRef ref) {
+    final defaultIconWidget = Icon(
+      objectDefaultIcon,
+      size: 16,
+      color: Theme.of(context).textTheme.labelMedium?.color,
+    );
+
     final refObjectId = refDetails?.targetIdStr();
-    if (refObjectId == null) return const SizedBox.shrink();
+    if (refObjectId == null) return defaultIconWidget;
+
     switch (refDetails?.typeStr()) {
       case 'pin':
         final pin = ref.watch(pinProvider(refObjectId)).valueOrNull;
@@ -104,11 +111,7 @@ class RefObjectWidget extends ConsumerWidget {
           icon: ActerIcon.list,
         );
       default:
-        return Icon(
-          objectDefaultIcon,
-          size: 16,
-          color: Theme.of(context).textTheme.labelMedium?.color,
-        );
+        return defaultIconWidget;
     }
   }
 

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -33,30 +33,25 @@ class ActivityReferencesItemWidget extends StatelessWidget {
   Widget? getRefObjectWidget(BuildContext context) {
     final refDetails = activity.refDetails();
     final refType = refDetails?.typeStr();
-    switch (refType) {
-      case 'pin':
-        return RefObjectWidget(
-          refDetails: refDetails,
-          objectDefaultIcon: PhosphorIconsRegular.pushPin,
-        );
-      case 'calendar-event':
-        return RefObjectWidget(
-          refDetails: refDetails,
-          objectDefaultIcon: PhosphorIconsRegular.calendar,
-        );
-      case 'task-list':
-        return RefObjectWidget(
-          refDetails: refDetails,
-          objectDefaultIcon: PhosphorIconsRegular.listChecks,
-        );
-      case 'task':
-        return RefObjectWidget(
-          refDetails: refDetails,
-          objectDefaultIcon: PhosphorIconsRegular.check,
-        );
-      default:
-        return null;
-    }
+    return switch (refType) {
+      'pin' => RefObjectWidget(
+        refDetails: refDetails,
+        objectDefaultIcon: PhosphorIconsRegular.pushPin,
+      ),
+      'calendar-event' => RefObjectWidget(
+        refDetails: refDetails,
+        objectDefaultIcon: PhosphorIconsRegular.calendar,
+      ),
+      'task-list' => RefObjectWidget(
+        refDetails: refDetails,
+        objectDefaultIcon: PhosphorIconsRegular.listChecks,
+      ),
+      'task' => RefObjectWidget(
+        refDetails: refDetails,
+        objectDefaultIcon: PhosphorIconsRegular.check,
+      ),
+      _ => null,
+    };
   }
 }
 

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -1,8 +1,14 @@
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/acter_icons.dart';
+import 'package:acter/common/widgets/acter_icon_picker/model/color_data.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_item_container_widgets.dart';
+import 'package:acter/features/pins/providers/pins_provider.dart';
+import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:acter/l10n/generated/l10n.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
-import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivityReferencesItemWidget extends StatelessWidget {
@@ -19,29 +25,100 @@ class ActivityReferencesItemWidget extends StatelessWidget {
       activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
-      subtitle: getRefPreview(),
+      subtitle: getRefObjectWidget(context),
       originServerTs: activity.originServerTs(),
     );
   }
 
-  String getRefPreview() {
+  Widget? getRefObjectWidget(BuildContext context) {
     final refDetails = activity.refDetails();
-    final refTitle = refDetails?.title();
     final refType = refDetails?.typeStr();
-    final objectType = SpaceObjectTypes.values.asNameMap()[refType];
-    switch (objectType) {
-      case SpaceObjectTypes.news:
-        return '${SpaceObjectTypes.news.emoji} $refTitle';
-      case SpaceObjectTypes.pin:
-        return '${SpaceObjectTypes.pin.emoji} $refTitle';
-      case SpaceObjectTypes.event:
-        return '${SpaceObjectTypes.event.emoji} $refTitle';
-      case SpaceObjectTypes.taskList:
-        return '${SpaceObjectTypes.taskList.emoji} $refTitle';
-      case SpaceObjectTypes.taskItem:
-        return '${SpaceObjectTypes.taskItem.emoji} $refTitle';
+    switch (refType) {
+      case 'pin':
+        return RefObjectWidget(
+          refDetails: refDetails,
+          objectDefaultIcon: PhosphorIconsRegular.pushPin,
+        );
+      case 'calendar-event':
+        return RefObjectWidget(
+          refDetails: refDetails,
+          objectDefaultIcon: PhosphorIconsRegular.calendar,
+        );
+      case 'task-list':
+        return RefObjectWidget(
+          refDetails: refDetails,
+          objectDefaultIcon: PhosphorIconsRegular.listChecks,
+        );
+      case 'task':
+        return RefObjectWidget(
+          refDetails: refDetails,
+          objectDefaultIcon: PhosphorIconsRegular.check,
+        );
       default:
-        return '${PushStyles.references.emoji} $refTitle';
+        return null;
     }
+  }
+}
+
+class RefObjectWidget extends ConsumerWidget {
+  final RefDetails? refDetails;
+  final IconData? objectDefaultIcon;
+  const RefObjectWidget({
+    super.key,
+    required this.refDetails,
+    this.objectDefaultIcon,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (refDetails == null) return const SizedBox.shrink();
+    return Row(
+      children: [
+        getRefIconWidget(context, ref),
+        const SizedBox(width: 4),
+        getRefTitleTextWidget(context),
+      ],
+    );
+  }
+
+  Widget getRefIconWidget(BuildContext context, WidgetRef ref) {
+    final refObjectId = refDetails?.targetIdStr();
+    if (refObjectId == null) return const SizedBox.shrink();
+    switch (refDetails?.typeStr()) {
+      case 'pin':
+        final pin = ref.watch(pinProvider(refObjectId)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: 16,
+          color: convertColor(pin?.display()?.color(), iconPickerColors[0]),
+          icon: ActerIcon.iconForPin(pin?.display()?.iconStr()),
+        );
+      case 'task-list':
+        final taskList = ref.watch(taskListProvider(refObjectId)).valueOrNull;
+        return ActerIconWidget(
+          iconSize: 16,
+          color: convertColor(
+            taskList?.display()?.color(),
+            iconPickerColors[0],
+          ),
+          icon: ActerIcon.list,
+        );
+      default:
+        return Icon(
+          objectDefaultIcon,
+          size: 16,
+          color: Theme.of(context).textTheme.labelMedium?.color,
+        );
+    }
+  }
+
+  Widget getRefTitleTextWidget(BuildContext context) {
+    final title = refDetails?.title();
+    if (title == null) return const SizedBox.shrink();
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.labelMedium,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
   }
 }

--- a/app/test/features/activity/item_widgets/activity_attachment_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_attachment_item_widget_test.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart';
 import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../common/mock_data/mock_avatar_info.dart';
 import '../../../helpers/test_util.dart';
@@ -17,10 +19,8 @@ void main() {
     await tester.pumpProviderWidget(
       overrides: [
         memberAvatarInfoProvider.overrideWith(
-          (ref, param) => MockAvatarInfo(
-            uniqueId: param.userId,
-            mockDisplayName: 'User-1',
-          ),
+          (ref, param) =>
+              MockAvatarInfo(uniqueId: param.userId, mockDisplayName: 'User-1'),
         ),
       ],
       child: Material(
@@ -37,21 +37,27 @@ void main() {
       mockName: 'budget.mp4',
       mockSubType: 'video',
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.pin.name,
-        mockEmoji: SpaceObjectTypes.pin.emoji,
+        mockType: 'pin',
+        mockEmoji: '📌',
         mockTitle: 'Pin Name',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.paperclip), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.attachment.emoji} Added attachment on'),
-      findsOneWidget,
-    );
+    expect(find.text('Added attachment on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.pushPin), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(find.text('${SpaceObjectTypes.pin.emoji} Pin Name'), findsOneWidget);
+    expect(find.text('Pin Name'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -66,24 +72,27 @@ void main() {
       mockSubType: 'video',
       mockType: PushStyles.attachment.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.event.name,
-        mockEmoji: SpaceObjectTypes.event.emoji,
+        mockType: 'event',
+        mockEmoji: '🗓️',
         mockTitle: 'Team Meeting',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.paperclip), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.attachment.emoji} Added attachment on'),
-      findsOneWidget,
-    );
+    expect(find.text('Added attachment on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.event.emoji} Team Meeting'),
-      findsOneWidget,
-    );
+    expect(find.text('Team Meeting'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -98,24 +107,27 @@ void main() {
       mockSubType: 'video',
       mockType: PushStyles.attachment.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskList.name,
-        mockEmoji: SpaceObjectTypes.taskList.emoji,
+        mockType: 'task-list',
+        mockEmoji: '📋',
         mockTitle: 'Project Tasks',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.paperclip), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.attachment.emoji} Added attachment on'),
-      findsOneWidget,
-    );
+    expect(find.text('Added attachment on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.listChecks), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskList.emoji} Project Tasks'),
-      findsOneWidget,
-    );
+    expect(find.text('Project Tasks'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -130,24 +142,27 @@ void main() {
       mockSubType: 'video',
       mockType: PushStyles.attachment.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskItem.name,
-        mockEmoji: SpaceObjectTypes.taskItem.emoji,
+        mockType: 'task',
+        mockEmoji: '☑️',
         mockTitle: 'Complete Documentation',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.paperclip), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.attachment.emoji} Added attachment on'),
-      findsOneWidget,
-    );
+    expect(find.text('Added attachment on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskItem.emoji} Complete Documentation'),
-      findsOneWidget,
-    );
+    expect(find.text('Complete Documentation'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);

--- a/app/test/features/activity/item_widgets/activity_attachment_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_attachment_item_widget_test.dart
@@ -156,7 +156,7 @@ void main() {
     expect(find.text('Added attachment on'), findsOneWidget);
 
     // Verify object icon
-    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+    expect(find.byIcon(PhosphorIconsRegular.checkCircle), findsAtLeast(1));
 
     // Verify Activity Object icon
     expect(find.byType(ActerIconWidget), findsNothing);

--- a/app/test/features/activity/item_widgets/activity_comment_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_comment_item_widget_test.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart';
 import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../common/mock_data/mock_avatar_info.dart';
 import '../../../helpers/test_util.dart';
@@ -18,10 +20,8 @@ void main() {
     await tester.pumpProviderWidget(
       overrides: [
         memberAvatarInfoProvider.overrideWith(
-          (ref, param) => MockAvatarInfo(
-            uniqueId: param.userId,
-            mockDisplayName: 'User-1',
-          ),
+          (ref, param) =>
+              MockAvatarInfo(uniqueId: param.userId, mockDisplayName: 'User-1'),
         ),
       ],
       child: Material(
@@ -39,21 +39,27 @@ void main() {
         bodyText: 'This is a comment on a pin object',
       ),
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.pin.name,
-        mockEmoji: SpaceObjectTypes.pin.emoji,
+        mockType: 'pin',
+        mockEmoji: '📌',
         mockTitle: 'Pin Name',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.chatCenteredDots), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.comment.emoji} Commented on'),
-      findsOneWidget,
-    );
+    expect(find.text('Commented on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.pushPin), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(find.text('${SpaceObjectTypes.pin.emoji} Pin Name'), findsOneWidget);
+    expect(find.text('Pin Name'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -65,28 +71,29 @@ void main() {
   testWidgets('Comment on Event Object', (tester) async {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.comment.name,
-      mockMsgContent: MockMsgContent(
-        bodyText: 'This is a comment on an event',
-      ),
+      mockMsgContent: MockMsgContent(bodyText: 'This is a comment on an event'),
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.event.name,
-        mockEmoji: SpaceObjectTypes.event.emoji,
+        mockType: 'event',
+        mockEmoji: '🗓️',
         mockTitle: 'Team Meeting',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.chatCenteredDots), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.comment.emoji} Commented on'),
-      findsOneWidget,
-    );
+    expect(find.text('Commented on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.event.emoji} Team Meeting'),
-      findsOneWidget,
-    );
+    expect(find.text('Team Meeting'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -102,24 +109,27 @@ void main() {
         bodyText: 'This is a comment on a task list',
       ),
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskList.name,
-        mockEmoji: SpaceObjectTypes.taskList.emoji,
+        mockType: 'task-list',
+        mockEmoji: '📋',
         mockTitle: 'Project Tasks',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.chatCenteredDots), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.comment.emoji} Commented on'),
-      findsOneWidget,
-    );
+    expect(find.text('Commented on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.listChecks), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskList.emoji} Project Tasks'),
-      findsOneWidget,
-    );
+    expect(find.text('Project Tasks'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -131,28 +141,29 @@ void main() {
   testWidgets('Comment on TaskItem Object', (tester) async {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.comment.name,
-      mockMsgContent: MockMsgContent(
-        bodyText: 'This is a comment on a task',
-      ),
+      mockMsgContent: MockMsgContent(bodyText: 'This is a comment on a task'),
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskItem.name,
-        mockEmoji: SpaceObjectTypes.taskItem.emoji,
+        mockType: 'task',
+        mockEmoji: '☑️',
         mockTitle: 'Complete Documentation',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.chatCenteredDots), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.comment.emoji} Commented on'),
-      findsOneWidget,
-    );
+    expect(find.text('Commented on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskItem.emoji} Complete Documentation'),
-      findsOneWidget,
-    );
+    expect(find.text('Complete Documentation'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -168,24 +179,27 @@ void main() {
         bodyText: 'This is a comment on a news item',
       ),
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.news.name,
-        mockEmoji: SpaceObjectTypes.news.emoji,
+        mockType: 'news',
+        mockEmoji: '🚀',
         mockTitle: 'Product Launch',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.chatCenteredDots), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.comment.emoji} Commented on'),
-      findsOneWidget,
-    );
+    expect(find.text('Commented on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.rocketLaunch), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.news.emoji} Product Launch'),
-      findsOneWidget,
-    );
+    expect(find.text('Boost'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);

--- a/app/test/features/activity/item_widgets/activity_comment_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_comment_item_widget_test.dart
@@ -157,7 +157,7 @@ void main() {
     expect(find.text('Commented on'), findsOneWidget);
 
     // Verify object icon
-    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+    expect(find.byIcon(PhosphorIconsRegular.checkCircle), findsAtLeast(1));
 
     // Verify Activity Object icon
     expect(find.byType(ActerIconWidget), findsNothing);

--- a/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
@@ -139,7 +139,7 @@ void main() {
     expect(find.text('Reacted on'), findsOneWidget);
 
     // Verify object icon
-    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+    expect(find.byIcon(PhosphorIconsRegular.checkCircle), findsAtLeast(1));
 
     // Verify Activity Object icon
     expect(find.byType(ActerIconWidget), findsNothing);

--- a/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
@@ -17,10 +17,8 @@ void main() {
     await tester.pumpProviderWidget(
       overrides: [
         memberAvatarInfoProvider.overrideWith(
-          (ref, param) => MockAvatarInfo(
-            uniqueId: param.userId,
-            mockDisplayName: 'User-1',
-          ),
+          (ref, param) =>
+              MockAvatarInfo(uniqueId: param.userId, mockDisplayName: 'User-1'),
         ),
       ],
       child: Material(
@@ -35,8 +33,8 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.reaction.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.pin.name,
-        mockEmoji: SpaceObjectTypes.pin.emoji,
+        mockType: 'pin',
+        mockEmoji: '📌',
         mockTitle: 'Pin Name',
       ),
     );
@@ -49,7 +47,7 @@ void main() {
     );
 
     // Verify object info
-    expect(find.text('${SpaceObjectTypes.pin.emoji} Pin Name'), findsOneWidget);
+    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -59,8 +57,8 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.reaction.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.event.name,
-        mockEmoji: SpaceObjectTypes.event.emoji,
+        mockType: 'event',
+        mockEmoji: '🗓️',
         mockTitle: 'Team Meeting',
       ),
     );
@@ -73,10 +71,7 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.event.emoji} Team Meeting'),
-      findsOneWidget,
-    );
+    expect(find.text('${'🗓️'} Team Meeting'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -86,8 +81,8 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.reaction.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskList.name,
-        mockEmoji: SpaceObjectTypes.taskList.emoji,
+        mockType: 'task-list',
+        mockEmoji: '📋',
         mockTitle: 'Project Tasks',
       ),
     );
@@ -100,10 +95,7 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskList.emoji} Project Tasks'),
-      findsOneWidget,
-    );
+    expect(find.text('${'📋'} Project Tasks'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -113,8 +105,8 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.reaction.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskItem.name,
-        mockEmoji: SpaceObjectTypes.taskItem.emoji,
+        mockType: 'task',
+        mockEmoji: '☑️',
         mockTitle: 'Complete Documentation',
       ),
     );
@@ -127,10 +119,7 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskItem.emoji} Complete Documentation'),
-      findsOneWidget,
-    );
+    expect(find.text('${'☑️'} Complete Documentation'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -140,8 +129,8 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.reaction.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.news.name,
-        mockEmoji: SpaceObjectTypes.news.emoji,
+        mockType: 'news',
+        mockEmoji: '🚀',
         mockTitle: 'Product Launch',
       ),
     );
@@ -154,10 +143,7 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.news.emoji} Boost'),
-      findsOneWidget,
-    );
+    expect(find.text('${'🚀'} Boost'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);

--- a/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reaction_item_widget_test.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/type_widgets/reaction.dart';
 import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../common/mock_data/mock_avatar_info.dart';
 import '../../../helpers/test_util.dart';
@@ -40,14 +42,20 @@ void main() {
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.heart), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.reaction.emoji} Reacted on'),
-      findsOneWidget,
-    );
+    expect(find.text('Reacted on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.pushPin), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
+    expect(find.text('Pin Name'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -64,14 +72,20 @@ void main() {
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.heart), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.reaction.emoji} Reacted on'),
-      findsOneWidget,
-    );
+    expect(find.text('Reacted on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(find.text('${'🗓️'} Team Meeting'), findsOneWidget);
+    expect(find.text('Team Meeting'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -88,14 +102,20 @@ void main() {
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.heart), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.reaction.emoji} Reacted on'),
-      findsOneWidget,
-    );
+    expect(find.text('Reacted on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.listChecks), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsOneWidget);
 
     // Verify object info
-    expect(find.text('${'📋'} Project Tasks'), findsOneWidget);
+    expect(find.text('Project Tasks'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -112,14 +132,20 @@ void main() {
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.heart), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.reaction.emoji} Reacted on'),
-      findsOneWidget,
-    );
+    expect(find.text('Reacted on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.check), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(find.text('${'☑️'} Complete Documentation'), findsOneWidget);
+    expect(find.text('Complete Documentation'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
@@ -136,14 +162,20 @@ void main() {
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.heart), findsOneWidget);
+
     // Verify action title
-    expect(
-      find.text('${PushStyles.reaction.emoji} Reacted on'),
-      findsOneWidget,
-    );
+    expect(find.text('Reacted on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.rocketLaunch), findsAtLeast(1));
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
 
     // Verify object info
-    expect(find.text('${'🚀'} Boost'), findsOneWidget);
+    expect(find.text('Boost'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);

--- a/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
@@ -1,8 +1,10 @@
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/widgets/acter_icon_picker/acter_icon_widget.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart';
 import 'package:acter_notifify/model/push_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import '../../../common/mock_data/mock_avatar_info.dart';
 import '../../../helpers/test_util.dart';
@@ -39,112 +41,38 @@ void main() {
         mockTitle: 'Pin Name',
       ),
       mockRefDetails: MockRefDetails(
-        mockTitle: 'Event Name',
-        mockType: 'event',
-      ),
-    );
-    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
-
-    // Verify action title
-    expect(
-      find.text('${PushStyles.references.emoji} Added references on'),
-      findsOneWidget,
-    );
-
-    // Verify object info
-    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
-
-    // Verify user info
-    expect(find.text('User-1'), findsOneWidget);
-
-    // Verify comment content
-    expect(find.text('${'🗓️'} Event Name'), findsOneWidget);
-  });
-
-  testWidgets('Add reference on Event Object', (tester) async {
-    MockActivity mockActivity = MockActivity(
-      mockType: PushStyles.references.name,
-      mockObject: MockActivityObject(
-        mockType: 'event',
-        mockEmoji: '🗓️',
         mockTitle: 'Team Meeting',
-      ),
-      mockRefDetails: MockRefDetails(
-        mockTitle: 'Task List Name',
-        mockType: 'task-list',
+        mockType: 'calendar-event',
+        mockTargetId: 'event-id',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
-    // Verify action title
-    expect(
-      find.text('${PushStyles.references.emoji} Added references on'),
-      findsOneWidget,
-    );
+    // Wait for the widget to be fully built
+    await tester.pump();
 
-    // Verify object info
-    expect(find.text('${'🗓️'} Team Meeting'), findsOneWidget);
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.link), findsOneWidget);
+
+    // Verify action title
+    expect(find.text('Added references on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.pushPin), findsAtLeast(1));
+
+    // Verify object title
+    expect(find.text('Pin Name'), findsOneWidget);
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsAtLeast(1));
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
 
-    // Verify reference content
-    expect(find.text('${'📋'} Task List Name'), findsOneWidget);
-  });
+    // Verify reference object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsOneWidget);
 
-  testWidgets('Add reference on TaskList Object', (tester) async {
-    MockActivity mockActivity = MockActivity(
-      mockType: PushStyles.references.name,
-      mockObject: MockActivityObject(
-        mockType: 'task-list',
-        mockEmoji: '📋',
-        mockTitle: 'Project Tasks',
-      ),
-      mockRefDetails: MockRefDetails(mockTitle: 'Task Name', mockType: 'task'),
-    );
-    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
-
-    // Verify action title
-    expect(
-      find.text('${PushStyles.references.emoji} Added references on'),
-      findsOneWidget,
-    );
-
-    // Verify object info
-    expect(find.text('${'📋'} Project Tasks'), findsOneWidget);
-
-    // Verify user info
-    expect(find.text('User-1'), findsOneWidget);
-
-    // Verify reference content
-    expect(find.text('${'☑️'} Task Name'), findsOneWidget);
-  });
-
-  testWidgets('Add reference on TaskItem Object', (tester) async {
-    MockActivity mockActivity = MockActivity(
-      mockType: PushStyles.references.name,
-      mockObject: MockActivityObject(
-        mockType: 'task',
-        mockEmoji: '☑️',
-        mockTitle: 'Complete Documentation',
-      ),
-      mockRefDetails: MockRefDetails(mockTitle: 'Pin Name', mockType: 'pin'),
-    );
-    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
-
-    // Verify action title
-    expect(
-      find.text('${PushStyles.references.emoji} Added references on'),
-      findsOneWidget,
-    );
-
-    // Verify object info
-    expect(find.text('${'☑️'} Complete Documentation'), findsOneWidget);
-
-    // Verify user info
-    expect(find.text('User-1'), findsOneWidget);
-
-    // Verify reference content
-    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
+    // Verify reference object title
+    expect(find.text('Team Meeting'), findsOneWidget);
   });
 }

--- a/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
@@ -18,10 +18,8 @@ void main() {
     await tester.pumpProviderWidget(
       overrides: [
         memberAvatarInfoProvider.overrideWith(
-          (ref, param) => MockAvatarInfo(
-            uniqueId: param.userId,
-            mockDisplayName: 'User-1',
-          ),
+          (ref, param) =>
+              MockAvatarInfo(uniqueId: param.userId, mockDisplayName: 'User-1'),
         ),
       ],
       child: Material(
@@ -36,13 +34,13 @@ void main() {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.references.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.pin.name,
-        mockEmoji: SpaceObjectTypes.pin.emoji,
+        mockType: 'pin',
+        mockEmoji: '📌',
         mockTitle: 'Pin Name',
       ),
       mockRefDetails: MockRefDetails(
         mockTitle: 'Event Name',
-        mockType: SpaceObjectTypes.event.name,
+        mockType: 'event',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
@@ -54,29 +52,26 @@ void main() {
     );
 
     // Verify object info
-    expect(find.text('${SpaceObjectTypes.pin.emoji} Pin Name'), findsOneWidget);
+    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
 
     // Verify comment content
-    expect(
-      find.text('${SpaceObjectTypes.event.emoji} Event Name'),
-      findsOneWidget,
-    );
+    expect(find.text('${'🗓️'} Event Name'), findsOneWidget);
   });
 
   testWidgets('Add reference on Event Object', (tester) async {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.references.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.event.name,
-        mockEmoji: SpaceObjectTypes.event.emoji,
+        mockType: 'event',
+        mockEmoji: '🗓️',
         mockTitle: 'Team Meeting',
       ),
       mockRefDetails: MockRefDetails(
         mockTitle: 'Task List Name',
-        mockType: SpaceObjectTypes.taskList.name,
+        mockType: 'task-list',
       ),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
@@ -88,33 +83,24 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.event.emoji} Team Meeting'),
-      findsOneWidget,
-    );
+    expect(find.text('${'🗓️'} Team Meeting'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
 
     // Verify reference content
-    expect(
-      find.text('${SpaceObjectTypes.taskList.emoji} Task List Name'),
-      findsOneWidget,
-    );
+    expect(find.text('${'📋'} Task List Name'), findsOneWidget);
   });
 
   testWidgets('Add reference on TaskList Object', (tester) async {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.references.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskList.name,
-        mockEmoji: SpaceObjectTypes.taskList.emoji,
+        mockType: 'task-list',
+        mockEmoji: '📋',
         mockTitle: 'Project Tasks',
       ),
-      mockRefDetails: MockRefDetails(
-        mockTitle: 'Task Name',
-        mockType: SpaceObjectTypes.taskItem.name,
-      ),
+      mockRefDetails: MockRefDetails(mockTitle: 'Task Name', mockType: 'task'),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
@@ -125,33 +111,24 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskList.emoji} Project Tasks'),
-      findsOneWidget,
-    );
+    expect(find.text('${'📋'} Project Tasks'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
 
     // Verify reference content
-    expect(
-      find.text('${SpaceObjectTypes.taskItem.emoji} Task Name'),
-      findsOneWidget,
-    );
+    expect(find.text('${'☑️'} Task Name'), findsOneWidget);
   });
 
   testWidgets('Add reference on TaskItem Object', (tester) async {
     MockActivity mockActivity = MockActivity(
       mockType: PushStyles.references.name,
       mockObject: MockActivityObject(
-        mockType: SpaceObjectTypes.taskItem.name,
-        mockEmoji: SpaceObjectTypes.taskItem.emoji,
+        mockType: 'task',
+        mockEmoji: '☑️',
         mockTitle: 'Complete Documentation',
       ),
-      mockRefDetails: MockRefDetails(
-        mockTitle: 'Pin Name',
-        mockType: SpaceObjectTypes.pin.name,
-      ),
+      mockRefDetails: MockRefDetails(mockTitle: 'Pin Name', mockType: 'pin'),
     );
     await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
 
@@ -162,18 +139,12 @@ void main() {
     );
 
     // Verify object info
-    expect(
-      find.text('${SpaceObjectTypes.taskItem.emoji} Complete Documentation'),
-      findsOneWidget,
-    );
+    expect(find.text('${'☑️'} Complete Documentation'), findsOneWidget);
 
     // Verify user info
     expect(find.text('User-1'), findsOneWidget);
 
     // Verify reference content
-    expect(
-      find.text('${SpaceObjectTypes.pin.emoji} Pin Name'),
-      findsOneWidget,
-    );
+    expect(find.text('${'📌'} Pin Name'), findsOneWidget);
   });
 }

--- a/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_reference_item_widget_test.dart
@@ -75,4 +75,136 @@ void main() {
     // Verify reference object title
     expect(find.text('Team Meeting'), findsOneWidget);
   });
+
+  testWidgets('Add reference on Event Object', (tester) async {
+    MockActivity mockActivity = MockActivity(
+      mockType: PushStyles.references.name,
+      mockObject: MockActivityObject(
+        mockType: 'event',
+        mockEmoji: '🗓️',
+        mockTitle: 'Team Meeting',
+      ),
+      mockRefDetails: MockRefDetails(
+        mockTitle: 'Project Planning',
+        mockType: 'pin',
+        mockTargetId: 'pin-id',
+      ),
+    );
+    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
+
+    // Wait for the widget to be fully built
+    await tester.pump();
+
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.link), findsOneWidget);
+
+    // Verify action title
+    expect(find.text('Added references on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsAtLeast(1));
+
+    // Verify object title
+    expect(find.text('Team Meeting'), findsOneWidget);
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsAtLeast(1));
+
+    // Verify user info
+    expect(find.text('User-1'), findsOneWidget);
+
+    // Verify reference object icon
+    expect(find.byIcon(PhosphorIconsRegular.pushPin), findsOneWidget);
+
+    // Verify reference object title
+    expect(find.text('Project Planning'), findsOneWidget);
+  });
+
+  testWidgets('Add reference on Task-list Object', (tester) async {
+    MockActivity mockActivity = MockActivity(
+      mockType: PushStyles.references.name,
+      mockObject: MockActivityObject(
+        mockType: 'task-list',
+        mockEmoji: '📋',
+        mockTitle: 'Project Tasks',
+      ),
+      mockRefDetails: MockRefDetails(
+        mockTitle: 'Team Meeting',
+        mockType: 'calendar-event',
+        mockTargetId: 'event-id',
+      ),
+    );
+    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
+
+    // Wait for the widget to be fully built
+    await tester.pump();
+
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.link), findsOneWidget);
+
+    // Verify action title
+    expect(find.text('Added references on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.listChecks), findsAtLeast(1));
+
+    // Verify object title
+    expect(find.text('Project Tasks'), findsOneWidget);
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsAtLeast(1));
+
+    // Verify user info
+    expect(find.text('User-1'), findsOneWidget);
+
+    // Verify reference object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsOneWidget);
+
+    // Verify reference object title
+    expect(find.text('Team Meeting'), findsOneWidget);
+  });
+
+  testWidgets('Add reference on TaskItem Object', (tester) async {
+    MockActivity mockActivity = MockActivity(
+      mockType: PushStyles.references.name,
+      mockObject: MockActivityObject(
+        mockType: 'task',
+        mockEmoji: '☑️',
+        mockTitle: 'Complete Documentation',
+      ),
+      mockRefDetails: MockRefDetails(
+        mockTitle: 'Team Meeting',
+        mockType: 'calendar-event',
+        mockTargetId: 'event-id',
+      ),
+    );
+    await createWidgetUnderTest(tester: tester, mockActivity: mockActivity);
+
+    // Wait for the widget to be fully built
+    await tester.pump();
+
+    // Verify action icon
+    expect(find.byIcon(PhosphorIconsRegular.link), findsOneWidget);
+
+    // Verify action title
+    expect(find.text('Added references on'), findsOneWidget);
+
+    // Verify object icon
+    expect(find.byIcon(PhosphorIconsRegular.checkCircle), findsAtLeast(1));
+
+    // Verify object title
+    expect(find.text('Complete Documentation'), findsOneWidget);
+
+    // Verify Activity Object icon
+    expect(find.byType(ActerIconWidget), findsNothing);
+
+    // Verify user info
+    expect(find.text('User-1'), findsOneWidget);
+
+    // Verify reference object icon
+    expect(find.byIcon(PhosphorIconsRegular.calendar), findsOneWidget);
+
+    // Verify reference object title
+    expect(find.text('Team Meeting'), findsOneWidget);
+  });
 }

--- a/app/test/features/activity/mock_data/mock_ref_details.dart
+++ b/app/test/features/activity/mock_data/mock_ref_details.dart
@@ -4,10 +4,12 @@ import 'package:mocktail/mocktail.dart';
 class MockRefDetails extends Mock implements RefDetails {
   final String mockTitle;
   final String mockType;
+  final String? mockTargetId;
 
   MockRefDetails({
     required this.mockTitle,
     required this.mockType,
+    this.mockTargetId,
   });
 
   @override
@@ -15,4 +17,7 @@ class MockRefDetails extends Mock implements RefDetails {
 
   @override
   String typeStr() => mockType;
+
+  @override
+  String? targetIdStr() => mockTargetId;
 }

--- a/packages/acter_notifify/lib/model/push_styles.dart
+++ b/packages/acter_notifify/lib/model/push_styles.dart
@@ -33,17 +33,3 @@ enum PushStyles {
 
   final String emoji;
 }
-
-//LIST OF PUSH STYLE EMOJIS
-enum SpaceObjectTypes {
-  //LIST OF OBJECT EMOJIS
-  news('🚀'),
-  pin('📌'),
-  event('🗓️'),
-  taskList('📋'),
-  taskItem('☑️');
-
-  const SpaceObjectTypes(this.emoji);
-
-  final String emoji;
-}


### PR DESCRIPTION
✅ TEST COVER IS THE MOST IMPORTANT PART OF THIS PR WHICH ENSURE DIFFERENT USE-CASES WORK FINE WITH THIS PR CHANGES
- - -

Fixes,
https://github.com/acterglobal/a3/issues/2686

This is the follow-up PR of https://github.com/acterglobal/a3/pull/2675 to replace emojis with Icons whenever applicable in Activity Item Widget.

There are some complexity of using icon widgets as there Pin and Task-list have `ActerIconsWIdget` with specific color and icon whereas other type have default icon based on the type.

Might be it is difficult to judge all the scenario from the code changes, but added full-cover of test-cases to ensure that each and every use-cases works as expected.

I have also tried to show-case some of the scenarios in below reference video.

https://github.com/user-attachments/assets/574516b4-90e1-4124-be7a-7ddad871487c

Here are some of the screenshots for additional references:

**Comment Items:**

![Screenshot 2025-03-07 at 8 10 17 PM](https://github.com/user-attachments/assets/b7c14ecc-3b23-410f-81db-a8df14ba620f)

**Reaction Items:**
![Screenshot 2025-03-07 at 8 11 14 PM](https://github.com/user-attachments/assets/d6f32e0f-3ab2-4472-a393-c37b255fad77)

**Add References Items**

![Screenshot 2025-03-07 at 8 12 58 PM](https://github.com/user-attachments/assets/664c4287-3e3e-44c0-8f40-9313e547301c)

**Add Attachment Items**
![Screenshot 2025-03-07 at 8 14 19 PM](https://github.com/user-attachments/assets/cef1969a-5886-4953-832f-6dd081add30a)

