### PR TITLE
Task invite accpeting & declining

### DIFF
--- a/native/acter/src/api/invitations.rs
+++ b/native/acter/src/api/invitations.rs
@@ -33,6 +33,27 @@ impl InvitationsManager {
         };
         self.inner.invited().contains(&user_id)
     }
+
+    /// whether
+    pub fn can_invite(&self, user_id: String) -> Result<bool> {
+        let user_id = UserId::parse(user_id)?;
+        Ok(!self.inner.accepted().contains(&user_id)
+            && !self.inner.declined().contains(&user_id)
+            && !self.inner.accepted().contains(&user_id))
+    }
+    pub fn has_accepted(&self) -> bool {
+        let Ok(user_id) = self.client.user_id() else {
+            return false;
+        };
+        self.inner.accepted().contains(&user_id)
+    }
+
+    pub fn has_declined(&self) -> bool {
+        let Ok(user_id) = self.client.user_id() else {
+            return false;
+        };
+        self.inner.declined().contains(&user_id)
+    }
     pub fn invited(&self) -> Vec<String> {
         self.inner
             .invited()
@@ -40,6 +61,23 @@ impl InvitationsManager {
             .map(|id| id.to_string())
             .collect()
     }
+
+    pub fn accepted(&self) -> Vec<String> {
+        self.inner
+            .accepted()
+            .iter()
+            .map(|id| id.to_string())
+            .collect()
+    }
+
+    pub fn declined(&self) -> Vec<String> {
+        self.inner
+            .declined()
+            .iter()
+            .map(|id| id.to_string())
+            .collect()
+    }
+
     pub fn has_invitations(&self) -> bool {
         !self.inner.invited().is_empty()
     }

--- a/native/core/src/models/invites.rs
+++ b/native/core/src/models/invites.rs
@@ -81,18 +81,26 @@ impl InvitationsManager {
         Ok(true)
     }
 
-    pub(crate) fn mark_as_accepted(&mut self, entry: OwnedUserId) -> Result<bool> {
-        self.stats.invited.remove(&entry);
-        self.stats.declined.remove(&entry);
-        self.stats.accepted.insert(entry);
-        Ok(true)
+    pub(crate) fn mark_as_accepted(&mut self, entry: OwnedUserId) -> bool {
+        let mut was_invited = self.stats.invited.remove(&entry);
+        if !was_invited {
+            was_invited = self.stats.declined.remove(&entry);
+        }
+        if was_invited {
+            self.stats.accepted.insert(entry);
+        }
+        was_invited
     }
 
-    pub(crate) fn mark_as_declined(&mut self, entry: OwnedUserId) -> Result<bool> {
-        self.stats.invited.remove(&entry);
-        self.stats.accepted.remove(&entry);
-        self.stats.declined.insert(entry);
-        Ok(true)
+    pub(crate) fn mark_as_declined(&mut self, entry: OwnedUserId) -> bool {
+        let mut was_invited = self.stats.invited.remove(&entry);
+        if !was_invited {
+            was_invited = self.stats.accepted.remove(&entry);
+        }
+        if was_invited {
+            self.stats.declined.insert(entry);
+        }
+        was_invited
     }
 
     pub fn stats(&self) -> &InviteStats {

--- a/native/core/src/models/invites.rs
+++ b/native/core/src/models/invites.rs
@@ -3,7 +3,10 @@ use matrix_sdk_base::ruma::{
     events::OriginalMessageLikeEvent, EventId, OwnedEventId, OwnedUserId, UserId,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, ops::Deref};
+use std::{
+    collections::{BTreeSet, HashMap},
+    ops::Deref,
+};
 use tracing::{error, trace};
 
 use super::{ActerModel, AnyActerModel, Capability, EventMeta};
@@ -16,7 +19,12 @@ use crate::{
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Getters)]
 pub struct InviteStats {
-    invited: Vec<OwnedUserId>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    invited: BTreeSet<OwnedUserId>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    accepted: BTreeSet<OwnedUserId>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    declined: BTreeSet<OwnedUserId>,
 }
 
 #[derive(Clone, Debug)]
@@ -48,10 +56,6 @@ impl InvitationsManager {
         self.event_id.clone()
     }
 
-    pub fn invited(&self) -> &Vec<OwnedUserId> {
-        &self.stats.invited
-    }
-
     pub async fn invite_entries(&self) -> Result<HashMap<OwnedUserId, ExplicitInvite>> {
         let mut entries = HashMap::new();
         for mdl in self
@@ -69,10 +73,25 @@ impl InvitationsManager {
 
     pub(crate) fn add_invite_entry(&mut self, entry: &ExplicitInvite) -> Result<bool> {
         for user_id in &entry.inner.mention.user_ids {
-            if !self.stats.invited.contains(user_id) {
-                self.stats.invited.push(user_id.clone());
+            if self.stats.accepted.contains(user_id) || self.stats.declined.contains(user_id) {
+                continue; // we ignore entries if the user already interacted with it
             }
+            self.stats.invited.insert(user_id.clone());
         }
+        Ok(true)
+    }
+
+    pub(crate) fn mark_as_accepted(&mut self, entry: OwnedUserId) -> Result<bool> {
+        self.stats.invited.remove(&entry);
+        self.stats.declined.remove(&entry);
+        self.stats.accepted.insert(entry);
+        Ok(true)
+    }
+
+    pub(crate) fn mark_as_declined(&mut self, entry: OwnedUserId) -> Result<bool> {
+        self.stats.invited.remove(&entry);
+        self.stats.accepted.remove(&entry);
+        self.stats.declined.insert(entry);
         Ok(true)
     }
 

--- a/native/core/src/models/tasks/task.rs
+++ b/native/core/src/models/tasks/task.rs
@@ -265,16 +265,16 @@ impl ActerModel for TaskSelfAssign {
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {
         let belongs_to = self.inner.task.event_id.clone();
         let sender = self.meta.sender.clone();
-        let mut updates = default_model_execute(store, self.into()).await?;
         let manager = {
             let mut manager = InvitationsManager::from_store_and_event_id(store, &belongs_to).await;
-            if manager.mark_as_accepted(sender)? {
+            if manager.mark_as_accepted(sender) {
                 Some(manager)
             } else {
                 None
             }
         };
 
+        let mut updates = default_model_execute(store, self.into()).await?;
         if let Some(manager) = manager {
             updates.push(manager.save().await?);
         }
@@ -339,16 +339,16 @@ impl ActerModel for TaskSelfUnassign {
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {
         let belongs_to = self.inner.task.event_id.clone();
         let sender = self.meta.sender.clone();
-        let mut updates = default_model_execute(store, self.into()).await?;
         let manager = {
             let mut manager = InvitationsManager::from_store_and_event_id(store, &belongs_to).await;
-            if manager.mark_as_declined(sender)? {
+            if manager.mark_as_declined(sender) {
                 Some(manager)
             } else {
                 None
             }
         };
 
+        let mut updates = default_model_execute(store, self.into()).await?;
         if let Some(manager) = manager {
             updates.push(manager.save().await?);
         }


### PR DESCRIPTION
implements task invitation management via self-assignment api.

- self-assign to a task means it the invitation was accepted
- self-unassign of a task means it was declined
- you can only invite someone if they weren't invited or haven't declined
- if they weren't invited but has unassigned, you can still invite them

With tests to ensure this works as expected.