### PR TITLE
[Chat NG] - fix file message alignment for own user

### DIFF
--- a/.changes/2792-file-message-alignment.md
+++ b/.changes/2792-file-message-alignment.md
@@ -1,0 +1,2 @@
+- [Labs] Chat NG:
+  - [fix] file messages now correctly appears on user's own side of the chat.

--- a/app/lib/features/chat_ng/widgets/events/file_message_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/file_message_event.dart
@@ -38,22 +38,20 @@ class FileMessageEvent extends ConsumerWidget {
           await notifier.downloadMedia();
         }
       },
-      child: Container(
-        padding: const EdgeInsets.all(20.0),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            getFileIcon(context),
-            const SizedBox(width: 20),
-            fileInfoUI(context),
-            const SizedBox(width: 10),
-            if (mediaState.mediaChatLoadingState.isLoading ||
-                mediaState.isDownloading)
-              const CircularProgressIndicator()
-            else if (mediaState.mediaFile == null)
-              const Icon(Icons.download),
-          ],
-        ),
+
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          getFileIcon(context),
+          const SizedBox(width: 20),
+          fileInfoUI(context),
+          const SizedBox(width: 10),
+          if (mediaState.mediaChatLoadingState.isLoading ||
+              mediaState.isDownloading)
+            const CircularProgressIndicator()
+          else if (mediaState.mediaFile == null)
+            const Icon(Icons.download),
+        ],
       ),
     );
   }
@@ -74,25 +72,19 @@ class FileMessageEvent extends ConsumerWidget {
 
   Widget fileInfoUI(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final colorScheme = Theme.of(context).colorScheme;
     final msgSize = content.size();
     if (msgSize == null) return const SizedBox.shrink();
-    return Expanded(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            content.body(),
-            style: textTheme.labelLarge,
-            overflow: TextOverflow.ellipsis,
-          ),
-          const SizedBox(height: 5),
-          Text(
-            formatBytes(msgSize.truncate()),
-            style: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
-          ),
-        ],
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          content.body(),
+          style: textTheme.labelLarge,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 5),
+        Text(formatBytes(msgSize.truncate()), style: textTheme.labelMedium),
+      ],
     );
   }
 }

--- a/app/lib/features/chat_ng/widgets/events/message_event_item.dart
+++ b/app/lib/features/chat_ng/widgets/events/message_event_item.dart
@@ -130,6 +130,7 @@ class MessageEventItem extends ConsumerWidget {
   ) {
     final msgType = item.msgType();
     final content = item.msgContent();
+    final wasEdited = item.wasEdited();
     // shouldn't happen but in case return empty
     if (msgType == null || content == null) return const SizedBox.shrink();
 
@@ -153,11 +154,27 @@ class MessageEventItem extends ConsumerWidget {
         ),
       ),
       'm.file' => alignedWidget(
-        FileMessageEvent(
-          roomId: roomId,
-          messageId: messageId,
-          content: content,
-        ),
+        isMe
+            ? ChatBubble.me(
+              context: context,
+              isLastMessageBySender: isLastMessageBySender,
+              isEdited: wasEdited,
+              child: FileMessageEvent(
+                roomId: roomId,
+                messageId: messageId,
+                content: content,
+              ),
+            )
+            : ChatBubble(
+              context: context,
+              isLastMessageBySender: isLastMessageBySender,
+              isEdited: wasEdited,
+              child: FileMessageEvent(
+                roomId: roomId,
+                messageId: messageId,
+                content: content,
+              ),
+            ),
       ),
       _ => _buildUnsupportedMessage(msgType),
     };


### PR DESCRIPTION
Fixes #2765.
- Also adjustments to file message UI padding.

## Screenshot:

<img width="757" alt="Screenshot 2025-04-04 at 16 10 34" src="https://github.com/user-attachments/assets/f86e7d48-2641-42f6-8374-522ad4f3dd13" />


<img width="757" alt="Screenshot 2025-04-04 at 16 09 09" src="https://github.com/user-attachments/assets/a2e8c386-d59f-46bd-b76d-094579dca72c" />
