### PR TITLE
[Chat-NG fix] - chat editor content validation

### DIFF
--- a/.changes/2793-chat-ng-editor-fix.md
+++ b/.changes/2793-chat-ng-editor-fix.md
@@ -1,0 +1,2 @@
+- [Labs] Chat NG:
+  - [fix] sending empty messages from chat editor when the content field is empty. Now editor checks for valid content present before sending.

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -175,3 +175,19 @@ extension ColorUtils on Color {
     return (alpha << 24) | (red << 16) | (green << 8) | blue;
   }
 }
+
+/// html requires to have some kind of structure even when document is empty, so check for that
+bool hasValidEditorContent({required String plainText, required String html}) {
+  if (plainText.trim().isEmpty) return false;
+  if (html.isEmpty) return false;
+
+  final hasOnlyStructure =
+      html
+          .replaceAll(RegExp(r'<br\s*/?>|<p\s*></p>|<p\s*>\s*</p>'), '')
+          .replaceAll(RegExp(r'<[^>]*>'), '')
+          .replaceAll('&nbsp;', ' ')
+          .trim()
+          .isEmpty;
+
+  return !hasOnlyStructure;
+}

--- a/app/lib/features/chat_ng/actions/send_message_action.dart
+++ b/app/lib/features/chat_ng/actions/send_message_action.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/providers/chat_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor/html_editor.dart';
 import 'package:acter/common/widgets/html_editor/models/mention_attributes.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
@@ -25,6 +26,11 @@ Future<void> sendMessageAction({
   final lang = L10n.of(context);
   final body = textEditorState.intoMarkdown();
   final html = textEditorState.intoHtml();
+
+  if (!hasValidEditorContent(plainText: body, html: html)) {
+    return;
+  }
+
   final bodyProcessedText = textEditorState.mentionsParsedText(body, null);
   ref.read(chatInputProvider.notifier).startSending();
   try {

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/providers/keyboard_visbility_provider.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor/html_editor.dart';
 import 'package:acter/features/attachments/actions/select_attachment.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
@@ -121,11 +122,12 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
   }
 
   void _editorUpdate(Transaction data) {
-    // check if actual document content is empty
-    final state = data.document.root.children.every(
-      (node) => node.delta?.toPlainText().isEmpty ?? true,
-    );
-    _isInputEmptyNotifier.value = state;
+    final plainText = textEditorState.intoMarkdown();
+    final html = textEditorState.intoHtml();
+
+    _isInputEmptyNotifier.value =
+        !hasValidEditorContent(plainText: plainText, html: html);
+
     _debounceTimer?.cancel();
     // delay operation to avoid excessive re-writes
     _debounceTimer = Timer(const Duration(milliseconds: 300), () async {

--- a/app/test/common/utils/utils_test.dart
+++ b/app/test/common/utils/utils_test.dart
@@ -1,0 +1,92 @@
+import 'package:acter/common/utils/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Editor Content Validation', () {
+    test('returns false for empty plain text', () {
+      expect(
+        hasValidEditorContent(plainText: '', html: '<p>Some content</p>'),
+        false,
+      );
+    });
+
+    test('returns false for empty HTML', () {
+      expect(hasValidEditorContent(plainText: 'Some text', html: ''), false);
+    });
+
+    test('returns false for whitespace-only plain text', () {
+      expect(
+        hasValidEditorContent(plainText: '   ', html: '<p>Some content</p>'),
+        false,
+      );
+    });
+
+    test('returns false for HTML with only <br> tag', () {
+      expect(
+        hasValidEditorContent(plainText: 'Some text', html: '<br>'),
+        false,
+      );
+    });
+
+    test('returns false for HTML with only empty paragraph', () {
+      expect(
+        hasValidEditorContent(plainText: 'Some text', html: '<p></p>'),
+        false,
+      );
+    });
+
+    test('returns false for HTML with only whitespace in paragraph', () {
+      expect(
+        hasValidEditorContent(plainText: 'Some text', html: '<p>   </p>'),
+        false,
+      );
+    });
+
+    test('returns false for HTML with only &nbsp;', () {
+      expect(
+        hasValidEditorContent(plainText: 'Some text', html: '<p>&nbsp;</p>'),
+        false,
+      );
+    });
+
+    test('returns true for valid plain text and HTML content', () {
+      expect(
+        hasValidEditorContent(
+          plainText: 'Hello World',
+          html: '<p>Hello World</p>',
+        ),
+        true,
+      );
+    });
+
+    test('returns true for HTML with formatting but valid content', () {
+      expect(
+        hasValidEditorContent(
+          plainText: 'Hello World',
+          html: '<p><strong>Hello</strong> <em>World</em></p>',
+        ),
+        true,
+      );
+    });
+
+    test('returns true for HTML with multiple paragraphs', () {
+      expect(
+        hasValidEditorContent(
+          plainText: 'Hello\nWorld',
+          html: '<p>Hello</p><p>World</p>',
+        ),
+        true,
+      );
+    });
+
+    test('returns true for HTML with line breaks and content', () {
+      expect(
+        hasValidEditorContent(
+          plainText: 'Hello\nWorld',
+          html: '<p>Hello<br>World</p>',
+        ),
+        true,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description:

Fix for #2763. Adds a validation for proper html structure checking whether its content is valid or exists with proper tests supporting the case .i.e. Appflowy html encoders still bounds to return some structure with empty text. So that needs to taken care of.

### Preview:

- Video where I showcased, trying different scenarios of empty content format but send button state doesn't appear unless, contains valid content.

https://github.com/user-attachments/assets/aaf0a46c-403b-46de-87ea-57a112bbe18e


