### PR TITLE
always show the overview section, regardless of whether we  have a topic

### DIFF
--- a/app/lib/features/space/providers/space_navbar_provider.dart
+++ b/app/lib/features/space/providers/space_navbar_provider.dart
@@ -25,12 +25,17 @@ enum TabEntry {
 class TabsNotifier extends FamilyNotifier<List<TabEntry>, String> {
   @override
   List<TabEntry> build(String spaceId) => [
-    if (ref.watch(topicProvider(spaceId)).valueOrNull != null)
-      TabEntry.overview,
+    // always show overview the first tab
+    TabEntry.overview,
+    // specific feature tabs
     if (ref.watch(isActerSpace(spaceId)).valueOrNull == true)
       ..._getFeatures(spaceId),
+
+    // child space related
     ..._childSpaces(spaceId),
+    // members
     TabEntry.members,
+    // and further actions
     ..._getActions(spaceId),
   ];
 

--- a/app/lib/features/space/providers/space_navbar_provider.dart
+++ b/app/lib/features/space/providers/space_navbar_provider.dart
@@ -3,7 +3,6 @@ import 'package:acter/common/providers/space_providers.dart';
 import 'package:acter/features/events/providers/event_providers.dart';
 import 'package:acter/features/news/providers/news_providers.dart';
 import 'package:acter/features/pins/providers/pins_provider.dart';
-import 'package:acter/features/space/providers/topic_provider.dart';
 import 'package:acter/features/tasks/providers/tasklists_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/app/test/features/spaces/provider/space_navabar_provider_test.dart
+++ b/app/test/features/spaces/provider/space_navabar_provider_test.dart
@@ -77,7 +77,7 @@ void main() {
         expect(next, equals([TabEntry.overview, TabEntry.members]));
       });
 
-      test('shows only members if nothing exists', () async {
+      test('shows it even if only members exists', () async {
         // Override the allActivitiesProvider to return our mock activities
         container = ProviderContainer(
           overrides: [
@@ -92,7 +92,7 @@ void main() {
 
         await container.pump();
         final next = container.read(tabsProvider(testSpaceId));
-        expect(next, equals([TabEntry.members]));
+        expect(next, equals([TabEntry.overview, TabEntry.members]));
       });
 
       group('updates', () {
@@ -463,7 +463,7 @@ void main() {
         expect(next, contains(TabEntry.members));
       });
 
-      test('shows only members if nothing exists', () async {
+      test('shows overview and members even without a topic ', () async {
         // Override the allActivitiesProvider to return our mock activities
         container = ProviderContainer(
           overrides: [
@@ -479,7 +479,7 @@ void main() {
 
         await container.pump();
         final next = container.read(tabsProvider(testSpaceId));
-        expect(next, equals([TabEntry.members]));
+        expect(next, equals([TabEntry.overview, TabEntry.members]));
       });
     });
 


### PR DESCRIPTION
Fixes the problem that the "Upgrade Button" doesn't show if there is no topic on a non-acter-space.
on top of #2780 