### PR TITLE
Fix object notifications

### DIFF
--- a/.changes/2689-object-notifications.md
+++ b/.changes/2689-object-notifications.md
@@ -1,0 +1,1 @@
+- Fix: notifications for some events (RSVP, Task) were not being shown

--- a/packages/acter_notifify/lib/platform/android.dart
+++ b/packages/acter_notifify/lib/platform/android.dart
@@ -312,7 +312,7 @@ Future<void> showNotificationOnAndroid(NotificationItem notification) async {
     'news' => _showNews(notification),
     'chat' => _showChat(notification),
     'dm' => _showDM(notification),
-    'comment' || 'reaction' => _showObjNotif(notification),
-    _ => _showFallback(notification),
+    'unknown' || '' || 'fallback' => _showFallback(notification),
+    _ => _showObjNotif(notification),
   });
 }


### PR DESCRIPTION
I noticed the other day that for some reason object notifications for RSVP yes didn't work, despite the test on the rust and flutter side passing fine. Turns out the `android`-notification showing code did a too rigorous selection of the pushStyle types to support. This PR fixes that problem and now it shows up nicely:

![image](https://github.com/user-attachments/assets/b7d4cc6e-e8bb-4d52-9270-92fb7ddc08a8)
