### PR TITLE
Implement new Permission defaults and API

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -2731,6 +2731,66 @@ object ActerUserAppSettingsBuilder {
 }
 
 
+//  ########  ######## ########  ##     ## ####  ######   ######  ####  #######  ##    ##  ######  
+//  ##     ## ##       ##     ## ###   ###  ##  ##    ## ##    ##  ##  ##     ## ###   ## ##    ## 
+//  ##     ## ##       ##     ## #### ####  ##  ##       ##        ##  ##     ## ####  ## ##       
+//  ########  ######   ########  ## ### ##  ##   ######   ######   ##  ##     ## ## ## ##  ######  
+//  ##        ##       ##   ##   ##     ##  ##        ##       ##  ##  ##     ## ##  ####       ## 
+//  ##        ##       ##    ##  ##     ##  ##  ##    ## ##    ##  ##  ##     ## ##   ### ##    ## 
+//  ##        ######## ##     ## ##     ## ####  ######   ######  ####  #######  ##    ##  ######  
+
+
+/// make app permissions builder
+fn new_app_permissions_builder() -> AppPermissionsBuilder;
+
+object AppPermissionsBuilder {
+    // whether or not News/Boosts should be activated
+    fn news(value: bool);
+    // whether or not pins should be activated
+    fn pins(value: bool);
+    // whether or not stories should be activated
+    fn stories(value: bool);
+    // whether or not calendar_events should be activated
+    fn calendar_events(value: bool);
+    // whether or not the tasks feature should be activated
+    fn tasks(value: bool);
+
+    /// specific permissions levels needed to post boosts
+    fn news_permisisons(value: u32);
+    /// specific permissions levels needed to post stories
+    fn stories_permisisons(value: u32);
+    /// specific permissions levels needed to post calender events
+    fn calendar_events_permisisons(value: u32);
+    /// specific permissions levels needed for task lists
+    fn task_lists_permisisons(value: u32);
+    /// specific permissions levels needed for tasks
+    fn tasks_permisisons(value: u32);
+    /// specific permissions levels needed for pins
+    fn pins_permisisons(value: u32);
+    /// specific permissions levels needed for comments
+    fn comments_permisisons(value: u32);
+    /// specific permissions levels needed for attachments
+    fn attachments_permisisons(value: u32);
+    /// specific permissions levels needed to rsvp
+    fn rsvp_permisisons(value: u32);
+
+    /// set level to kick a user
+    fn kick(value: u32);
+    /// set level to ban a user
+    fn ban(value: u32);
+    /// set level to ban a user
+    fn invite(value: u32);
+    /// set level to redact user content
+    fn redact(value: u32);
+
+    /// set default sending level if not specified
+    fn events_default(value: u32);
+    /// set the detault level users have when entering 
+    fn users_default(value: u32);
+    /// set the default state level needed if not specified
+    fn state_default(value: u32);
+}
+
 
 //     ###     ######   ######   #######  ##     ## ##    ## ########
 //    ## ##   ##    ## ##    ## ##     ## ##     ## ###   ##    ##
