### PR TITLE
[simplefix] Rename SyncAnyActerEvent to AnySyncActerEvent

### DIFF
--- a/native/acter/src/api/client/sync.rs
+++ b/native/acter/src/api/client/sync.rs
@@ -1,5 +1,5 @@
 use acter_core::{
-    events::SyncAnyActerEvent, executor::Executor, models::AnyActerModel,
+    events::AnySyncActerEvent, executor::Executor, models::AnyActerModel,
     referencing::ExecuteReference, spaces::is_acter_space,
 };
 use anyhow::Result;
@@ -243,13 +243,14 @@ impl Client {
 
         // Any
         self.add_event_handler(
-            |ev: SyncAnyActerEvent, room: SdkRoom, Ctx(executor): Ctx<Executor>| async move {
+            |ev: AnySyncActerEvent, room: SdkRoom, Ctx(executor): Ctx<Executor>| async move {
                 let room_id = room.room_id().to_owned();
                 let acter_event = ev.into_full_any_acter_event(room_id);
                 AnyActerModel::execute(&executor, acter_event).await;
             },
         );
     }
+
     fn refresh_history_on_start(
         &self,
         sync_keys: Vec<OwnedRoomId>,

--- a/native/acter/src/api/push/notification_item.rs
+++ b/native/acter/src/api/push/notification_item.rs
@@ -4,7 +4,7 @@ use acter_core::{
         attachments::{AttachmentContent, FallbackAttachmentContent},
         news::{FallbackNewsContent, NewsContent},
         rsvp::RsvpStatus,
-        AnyActerEvent, RefDetails, RefPreview, SyncAnyActerEvent, UtcDateTime,
+        AnyActerEvent, AnySyncActerEvent, RefDetails, RefPreview, UtcDateTime,
     },
     models::{ActerModel, AnyActerModel, Attachment},
     push::default_rules,
@@ -416,10 +416,10 @@ impl NotificationItem {
 
         // acter specific items:
         if let RawNotificationEvent::Timeline(raw_tl) = &inner.raw_event {
-            if let Ok(event) = raw_tl.deserialize_as::<SyncAnyActerEvent>() {
+            if let Ok(event) = raw_tl.deserialize_as::<AnySyncActerEvent>() {
                 if !matches!(
                     event,
-                    SyncAnyActerEvent::RegularTimelineEvent(AnySyncTimelineEvent::MessageLike(_))
+                    AnySyncActerEvent::RegularTimelineEvent(AnySyncTimelineEvent::MessageLike(_))
                 ) {
                     return builder
                         .build_for_acter_object(client, event.into_full_any_acter_event(room_id))

--- a/native/core/src/events.rs
+++ b/native/core/src/events.rs
@@ -66,7 +66,6 @@ pub enum AnyActerEvent {
 impl AnyActerEvent {
     pub fn room_id(&self) -> &RoomId {
         match &self {
-            Self::Attachment(e) => e.room_id(),
             AnyActerEvent::CalendarEvent(e) => e.room_id(),
             AnyActerEvent::CalendarEventUpdate(e) => e.room_id(),
             AnyActerEvent::Pin(e) => e.room_id(),
@@ -83,6 +82,7 @@ impl AnyActerEvent {
             AnyActerEvent::TaskSelfUnassign(e) => e.room_id(),
             AnyActerEvent::Comment(e) => e.room_id(),
             AnyActerEvent::CommentUpdate(e) => e.room_id(),
+            AnyActerEvent::Attachment(e) => e.room_id(),
             AnyActerEvent::AttachmentUpdate(e) => e.room_id(),
             AnyActerEvent::Reaction(e) => e.room_id(),
             AnyActerEvent::ReadReceipt(e) => e.room_id(),
@@ -146,6 +146,7 @@ impl<'de> serde::Deserialize<'de> for AnyActerEvent {
                     .map_err(D::Error::custom)?;
                 Ok(Self::StoryUpdate(event))
             }
+
             tasks::TaskListEventContent::TYPE => {
                 let event = smart_serde_json::from_str::<tasks::TaskListEvent>(json.get())
                     .map_err(D::Error::custom)?;
@@ -173,7 +174,6 @@ impl<'de> serde::Deserialize<'de> for AnyActerEvent {
                     .map_err(D::Error::custom)?;
                 Ok(Self::TaskSelfAssign(event))
             }
-
             tasks::TaskSelfUnassignEventContent::TYPE => {
                 let event = smart_serde_json::from_str::<tasks::TaskSelfUnassignEvent>(json.get())
                     .map_err(D::Error::custom)?;
@@ -272,7 +272,7 @@ impl<'de> serde::Deserialize<'de> for AnyActerEvent {
 }
 
 #[derive(Clone, Debug)]
-pub enum SyncAnyActerEvent {
+pub enum AnySyncActerEvent {
     CalendarEvent(calendar::SyncCalendarEventEvent),
     CalendarEventUpdate(calendar::SyncCalendarEventUpdateEvent),
 
@@ -290,6 +290,7 @@ pub enum SyncAnyActerEvent {
 
     Task(tasks::SyncTaskEvent),
     TaskUpdate(tasks::SyncTaskUpdateEvent),
+
     TaskSelfAssign(tasks::SyncTaskSelfAssignEvent),
     TaskSelfUnassign(tasks::SyncTaskSelfUnassignEvent),
 
@@ -308,7 +309,7 @@ pub enum SyncAnyActerEvent {
     RegularTimelineEvent(AnySyncTimelineEvent),
 }
 
-impl SyncAnyActerEvent {
+impl AnySyncActerEvent {
     /// Convert this sync event into a full event (one with a `room_id` field).
     pub fn into_full_any_acter_event(self, room_id: OwnedRoomId) -> AnyActerEvent {
         match self {
@@ -347,7 +348,7 @@ impl SyncAnyActerEvent {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for SyncAnyActerEvent {
+impl<'de> serde::Deserialize<'de> for AnySyncActerEvent {
     fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -433,7 +434,6 @@ impl<'de> serde::Deserialize<'de> for SyncAnyActerEvent {
                         .map_err(D::Error::custom)?;
                 Ok(Self::TaskSelfAssign(event))
             }
-
             tasks::TaskSelfUnassignEventContent::TYPE => {
                 let event =
                     smart_serde_json::from_str::<tasks::SyncTaskSelfUnassignEvent>(json.get())
@@ -538,7 +538,7 @@ impl<'de> serde::Deserialize<'de> for SyncAnyActerEvent {
     }
 }
 
-impl SyncEvent for SyncAnyActerEvent {
+impl SyncEvent for AnySyncActerEvent {
     const KIND: HandlerKind = HandlerKind::Timeline;
     const TYPE: Option<&'static str> = None;
 }


### PR DESCRIPTION
Replace `SyncAny` with `AnySync` in according to naming convention from matrix-sdk.