### PR TITLE
Fixes : Invitation list not update after accepting invite

### DIFF
--- a/app/lib/features/invitations/widgets/invitation_item_widget.dart
+++ b/app/lib/features/invitations/widgets/invitation_item_widget.dart
@@ -164,6 +164,7 @@ class _InvitationWidgetState extends ConsumerState<InvitationItemWidget> {
     final client = await ref.read(alwaysClientProvider.future);
     try {
       await widget.invitation.accept();
+      ref.invalidate(invitationListProvider);
     } catch (e, s) {
       _log.severe('Failure accepting invite', e, s);
       if (!context.mounted) {

--- a/app/lib/features/invitations/widgets/invitation_item_widget.dart
+++ b/app/lib/features/invitations/widgets/invitation_item_widget.dart
@@ -167,6 +167,7 @@ class _InvitationWidgetState extends ConsumerState<InvitationItemWidget> {
       ref.invalidate(invitationListProvider);
     } catch (e, s) {
       _log.severe('Failure accepting invite', e, s);
+      ref.invalidate(invitationListProvider);
       if (!context.mounted) {
         EasyLoading.dismiss();
         return;


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3-meta/issues/894

I have did missing `ref.invalidate(invitationListProvider);` on Accept Invite success and Error cases and which is fixes the Invitation list updation issues.

Reference Video:

https://github.com/user-attachments/assets/9a1eece1-b48d-4dbb-bafa-02eb2944d5da

Side-note:
- However randomly I notice one issue that even after successfully accepting invite, list is not updating and showing invitation and when we click on it then it is showing below error.
`Failed to accept invite: Unable to join a room we are not invited`

![Screenshot 2025-04-01 at 2 17 32 PM](https://github.com/user-attachments/assets/668f6312-010e-446e-a8dd-800a6c8cb320)

- At the moment everything seems to be working fine after `ref.invalidate(invitationListProvider);` changes and not able to see any at the moment.
