### PR TITLE
Fix parsing of https://app.acter.global/ URI's generated by the server

### DIFF
--- a/app/lib/features/deep_linking/parse_acter_uri.dart
+++ b/app/lib/features/deep_linking/parse_acter_uri.dart
@@ -50,11 +50,7 @@ UriParseResult _parseHttpsUri(Uri uri) {
   if (hash == null || hash.isEmpty) {
     throw IncorrectHashError();
   }
-
-  final pathWithoutHash = uri.path.substring(
-    0,
-    uri.path.length - hash.length - 1,
-  );
+  final pathWithoutHash = uri.path.substring(0, uri.path.length - hash.length);
   final strippedUri = uri.replace(path: pathWithoutHash);
   final hashableUri = strippedUri.toString();
   final calculatedHash = sha1.convert(utf8.encode(hashableUri)).toString();

--- a/app/test/features/deep_linking/parse_acter_uri_test.dart
+++ b/app/test/features/deep_linking/parse_acter_uri_test.dart
@@ -207,7 +207,7 @@ UriMaker makeUriMakerForPublicPrefix(
             : null;
     final hash =
         sha1.convert(utf8.encode('$uriPrefix$finalQuery#$path')).toString();
-    return Uri.parse('$uriPrefix/$hash$finalQuery#$path');
+    return Uri.parse('$uriPrefix$hash$finalQuery#$path');
   }
 
   return makeDomainLink;


### PR DESCRIPTION
The format wasn't quite exactly as agreed and thus on Acter parsing app.acter.global URIs failed with a hash-mismatch error. This updates the test and fixes the problem.