### PR TITLE
Refactor timeline-related objects

### DIFF
--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -172,7 +172,7 @@ impl Convo {
                 };
                 let room_id = latest_msg_room.room_id();
 
-                let full_event = TimelineItem::new_event_item(user_id.clone(), &msg);
+                let full_event = TimelineItem::new_event_item(&msg, user_id.clone());
                 set_latest_msg(&latest_msg_client, room_id, &last_msg_lock_tl, full_event).await;
             }
             warn!(room_id=?latest_msg_room.room_id(), "Timeline stopped")

--- a/native/acter/src/api/stream.rs
+++ b/native/acter/src/api/stream.rs
@@ -90,7 +90,7 @@ impl TimelineStream {
                 let Some(tl) = timeline.item_by_event_id(&event_id).await else {
                     bail!("Event not found")
                 };
-                Ok(TimelineItem::new_event_item(user_id, &tl))
+                Ok(TimelineItem::new_event_item(&tl, user_id))
             })
             .await?
     }


### PR DESCRIPTION
This PR was split from https://github.com/acterglobal/a3/pull/2751.

- Will remove unnecessary fields in `TimelineItem`, except needed fields.
- Will integrate timeline-related objects into single directory.