### PR TITLE
[Chat-NG] allow opening member info drawer on message avatar

### DIFF
--- a/.changes/2814-avatar-interaction.md
+++ b/.changes/2814-avatar-interaction.md
@@ -1,0 +1,2 @@
+- [Labs] Chat NG:
+  - [fix] tapping on chat message avatar should open member info drawer now.

--- a/app/lib/features/chat_ng/widgets/events/chat_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/chat_event.dart
@@ -3,6 +3,7 @@ import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/features/chat_ng/providers/chat_room_messages_provider.dart';
 import 'package:acter/features/chat_ng/utils.dart';
 import 'package:acter/features/chat_ng/widgets/events/chat_event_item.dart';
+import 'package:acter/features/member/dialogs/show_member_info_drawer.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart'
@@ -87,20 +88,7 @@ class ChatEvent extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           shouldShowAvatar
-              ? Padding(
-                padding: const EdgeInsets.only(left: 8),
-                child: ActerAvatar(
-                  options: AvatarOptions.DM(
-                    ref.watch(
-                      memberAvatarInfoProvider((
-                        roomId: roomId,
-                        userId: item.sender(),
-                      )),
-                    ),
-                    size: 14,
-                  ),
-                ),
-              )
+              ? _buildAvatar(ctx, ref, item.sender())
               : const SizedBox(width: 40),
           Flexible(
             child: ChatEventItem(
@@ -115,6 +103,28 @@ class ChatEvent extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildAvatar(BuildContext context, WidgetRef ref, String userId) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 8),
+      child: GestureDetector(
+        onTap:
+            () => showMemberInfoDrawer(
+              context: context,
+              roomId: roomId,
+              memberId: userId,
+            ),
+        child: ActerAvatar(
+          options: AvatarOptions.DM(
+            ref.watch(
+              memberAvatarInfoProvider((roomId: roomId, userId: userId)),
+            ),
+            size: 14,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
- fixes #2799.

https://github.com/user-attachments/assets/75de3600-1557-423e-a6c9-358fd53f5bf1