@@ -3026,6 +3086,7 @@ object CreateConvoSettingsBuilder {
 
 object CreateConvoSettings {}
 
+
 /// make space settings builder
 fn new_space_settings_builder() -> CreateSpaceSettingsBuilder;
 
@@ -3056,6 +3117,9 @@ object CreateSpaceSettingsBuilder {
     /// if the join rule is restricted or knockrestricted AND a parent is set
     /// the space will be a subspace of the parent space
     fn set_parent(value: string);
+
+    /// set the permissions for apps and events for the space creation
+    fn set_permissions(value: AppPermissionsBuilder);
 
     fn build() -> CreateSpaceSettings;
 }

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -123,7 +123,7 @@ pub use settings::{
 };
 pub use spaces::{
     new_space_settings_builder, CreateSpaceSettings, CreateSpaceSettingsBuilder,
-    RelationTargetType, Space, SpaceDiff,
+    RelationTargetType, Space, SpaceDiff, AppPermissionsBuilder, new_app_permissions_builder,
 };
 pub use stories::{Story, StoryDraft, StorySlide, StorySlideDraft, StoryUpdateBuilder};
 pub use stream::{MsgDraft, RoomMessageDiff, TimelineStream};

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -779,7 +779,7 @@ impl Room {
         let my_id = self.user_id()?;
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -902,7 +902,7 @@ impl Room {
 
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -930,7 +930,7 @@ impl Room {
 
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -952,7 +952,7 @@ impl Room {
         let me = self.clone();
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -979,7 +979,7 @@ impl Room {
         let me = self.clone();
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -1007,7 +1007,7 @@ impl Room {
         let uid = UserId::parse(user_id)?;
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };
@@ -1308,7 +1308,7 @@ impl Room {
         let me = self.clone();
         let is_acter_space = self.is_acter_space().await?;
         let acter_app_settings = if is_acter_space {
-            Some(self.app_settings_content().await?)
+            self.app_settings_content().await?
         } else {
             None
         };

--- a/native/acter/src/api/settings/space.rs
+++ b/native/acter/src/api/settings/space.rs
@@ -124,6 +124,9 @@ impl RoomPowerLevels {
     pub fn events_default(&self) -> i64 {
         self.inner.events_default.into()
     }
+    pub fn state_default(&self) -> i64 {
+        self.inner.state_default.into()
+    }
     pub fn users_default(&self) -> i64 {
         self.inner.users_default.into()
     }
@@ -167,7 +170,7 @@ impl ActerAppSettings {
 impl Room {
     pub async fn app_settings(&self) -> Result<ActerAppSettings> {
         Ok(ActerAppSettings {
-            inner: self.app_settings_content().await?,
+            inner: self.app_settings_content().await?.unwrap_or_default(),
         })
     }
 
@@ -289,21 +292,16 @@ impl Room {
             .await?
     }
 
-    pub(crate) async fn app_settings_content(&self) -> Result<ActerAppSettingsContent> {
+    pub async fn app_settings_content(&self) -> Result<Option<ActerAppSettingsContent>> {
         let room = self.room.clone();
         RUNTIME
             .spawn(async move {
-                if let Some(a) = room
+                let content = room
                     .get_state_event_static::<ActerAppSettingsContent>()
                     .await?
-                {
-                    if let Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(inner))) =
-                        a.deserialize()
-                    {
-                        return Ok(inner.content);
-                    }
-                }
-                Ok(ActerAppSettingsContent::default()) // all other cases we fall back to default
+                    .context("No Settings set up")?
+                    .deserialize()?;
+                Ok(content.original_content().cloned())
             })
             .await?
     }

--- a/native/acter/src/api/spaces.rs
+++ b/native/acter/src/api/spaces.rs
@@ -2,7 +2,7 @@ pub mod categories;
 
 pub use acter_core::spaces::{
     CreateSpaceSettings, CreateSpaceSettingsBuilder, RelationTargetType, SpaceRelation,
-    SpaceRelations as CoreSpaceRelations,
+    SpaceRelations as CoreSpaceRelations, AppPermissionsBuilder, new_app_permissions_builder,
 };
 use acter_core::{
     error::Error, events::AnyActerEvent, models::AnyActerModel,

--- a/native/core/src/error.rs
+++ b/native/core/src/error.rs
@@ -5,10 +5,10 @@ use crate::models::EventMeta;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Error in the inner MatrixSDK")]
+    #[error("Error in the inner MatrixSDK: {0}")]
     MatrixSdk(#[from] matrix_sdk::Error),
 
-    #[error("Error in the MatrixSDK HTTP")]
+    #[error("Error in the MatrixSDK HTTP: {0}")]
     HttpError(#[from] matrix_sdk::HttpError),
 
     #[error("Not a known Acter Event")]

--- a/native/core/src/events/settings/space.rs
+++ b/native/core/src/events/settings/space.rs
@@ -17,6 +17,9 @@ impl SimpleSettingWithTurnOff {
     pub fn off() -> Option<Self> {
         Some(SimpleSettingWithTurnOff { active: false })
     }
+    pub fn on() -> Option<Self> {
+        Some(SimpleSettingWithTurnOff { active: true })
+    }
     pub fn active(&self) -> bool {
         self.active
     }
@@ -36,6 +39,10 @@ impl SimpleOnOffSetting {
     pub fn off() -> Option<Self> {
         // no need, we are off by default
         None
+    }
+
+    pub fn on() -> Option<Self> {
+        Some(SimpleOnOffSetting { active: true })
     }
 
     pub fn active(&self) -> bool {
@@ -64,11 +71,11 @@ pub type EventsSettings = SimpleSettingWithTurnOff;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent, Builder, Default)]
 #[ruma_event(type = "global.acter.app_settings", kind = State, state_key_type = EmptyStateKey)]
 pub struct ActerAppSettingsContent {
-    news: Option<NewsSettings>,
-    pins: Option<PinsSettings>,
-    events: Option<EventsSettings>,
-    tasks: Option<TasksSettings>,
-    stories: Option<StoriesSettings>,
+    pub(crate) news: Option<NewsSettings>,
+    pub(crate) pins: Option<PinsSettings>,
+    pub(crate) events: Option<EventsSettings>,
+    pub(crate) tasks: Option<TasksSettings>,
+    pub(crate) stories: Option<StoriesSettings>,
 }
 
 impl ActerAppSettingsContent {
@@ -95,6 +102,16 @@ impl ActerAppSettingsContent {
             events: EventsSettings::off(),
             tasks: TasksSettings::off(),
             stories: StoriesSettings::off(),
+        }
+    }
+
+    pub fn creation_defaults() -> ActerAppSettingsContent {
+        ActerAppSettingsContent {
+            news: NewsSettings::on(),
+            pins: PinsSettings::on(),
+            events: EventsSettings::on(),
+            tasks: TasksSettings::on(),
+            stories: StoriesSettings::on(),
         }
     }
 

--- a/native/core/src/spaces/permissions.rs
+++ b/native/core/src/spaces/permissions.rs
@@ -1,0 +1,245 @@
+use matrix_sdk::ruma::{
+    events::{
+        room::power_levels::RoomPowerLevelsEventContent, StaticEventContent, TimelineEventType,
+    },
+    Int,
+};
+use serde::Deserialize;
+
+use crate::events::{
+    attachments::AttachmentEventContent,
+    calendar::CalendarEventEventContent,
+    comments::CommentEventContent,
+    news::NewsEntryEventContent,
+    pins::PinEventContent,
+    rsvp::RsvpEventContent,
+    settings::{
+        ActerAppSettingsContent, SimpleOnOffSettingBuilder, SimpleSettingWithTurnOffBuilder,
+    },
+    stories::StoryEventContent,
+    tasks::{TaskEventContent, TaskListEventContent},
+};
+
+pub fn new_app_permissions_builder() -> AppPermissionsBuilder {
+    AppPermissionsBuilder::new()
+}
+
+#[derive(Clone, Deserialize)]
+pub struct AppPermissionsBuilder {
+    #[serde(default = "ActerAppSettingsContent::creation_defaults")]
+    pub(super) settings: ActerAppSettingsContent,
+    #[serde(default)]
+    pub(super) permissions: RoomPowerLevelsEventContent,
+}
+
+impl Default for AppPermissionsBuilder {
+    fn default() -> Self {
+        Self {
+            settings: ActerAppSettingsContent::creation_defaults(),
+            permissions: RoomPowerLevelsEventContent::default(),
+        }
+    }
+}
+
+impl AppPermissionsBuilder {
+    pub fn new() -> Self {
+        AppPermissionsBuilder::default()
+    }
+
+    pub(crate) fn unpack(self) -> (ActerAppSettingsContent, RoomPowerLevelsEventContent) {
+        let AppPermissionsBuilder {
+            settings,
+            mut permissions,
+        } = self;
+        if settings.news().active()
+            && !permissions
+                .events
+                .contains_key(&<NewsEntryEventContent as StaticEventContent>::TYPE.into())
+        {
+            // set the defaults if not given
+            permissions.events.insert(
+                <NewsEntryEventContent as StaticEventContent>::TYPE.into(),
+                Int::from(100),
+            );
+        }
+        if settings.stories().active()
+            && !permissions
+                .events
+                .contains_key(&<StoryEventContent as StaticEventContent>::TYPE.into())
+        {
+            permissions.events.insert(
+                <StoryEventContent as StaticEventContent>::TYPE.into(),
+                Int::from(0),
+            );
+        }
+        if settings.events().active() {
+            if !permissions
+                .events
+                .contains_key(&<CalendarEventEventContent as StaticEventContent>::TYPE.into())
+            {
+                permissions.events.insert(
+                    <CalendarEventEventContent as StaticEventContent>::TYPE.into(),
+                    Int::from(0),
+                );
+            }
+            if !permissions
+                .events
+                .contains_key(&<RsvpEventContent as StaticEventContent>::TYPE.into())
+            {
+                permissions.events.insert(
+                    <RsvpEventContent as StaticEventContent>::TYPE.into(),
+                    Int::from(0),
+                );
+            }
+        }
+        if settings.pins().active()
+            && !permissions
+                .events
+                .contains_key(&<PinEventContent as StaticEventContent>::TYPE.into())
+        {
+            permissions.events.insert(
+                <PinEventContent as StaticEventContent>::TYPE.into(),
+                Int::from(0),
+            );
+        }
+
+        if settings.tasks().active() {
+            if permissions
+                .events
+                .contains_key(&<TaskListEventContent as StaticEventContent>::TYPE.into())
+            {
+                permissions.events.insert(
+                    <TaskListEventContent as StaticEventContent>::TYPE.into(),
+                    Int::from(0),
+                );
+            }
+            if permissions
+                .events
+                .contains_key(&<TaskEventContent as StaticEventContent>::TYPE.into())
+            {
+                permissions.events.insert(
+                    <TaskEventContent as StaticEventContent>::TYPE.into(),
+                    Int::from(0),
+                );
+            }
+        }
+        (settings, permissions)
+    }
+
+    // Settings functions
+    pub fn news(&mut self, active: bool) {
+        self.settings.news = Some(
+            SimpleSettingWithTurnOffBuilder::default()
+                .active(active)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    pub fn stories(&mut self, active: bool) {
+        self.settings.stories = Some(
+            SimpleOnOffSettingBuilder::default()
+                .active(active)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    pub fn pins(&mut self, active: bool) {
+        self.settings.pins = Some(
+            SimpleSettingWithTurnOffBuilder::default()
+                .active(active)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    pub fn calendar_events(&mut self, active: bool) {
+        self.settings.events = Some(
+            SimpleSettingWithTurnOffBuilder::default()
+                .active(active)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    pub fn tasks(&mut self, active: bool) {
+        self.settings.tasks = Some(
+            SimpleOnOffSettingBuilder::default()
+                .active(active)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    fn set_for_key(&mut self, key: TimelineEventType, value: u32) {
+        self.permissions.events.insert(key, Int::from(value));
+    }
+
+    pub fn news_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <NewsEntryEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn stories_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <StoryEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn calendar_events_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <CalendarEventEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn task_lists_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <TaskListEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn tasks_permisisons(&mut self, value: u32) {
+        self.set_for_key(<TaskEventContent as StaticEventContent>::TYPE.into(), value)
+    }
+    pub fn pins_permisisons(&mut self, value: u32) {
+        self.set_for_key(<PinEventContent as StaticEventContent>::TYPE.into(), value)
+    }
+    pub fn comments_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <CommentEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn attachments_permisisons(&mut self, value: u32) {
+        self.set_for_key(
+            <AttachmentEventContent as StaticEventContent>::TYPE.into(),
+            value,
+        )
+    }
+    pub fn rsvp_permisisons(&mut self, value: u32) {
+        self.set_for_key(<RsvpEventContent as StaticEventContent>::TYPE.into(), value)
+    }
+    pub fn events_default(&mut self, value: u32) {
+        self.permissions.events_default = Int::from(value);
+    }
+    pub fn users_default(&mut self, value: u32) {
+        self.permissions.users_default = Int::from(value);
+    }
+    pub fn state_default(&mut self, value: u32) {
+        self.permissions.state_default = Int::from(value);
+    }
+    pub fn kick(&mut self, value: u32) {
+        self.permissions.kick = Int::from(value);
+    }
+    pub fn ban(&mut self, value: u32) {
+        self.permissions.ban = Int::from(value);
+    }
+    pub fn invite(&mut self, value: u32) {
+        self.permissions.invite = Int::from(value);
+    }
+    pub fn redact(&mut self, value: u32) {
+        self.permissions.redact = Int::from(value);
+    }
+}

--- a/native/test/src/tests/invitation.rs
+++ b/native/test/src/tests/invitation.rs
@@ -21,7 +21,7 @@ async fn chat_invitation_shows_up() -> Result<()> {
     let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
 
     let convo = Retry::spawn(retry_strategy.clone(), || async {
-        sisko.convo(room_id.as_str().try_into()?).await
+        sisko.convo(room_id.as_str().into()).await
     })
     .await?;
 
@@ -67,7 +67,7 @@ async fn space_invitation_shows_up() -> Result<()> {
     let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
 
     let space = Retry::spawn(retry_strategy.clone(), || async {
-        sisko.space(room_id.as_str().try_into()?).await
+        sisko.space(room_id.as_str().into()).await
     })
     .await?;
 

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -1795,6 +1795,17 @@ class Api {
     return tmp1;
   }
 
+  /// make app permissions builder
+  AppPermissionsBuilder newAppPermissionsBuilder() {
+    final tmp0 = _newAppPermissionsBuilder();
+    final tmp2 = tmp0;
+    final ffi.Pointer<ffi.Void> tmp2_0 = ffi.Pointer.fromAddress(tmp2);
+    final tmp2_1 = _Box(this, tmp2_0, "drop_box_AppPermissionsBuilder");
+    tmp2_1._finalizer = this._registerFinalizer(tmp2_1);
+    final tmp1 = AppPermissionsBuilder._(this, tmp2_1);
+    return tmp1;
+  }
+
   /// make convo settings builder
   CreateConvoSettingsBuilder newConvoSettingsBuilder() {
     final tmp0 = _newConvoSettingsBuilder();
@@ -18212,6 +18223,12 @@ class Api {
 
   late final _newJoinRuleBuilder =
       _newJoinRuleBuilderPtr.asFunction<int Function()>();
+  late final _newAppPermissionsBuilderPtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
+          "__new_app_permissions_builder");
+
+  late final _newAppPermissionsBuilder =
+      _newAppPermissionsBuilderPtr.asFunction<int Function()>();
   late final _newConvoSettingsBuilderPtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function()>>(
           "__new_convo_settings_builder");
@@ -27914,6 +27931,279 @@ class Api {
           int Function(
             int,
           )>();
+  late final _appPermissionsBuilderNewsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__AppPermissionsBuilder_news");
+
+  late final _appPermissionsBuilderNews =
+      _appPermissionsBuilderNewsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderPinsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__AppPermissionsBuilder_pins");
+
+  late final _appPermissionsBuilderPins =
+      _appPermissionsBuilderPinsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderStoriesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__AppPermissionsBuilder_stories");
+
+  late final _appPermissionsBuilderStories =
+      _appPermissionsBuilderStoriesPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderCalendarEventsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__AppPermissionsBuilder_calendar_events");
+
+  late final _appPermissionsBuilderCalendarEvents =
+      _appPermissionsBuilderCalendarEventsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderTasksPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint8,
+          )>>("__AppPermissionsBuilder_tasks");
+
+  late final _appPermissionsBuilderTasks =
+      _appPermissionsBuilderTasksPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderNewsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_news_permisisons");
+
+  late final _appPermissionsBuilderNewsPermisisons =
+      _appPermissionsBuilderNewsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderStoriesPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_stories_permisisons");
+
+  late final _appPermissionsBuilderStoriesPermisisons =
+      _appPermissionsBuilderStoriesPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderCalendarEventsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_calendar_events_permisisons");
+
+  late final _appPermissionsBuilderCalendarEventsPermisisons =
+      _appPermissionsBuilderCalendarEventsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderTaskListsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_task_lists_permisisons");
+
+  late final _appPermissionsBuilderTaskListsPermisisons =
+      _appPermissionsBuilderTaskListsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderTasksPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_tasks_permisisons");
+
+  late final _appPermissionsBuilderTasksPermisisons =
+      _appPermissionsBuilderTasksPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderPinsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_pins_permisisons");
+
+  late final _appPermissionsBuilderPinsPermisisons =
+      _appPermissionsBuilderPinsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderCommentsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_comments_permisisons");
+
+  late final _appPermissionsBuilderCommentsPermisisons =
+      _appPermissionsBuilderCommentsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderAttachmentsPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_attachments_permisisons");
+
+  late final _appPermissionsBuilderAttachmentsPermisisons =
+      _appPermissionsBuilderAttachmentsPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderRsvpPermisisonsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_rsvp_permisisons");
+
+  late final _appPermissionsBuilderRsvpPermisisons =
+      _appPermissionsBuilderRsvpPermisisonsPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderKickPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_kick");
+
+  late final _appPermissionsBuilderKick =
+      _appPermissionsBuilderKickPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderBanPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_ban");
+
+  late final _appPermissionsBuilderBan =
+      _appPermissionsBuilderBanPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderInvitePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_invite");
+
+  late final _appPermissionsBuilderInvite =
+      _appPermissionsBuilderInvitePtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderRedactPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_redact");
+
+  late final _appPermissionsBuilderRedact =
+      _appPermissionsBuilderRedactPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderEventsDefaultPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_events_default");
+
+  late final _appPermissionsBuilderEventsDefault =
+      _appPermissionsBuilderEventsDefaultPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderUsersDefaultPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_users_default");
+
+  late final _appPermissionsBuilderUsersDefault =
+      _appPermissionsBuilderUsersDefaultPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
+  late final _appPermissionsBuilderStateDefaultPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.Uint32,
+          )>>("__AppPermissionsBuilder_state_default");
+
+  late final _appPermissionsBuilderStateDefault =
+      _appPermissionsBuilderStateDefaultPtr.asFunction<
+          void Function(
+            int,
+            int,
+          )>();
   late final _accountUserIdPtr = _lookup<
       ffi.NativeFunction<
           ffi.IntPtr Function(
@@ -29168,6 +29458,19 @@ class Api {
           void Function(
             int,
             int,
+            int,
+            int,
+          )>();
+  late final _createSpaceSettingsBuilderSetPermissionsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.IntPtr,
+            ffi.IntPtr,
+          )>>("__CreateSpaceSettingsBuilder_set_permissions");
+
+  late final _createSpaceSettingsBuilderSetPermissions =
+      _createSpaceSettingsBuilderSetPermissionsPtr.asFunction<
+          void Function(
             int,
             int,
           )>();
@@ -58358,6 +58661,349 @@ class ActerUserAppSettingsBuilder {
   }
 }
 
+class AppPermissionsBuilder {
+  final Api _api;
+  final _Box _box;
+
+  AppPermissionsBuilder._(this._api, this._box);
+
+  void news(
+    bool value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._appPermissionsBuilderNews(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  void pins(
+    bool value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._appPermissionsBuilderPins(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  void stories(
+    bool value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._appPermissionsBuilderStories(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  void calendarEvents(
+    bool value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._appPermissionsBuilderCalendarEvents(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  void tasks(
+    bool value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1 ? 1 : 0;
+    _api._appPermissionsBuilderTasks(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed to post boosts
+  void newsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderNewsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed to post stories
+  void storiesPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderStoriesPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed to post calender events
+  void calendarEventsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderCalendarEventsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed for task lists
+  void taskListsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderTaskListsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed for tasks
+  void tasksPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderTasksPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed for pins
+  void pinsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderPinsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed for comments
+  void commentsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderCommentsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed for attachments
+  void attachmentsPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderAttachmentsPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// specific permissions levels needed to rsvp
+  void rsvpPermisisons(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderRsvpPermisisons(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set level to kick a user
+  void kick(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderKick(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set level to ban a user
+  void ban(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderBan(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set level to ban a user
+  void invite(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderInvite(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set level to redact user content
+  void redact(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderRedact(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set default sending level if not specified
+  void eventsDefault(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderEventsDefault(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set the detault level users have when entering
+  void usersDefault(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderUsersDefault(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// set the default state level needed if not specified
+  void stateDefault(
+    int value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1;
+    _api._appPermissionsBuilderStateDefault(
+      tmp0,
+      tmp2,
+    );
+    return;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
 class Account {
   final Api _api;
   final _Box _box;
@@ -61070,6 +61716,22 @@ class CreateSpaceSettingsBuilder {
       tmp2,
       tmp3,
       tmp4,
+    );
+    return;
+  }
+
+  /// set the permissions for apps and events for the space creation
+  void setPermissions(
+    AppPermissionsBuilder value,
+  ) {
+    final tmp1 = value;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    tmp0 = _box.borrow();
+    tmp2 = tmp1._box.move();
+    _api._createSpaceSettingsBuilderSetPermissions(
+      tmp0,
+      tmp2,
     );
     return;
   }


### PR DESCRIPTION
We want stories to be default-on on spaces we create. this adds a new API to do that right at initialization, including power level settings support. Has tests!