### PR TITLE
Bump to latest device_calendar develop for android device fixes

### DIFF
--- a/.changes/2738-android-caldendar-sync.md
+++ b/.changes/2738-android-caldendar-sync.md
@@ -1,0 +1,1 @@
+- Fix calendar sync on some older devices not showing any events

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -565,8 +565,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ben-fix-event-color-type
-      resolved-ref: "56522f0b513056b764be2425b3dae4d29ece7863"
+      ref: "2e0c2050d48c9bd2eb3cfc47650fbd63b1490ea5"
+      resolved-ref: "2e0c2050d48c9bd2eb3cfc47650fbd63b1490ea5"
       url: "https://github.com/acterglobal/device_calendar"
     source: git
     version: "4.3.1"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -152,7 +152,7 @@ dependencies:
   device_calendar: #^4.3.3-20240801
     git:
       url: https://github.com/acterglobal/device_calendar
-      ref: ben-fix-event-color-type
+      ref: 2e0c2050d48c9bd2eb3cfc47650fbd63b1490ea5
   quickalert: ^1.1.0
   drag_and_drop_lists:
     git:


### PR DESCRIPTION
fixes #2729 , https://github.com/acterglobal/a3-meta/issues/551 , https://github.com/acterglobal/a3-meta/issues/822

Due to an internal type error on some devices the device calendar wasn't able to create events with the plugin. Updating the plugin to the latest development version fixes it.

This has been shown to be faulty on the last release but working with this patch via lambdatest.com on a "Samsung S9+" (Android 10) as well as a "One Plus Nord" (Android 11).