### PR TITLE
chat-ng: open link fix

### DIFF
--- a/app/lib/common/actions/open_link.dart
+++ b/app/lib/common/actions/open_link.dart
@@ -1,5 +1,4 @@
 import 'package:acter/features/settings/providers/settings_providers.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,6 +13,17 @@ Future<bool> openLink({
   return switch (ref.read(openSystemLinkSettingsProvider)) {
     OpenSystemLinkSetting.copy => _copyToClipboard(lang, target),
     OpenSystemLinkSetting.open => await _tryOpeningLink(lang, target),
+  };
+}
+
+Future<bool> openUri({
+  required WidgetRef ref,
+  required Uri uri,
+  required L10n lang,
+}) async {
+  return switch (ref.read(openSystemLinkSettingsProvider)) {
+    OpenSystemLinkSetting.copy => _copyToClipboard(lang, uri.toString()),
+    OpenSystemLinkSetting.open => await launchUrl(uri),
   };
 }
 

--- a/app/lib/common/actions/open_link.dart
+++ b/app/lib/common/actions/open_link.dart
@@ -6,13 +6,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-Future<bool> openLink(
-  WidgetRef ref,
-  String target,
-  BuildContext context,
-) async {
-  final lang = L10n.of(context);
-  return switch (ref.watch(openSystemLinkSettingsProvider)) {
+Future<bool> openLink({
+  required WidgetRef ref,
+  required String target,
+  required L10n lang,
+}) async {
+  return switch (ref.read(openSystemLinkSettingsProvider)) {
     OpenSystemLinkSetting.copy => _copyToClipboard(lang, target),
     OpenSystemLinkSetting.open => await _tryOpeningLink(lang, target),
   };

--- a/app/lib/common/widgets/render_html.dart
+++ b/app/lib/common/widgets/render_html.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/actions/open_link.dart';
+import 'package:acter/l10n/generated/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_matrix_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,7 +19,11 @@ class RenderHtml extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Html(
       onLinkTap: (target) async {
-        await openLink(ref, target.toString(), context);
+        await openLink(
+          ref: ref,
+          target: target.toString(),
+          lang: L10n.of(context),
+        );
       },
       data: text,
       defaultTextStyle: defaultTextStyle,

--- a/app/lib/features/activities/widgets/space_activities_section/space_activities_section_widget.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/space_activities_section_widget.dart
@@ -27,9 +27,9 @@ Widget? buildSpaceActivitiesSectionWidget(BuildContext context, WidgetRef ref) {
           trailing: const Icon(Icons.arrow_forward_ios),
           onTap:
               () => openLink(
-                ref,
-                'https://github.com/acterglobal/a3/issues/2597',
-                context,
+                ref: ref,
+                target: 'https://github.com/acterglobal/a3/issues/2597',
+                lang: L10n.of(context),
               ),
         ),
       ),

--- a/app/lib/features/attachments/widgets/msg_content_attachment_item.dart
+++ b/app/lib/features/attachments/widgets/msg_content_attachment_item.dart
@@ -161,7 +161,11 @@ class MsgContentAttachmentItem extends ConsumerWidget {
   ) async {
     // Open attachment link
     if (attachmentType == AttachmentType.link) {
-      await openLink(ref, attachment.link() ?? '', context);
+      await openLink(
+        ref: ref,
+        target: attachment.link() ?? '',
+        lang: L10n.of(context),
+      );
     } else if (mediaFile == null) {
       // If attachment is media then check media is downloaded
       // If attachment not downloaded

--- a/app/lib/features/chat/utils.dart
+++ b/app/lib/features/chat/utils.dart
@@ -6,6 +6,7 @@ import 'package:acter/features/chat/providers/chat_providers.dart';
 import 'package:acter/features/preview/actions/show_room_preview.dart';
 import 'package:acter/features/deep_linking/actions/handle_deep_link_uri.dart';
 import 'package:acter/features/deep_linking/parse_acter_uri.dart';
+import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter/router/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:acter_trigger_auto_complete/acter_trigger_autocomplete.dart';
@@ -352,7 +353,7 @@ Future<void> onMessageLinkTap(
     ///If link is other than matrix room link
     ///Then open it on browser
     else {
-      await openLink(ref, uri.toString(), context);
+      await openLink(ref: ref, target: uri.toString(), lang: L10n.of(context));
     }
   }
 }

--- a/app/lib/features/chat_ng/widgets/events/text_message_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/text_message_event.dart
@@ -1,15 +1,18 @@
+import 'package:acter/common/actions/open_link.dart';
 import 'package:acter/common/themes/acter_theme.dart';
 import 'package:acter/common/themes/app_theme.dart';
 import 'package:acter/features/chat/widgets/pill_builder.dart';
+import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' show MsgContent;
 import 'package:flutter/material.dart';
 import 'package:flutter_matrix_html/flutter_html.dart';
 import 'package:flutter_matrix_html/text_parser.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:markdown/markdown.dart' as md;
 
 enum TextMessageType { regular, reply, emoji, notice }
 
-class TextMessageEvent extends StatelessWidget {
+class TextMessageEvent extends ConsumerWidget {
   final String roomId;
   final MsgContent content;
   final TextMessageType _type;
@@ -94,7 +97,7 @@ class TextMessageEvent extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final textTheme = Theme.of(context).textTheme;
     final chatTheme = Theme.of(context).chatTheme;
     final colorScheme = Theme.of(context).colorScheme;
@@ -144,6 +147,9 @@ class TextMessageEvent extends StatelessWidget {
               ),
           renderNewlines: true,
           maxLines: _type == TextMessageType.reply ? 2 : null,
+          onLinkTap: (Uri uri) {
+            openUri(ref: ref, uri: uri, lang: L10n.of(context));
+          },
           defaultTextStyle: textTheme.bodySmall?.copyWith(
             color:
                 _type == TextMessageType.notice

--- a/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
+++ b/app/lib/features/news/widgets/news_item_slide/news_slide_actions.dart
@@ -93,7 +93,7 @@ class UpdateSlideActions extends ConsumerWidget {
       return Card(
         child: ListTile(
           leading: const Icon(Atlas.link),
-          onTap: () => openLink(ref, uri, context),
+          onTap: () => openLink(ref: ref, target: uri, lang: L10n.of(context)),
           title: Text(title, maxLines: 2, overflow: TextOverflow.ellipsis),
           subtitle: Text(
             uri,
@@ -107,7 +107,7 @@ class UpdateSlideActions extends ConsumerWidget {
       return Card(
         child: ListTile(
           leading: const Icon(Atlas.link),
-          onTap: () => openLink(ref, uri, context),
+          onTap: () => openLink(ref: ref, target: uri, lang: L10n.of(context)),
           title: Text(
             uri,
             maxLines: 2,

--- a/app/lib/features/news/widgets/news_post_editor/selected_action_button.dart
+++ b/app/lib/features/news/widgets/news_post_editor/selected_action_button.dart
@@ -146,7 +146,7 @@ class SelectedActionButton extends ConsumerWidget {
       child: Card(
         child: ListTile(
           leading: const Icon(Atlas.link),
-          onTap: () => openLink(ref, uri, context),
+          onTap: () => openLink(ref: ref, target: uri, lang: L10n.of(context)),
           title: Text(
             refDetail.title() ?? L10n.of(context).unknown,
             maxLines: 2,

--- a/app/lib/features/pins/widgets/fake_link_attachment_item.dart
+++ b/app/lib/features/pins/widgets/fake_link_attachment_item.dart
@@ -52,7 +52,7 @@ class FakeLinkAttachmentItem extends ConsumerWidget {
       ),
       child: ListTile(
         leading: const Icon(Atlas.link),
-        onTap: () => openLink(ref, link, context),
+        onTap: () => openLink(ref: ref, target: link, lang: L10n.of(context)),
         title: Text(
           link,
           maxLines: 2,


### PR DESCRIPTION
Chat NG didn't adhere to the open link feature to copy to the clipboard. this fixes the behavior.