### PR TITLE
Extend timeline event item to cover policy rule room

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1031,6 +1031,9 @@ object TimelineEventItem {
     /// covers some of m.room.member
     fn profile_content() -> Option<ProfileContent>;
 
+    /// covers m.policy.rule.room
+    fn policy_rule_room_content() -> Option<PolicyRuleRoomContent>;
+
     /// original event id, if this msg is reply to another msg
     fn in_reply_to() -> Option<string>;
 
@@ -1192,6 +1195,31 @@ object JoinRuleBuilder {
     fn join_rule(input: string);
     fn add_room(room: string);
 }
+
+
+//  ########   #######   #######  ##     ##     ######  ########    ###    ######## ########     ######  ##     ##    ###    ##    ##  ######   ######## 
+//  ##     ## ##     ## ##     ## ###   ###    ##    ##    ##      ## ##      ##    ##          ##    ## ##     ##   ## ##   ###   ## ##    ##  ##       
+//  ##     ## ##     ## ##     ## #### ####    ##          ##     ##   ##     ##    ##          ##       ##     ##  ##   ##  ####  ## ##        ##       
+//  ########  ##     ## ##     ## ## ### ##     ######     ##    ##     ##    ##    ######      ##       ######### ##     ## ## ## ## ##   #### ######   
+//  ##   ##   ##     ## ##     ## ##     ##          ##    ##    #########    ##    ##          ##       ##     ## ######### ##  #### ##    ##  ##       
+//  ##    ##  ##     ## ##     ## ##     ##    ##    ##    ##    ##     ##    ##    ##          ##    ## ##     ## ##     ## ##   ### ##    ##  ##       
+//  ##     ##  #######   #######  ##     ##     ######     ##    ##     ##    ##    ########     ######  ##     ## ##     ## ##    ##  ######   ######## 
+
+
+object PolicyRuleRoomContent {
+    fn entity_change() -> Option<string>;
+    fn entity_new_val() -> string;
+    fn entity_old_val() -> Option<string>;
+
+    fn reason_change() -> Option<string>;
+    fn reason_new_val() -> string;
+    fn reason_old_val() -> Option<string>;
+
+    fn recommendation_change() -> Option<string>;
+    fn recommendation_new_val() -> string;
+    fn recommendation_old_val() -> Option<string>;
+}
+
 
 //  ########   #######   #######  ##     ##
 //  ##     ## ##     ## ##     ## ###   ###
@@ -1595,6 +1623,11 @@ object Convo {
 
     /// get the internal reference object, defined in Room
     fn ref_details() -> Future<Result<RefDetails>>;
+
+    /// set a moderation policy rule which affects room IDs and room aliases.
+    /// entity: #*:example.org
+    /// reason: undesirable content
+    fn set_policy_rule_room(entity: string, reason: string) -> Future<Result<EventId>>;
 }
 
 
@@ -2637,6 +2670,11 @@ object Space {
 
     /// get the internal reference object, defined in Room
     fn ref_details() -> Future<Result<RefDetails>>;
+
+    /// set a moderation policy rule which affects room IDs and room aliases.
+    /// entity: #*:example.org
+    /// reason: undesirable content
+    fn set_policy_rule_room(entity: string, reason: string) -> Future<Result<EventId>>;
 }
 
 enum MembershipStatus {

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -66,7 +66,7 @@ pub use acter_core::{
         UtcDateTime,
     },
     models::{
-        status::{MembershipContent, ProfileContent},
+        status::{MembershipContent, PolicyRuleRoomContent, ProfileContent},
         ActerModel, Tag, TextMessageContent,
     },
 };

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -1,5 +1,5 @@
 use acter_core::{
-    models::status::{MembershipContent, ProfileContent},
+    models::status::{MembershipContent, PolicyRuleRoomContent, ProfileContent},
     util::do_vecs_match,
 };
 use anyhow::{bail, Result};
@@ -286,6 +286,14 @@ impl TimelineEventItem {
         }
     }
 
+    pub fn policy_rule_room_content(&self) -> Option<PolicyRuleRoomContent> {
+        if let Some(TimelineEventContent::PolicyRuleRoom(c)) = &self.content {
+            Some(c.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn in_reply_to(&self) -> Option<String> {
         self.in_reply_to.as_ref().map(ToString::to_string)
     }
@@ -340,52 +348,13 @@ impl TimelineEventItem {
 impl TimelineEventItemBuilder {
     fn handle_other_state(&mut self, state: &OtherState) {
         match state.content() {
-            AnyOtherFullStateEventContent::PolicyRuleRoom(c) => {
+            AnyOtherFullStateEventContent::PolicyRuleRoom(FullStateEventContent::Original {
+                content,
+                prev_content,
+            }) => {
                 self.event_type("m.policy.rule.room".to_owned());
-                let msg_content = match c {
-                    FullStateEventContent::Original {
-                        content,
-                        prev_content,
-                    } => {
-                        let PolicyRuleRoomEventContent(cur) = content;
-                        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev)) = prev_content
-                        {
-                            let mut result = vec![];
-                            if let Some(entity) = prev.entity.clone() {
-                                if entity != cur.entity {
-                                    result.push("changed entity".to_owned());
-                                }
-                            } else {
-                                result.push("added entity".to_owned());
-                            }
-                            if let Some(reason) = prev.reason.clone() {
-                                if reason != cur.reason {
-                                    result.push("changed reason".to_owned());
-                                }
-                            } else {
-                                result.push("added reason".to_owned());
-                            }
-                            if let Some(recommendation) = prev.recommendation.clone() {
-                                if recommendation.ne(&cur.recommendation) {
-                                    result.push("changed recommendation".to_owned());
-                                }
-                            } else {
-                                result.push("added recommendation".to_owned());
-                            }
-                            if result.is_empty() {
-                                MsgContent::from_text("empty content".to_owned())
-                            } else {
-                                MsgContent::from_text(result.join(", "))
-                            }
-                        } else {
-                            MsgContent::from_text("added policy room rule".to_owned())
-                        }
-                    }
-                    FullStateEventContent::Redacted(r) => {
-                        MsgContent::from_text("deleted policy room rule".to_owned())
-                    }
-                };
-                self.content(Some(TimelineEventContent::Message(msg_content)));
+                let c = PolicyRuleRoomContent::new(content.clone(), prev_content.clone());
+                self.content(Some(TimelineEventContent::PolicyRuleRoom(c)));
             }
             AnyOtherFullStateEventContent::PolicyRuleServer(c) => {
                 self.event_type("m.policy.rule.server".to_owned());

--- a/native/acter/src/api/timeline/room_event.rs
+++ b/native/acter/src/api/timeline/room_event.rs
@@ -1,4 +1,4 @@
-use acter_core::models::status::{MembershipContent, ProfileContent};
+use acter_core::models::status::{MembershipContent, PolicyRuleRoomContent, ProfileContent};
 use matrix_sdk_base::ruma::events::room::message::MessageType;
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +10,7 @@ pub enum TimelineEventContent {
     Message(MsgContent),
     MembershipChange(MembershipContent),
     ProfileChange(ProfileContent),
+    PolicyRuleRoom(PolicyRuleRoomContent),
 }
 
 impl TryFrom<&MessageType> for TimelineEventContent {

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -13,7 +13,7 @@ use crate::{
         UtcDateTime,
     },
     models::{
-        status::{MembershipContent, ProfileContent},
+        status::{MembershipContent, PolicyRuleRoomContent, ProfileContent},
         ActerModel, ActerSupportedRoomStatusEvents, AnyActerModel, EventMeta, Task,
     },
     store::Store,
@@ -26,6 +26,7 @@ pub mod status;
 pub enum ActivityContent {
     MembershipChange(MembershipContent),
     ProfileChange(ProfileContent),
+    PolicyRuleRoom(PolicyRuleRoomContent),
     RoomCreate(RoomCreateEventContent),
     RoomName(String),
     Boost {
@@ -136,6 +137,7 @@ impl Activity {
                     unreachable!()
                 }
             }
+            ActivityContent::PolicyRuleRoom(_) => "policyRuleRoom",
             ActivityContent::RoomCreate(_) => "roomCreate",
             ActivityContent::RoomName(_) => "roomName",
             ActivityContent::Comment { .. } => "comment",
@@ -202,6 +204,7 @@ impl Activity {
         match &self.inner {
             ActivityContent::MembershipChange(_)
             | ActivityContent::ProfileChange(_)
+            | ActivityContent::PolicyRuleRoom(_)
             | ActivityContent::RoomCreate(_)
             | ActivityContent::RoomName(_) => None,
 
@@ -299,6 +302,7 @@ impl Activity {
             }
             ActivityContent::MembershipChange(_)
             | ActivityContent::ProfileChange(_)
+            | ActivityContent::PolicyRuleRoom(_)
             | ActivityContent::RoomCreate(_)
             | ActivityContent::RoomName(_) => todo!(),
         }
@@ -336,6 +340,9 @@ impl Activity {
                 }
                 ActerSupportedRoomStatusEvents::ProfileChange(c) => {
                     Ok(Self::new(meta, ActivityContent::ProfileChange(c)))
+                }
+                ActerSupportedRoomStatusEvents::PolicyRuleRoom(c) => {
+                    Ok(Self::new(meta, ActivityContent::PolicyRuleRoom(c)))
                 }
                 ActerSupportedRoomStatusEvents::RoomCreate(c) => {
                     Ok(Self::new(meta, ActivityContent::RoomCreate(c)))

--- a/native/core/src/models/status/mod.rs
+++ b/native/core/src/models/status/mod.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 
 mod membership;
 mod profile;
+mod room_state;
 
 use crate::{
     events::AnyActerEvent,
@@ -17,6 +18,7 @@ use crate::{
 };
 pub use membership::MembershipContent;
 pub use profile::{Change, ProfileContent};
+pub use room_state::PolicyRuleRoomContent;
 
 use super::{conversion::ParseError, ActerModel, Capability, EventMeta, Store};
 
@@ -24,6 +26,7 @@ use super::{conversion::ParseError, ActerModel, Capability, EventMeta, Store};
 pub enum ActerSupportedRoomStatusEvents {
     MembershipChange(MembershipContent),
     ProfileChange(ProfileContent),
+    PolicyRuleRoom(PolicyRuleRoomContent),
     RoomCreate(RoomCreateEventContent),
     RoomName(String),
 }
@@ -98,6 +101,16 @@ impl TryFrom<AnyStateEvent> for RoomStatus {
                 };
                 Ok(RoomStatus {
                     inner: inner_status,
+                    meta,
+                })
+            }
+            AnyStateEvent::PolicyRuleRoom(StateEvent::Original(inner)) => {
+                let content = PolicyRuleRoomContent::new(
+                    inner.content.clone(),
+                    inner.unsigned.prev_content.clone(),
+                );
+                Ok(RoomStatus {
+                    inner: ActerSupportedRoomStatusEvents::PolicyRuleRoom(content),
                     meta,
                 })
             }

--- a/native/core/src/models/status/room_state.rs
+++ b/native/core/src/models/status/room_state.rs
@@ -1,0 +1,107 @@
+use matrix_sdk_base::ruma::events::policy::rule::room::{
+    PolicyRuleRoomEventContent, PossiblyRedactedPolicyRuleRoomEventContent,
+};
+use serde::{Deserialize, Serialize};
+
+// m.policy.rule.room
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PolicyRuleRoomContent {
+    content: PolicyRuleRoomEventContent,
+    prev_content: Option<PossiblyRedactedPolicyRuleRoomEventContent>,
+}
+
+impl PolicyRuleRoomContent {
+    pub fn new(
+        content: PolicyRuleRoomEventContent,
+        prev_content: Option<PossiblyRedactedPolicyRuleRoomEventContent>,
+    ) -> Self {
+        PolicyRuleRoomContent {
+            content,
+            prev_content,
+        }
+    }
+
+    pub fn entity_change(&self) -> Option<String> {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            if let Some(prev_entity) = &prev_content.entity {
+                if content.entity == *prev_entity {
+                    return None;
+                } else {
+                    return Some("Changed".to_owned());
+                }
+            }
+        }
+        Some("Set".to_owned())
+    }
+
+    pub fn entity_new_val(&self) -> String {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        content.entity.clone()
+    }
+
+    pub fn entity_old_val(&self) -> Option<String> {
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            prev_content.entity.clone()
+        } else {
+            None
+        }
+    }
+
+    pub fn reason_change(&self) -> Option<String> {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            if let Some(prev_reason) = &prev_content.reason {
+                if content.reason == *prev_reason {
+                    return None;
+                } else {
+                    return Some("Changed".to_owned());
+                }
+            }
+        }
+        Some("Set".to_owned())
+    }
+
+    pub fn reason_new_val(&self) -> String {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        content.reason.clone()
+    }
+
+    pub fn reason_old_val(&self) -> Option<String> {
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            prev_content.reason.clone()
+        } else {
+            None
+        }
+    }
+
+    pub fn recommendation_change(&self) -> Option<String> {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            if let Some(prev_recommendation) = &prev_content.recommendation {
+                if content.recommendation == *prev_recommendation {
+                    return None;
+                } else {
+                    return Some("Changed".to_owned());
+                }
+            }
+        }
+        Some("Set".to_owned())
+    }
+
+    pub fn recommendation_new_val(&self) -> String {
+        let PolicyRuleRoomEventContent(content) = &self.content;
+        content.recommendation.to_string()
+    }
+
+    pub fn recommendation_old_val(&self) -> Option<String> {
+        if let Some(PossiblyRedactedPolicyRuleRoomEventContent(prev_content)) = &self.prev_content {
+            prev_content
+                .recommendation
+                .as_ref()
+                .map(ToString::to_string)
+        } else {
+            None
+        }
+    }
+}

--- a/native/test/src/tests/room/mod.rs
+++ b/native/test/src/tests/room/mod.rs
@@ -1,1 +1,2 @@
+mod policy_rule_room;
 mod user_settings;

--- a/native/test/src/tests/room/policy_rule_room.rs
+++ b/native/test/src/tests/room/policy_rule_room.rs
@@ -1,0 +1,106 @@
+use acter::api::TimelineItem;
+use anyhow::Result;
+use core::time::Duration;
+use futures::{pin_mut, stream::StreamExt, FutureExt};
+use tokio::time::sleep;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::random_user_with_random_convo;
+
+#[tokio::test]
+async fn test_policy_rule_room() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut user, room_id) = random_user_with_random_convo("policy_rule_room").await?;
+    let state_sync = user.start_sync();
+    state_sync.await_has_synced_history().await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    let target_id = room_id.clone();
+    Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        let room_id = target_id.clone();
+        async move { client.convo(room_id.to_string()).await }
+    })
+    .await?;
+
+    let convo = user.convo(room_id.to_string()).await?;
+    let timeline = convo.timeline_stream();
+    let stream = timeline.messages_stream();
+    pin_mut!(stream);
+
+    let policy_event_id = convo
+        .set_policy_rule_room(
+            "#*:example.org".to_owned(),
+            "undesirable content".to_owned(),
+        )
+        .await?;
+
+    // room state event may reach via pushback action or reset action
+    let mut i = 30;
+    let mut found_event_id = None;
+    while i > 0 {
+        if let Some(diff) = stream.next().now_or_never().flatten() {
+            match diff.action().as_str() {
+                "PushBack" | "Set" => {
+                    let value = diff
+                        .value()
+                        .expect("diff pushback action should have valid value");
+                    if let Some(event_id) = match_msg(&value, "Set", "#*:example.org") {
+                        found_event_id = Some(event_id);
+                    }
+                }
+                "Reset" => {
+                    let values = diff
+                        .values()
+                        .expect("diff reset action should have valid values");
+                    for value in values.iter() {
+                        if let Some(event_id) = match_msg(value, "Set", "#*:example.org") {
+                            found_event_id = Some(event_id);
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            // yay
+            if found_event_id.is_some() {
+                break;
+            }
+        }
+        i -= 1;
+        sleep(Duration::from_secs(1)).await;
+    }
+    assert_eq!(
+        found_event_id,
+        Some(policy_event_id.to_string()),
+        "Even after 30 seconds, policy rule room not received",
+    );
+
+    Ok(())
+}
+
+fn match_msg(msg: &TimelineItem, change: &str, new_val: &str) -> Option<String> {
+    if msg.is_virtual() {
+        return None;
+    }
+    let event_item = msg.event_item().expect("room msg should have event item");
+    let Some(content) = event_item.policy_rule_room_content() else {
+        return None;
+    };
+    let Some(chg) = content.entity_change() else {
+        return None;
+    };
+    if chg != change {
+        return None;
+    }
+    if content.entity_new_val() != new_val {
+        return None;
+    }
+    event_item.event_id()
+}

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -7172,6 +7172,51 @@ class Api {
     return tmp7;
   }
 
+  EventId? __convoSetPolicyRuleRoomFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _convoSetPolicyRuleRoomFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
   EventId? __commentDraftSendFuturePoll(int boxed, int postCobject, int port) {
     final tmp0 = boxed;
     final tmp2 = postCobject;
@@ -10327,6 +10372,51 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_RefDetails");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = RefDetails._(this, tmp13_1);
+    return tmp7;
+  }
+
+  EventId? __spaceSetPolicyRuleRoomFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceSetPolicyRuleRoomFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
     return tmp7;
   }
 
@@ -19520,6 +19610,17 @@ class Api {
   late final _timelineEventItemProfileContent =
       _timelineEventItemProfileContentPtr
           .asFunction<_TimelineEventItemProfileContentReturn Function(int)>();
+  late final _timelineEventItemPolicyRuleRoomContentPtr = _lookup<
+    ffi.NativeFunction<
+      _TimelineEventItemPolicyRuleRoomContentReturn Function(ffi.IntPtr)
+    >
+  >("__TimelineEventItem_policy_rule_room_content");
+
+  late final _timelineEventItemPolicyRuleRoomContent =
+      _timelineEventItemPolicyRuleRoomContentPtr
+          .asFunction<
+            _TimelineEventItemPolicyRuleRoomContentReturn Function(int)
+          >();
   late final _timelineEventItemInReplyToPtr = _lookup<
     ffi.NativeFunction<_TimelineEventItemInReplyToReturn Function(ffi.IntPtr)>
   >("__TimelineEventItem_in_reply_to");
@@ -19876,6 +19977,93 @@ class Api {
   late final _joinRuleBuilderAddRoom =
       _joinRuleBuilderAddRoomPtr
           .asFunction<void Function(int, int, int, int)>();
+  late final _policyRuleRoomContentEntityChangePtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentEntityChangeReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_entity_change");
+
+  late final _policyRuleRoomContentEntityChange =
+      _policyRuleRoomContentEntityChangePtr
+          .asFunction<_PolicyRuleRoomContentEntityChangeReturn Function(int)>();
+  late final _policyRuleRoomContentEntityNewValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentEntityNewValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_entity_new_val");
+
+  late final _policyRuleRoomContentEntityNewVal =
+      _policyRuleRoomContentEntityNewValPtr
+          .asFunction<_PolicyRuleRoomContentEntityNewValReturn Function(int)>();
+  late final _policyRuleRoomContentEntityOldValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentEntityOldValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_entity_old_val");
+
+  late final _policyRuleRoomContentEntityOldVal =
+      _policyRuleRoomContentEntityOldValPtr
+          .asFunction<_PolicyRuleRoomContentEntityOldValReturn Function(int)>();
+  late final _policyRuleRoomContentReasonChangePtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentReasonChangeReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_reason_change");
+
+  late final _policyRuleRoomContentReasonChange =
+      _policyRuleRoomContentReasonChangePtr
+          .asFunction<_PolicyRuleRoomContentReasonChangeReturn Function(int)>();
+  late final _policyRuleRoomContentReasonNewValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentReasonNewValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_reason_new_val");
+
+  late final _policyRuleRoomContentReasonNewVal =
+      _policyRuleRoomContentReasonNewValPtr
+          .asFunction<_PolicyRuleRoomContentReasonNewValReturn Function(int)>();
+  late final _policyRuleRoomContentReasonOldValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentReasonOldValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_reason_old_val");
+
+  late final _policyRuleRoomContentReasonOldVal =
+      _policyRuleRoomContentReasonOldValPtr
+          .asFunction<_PolicyRuleRoomContentReasonOldValReturn Function(int)>();
+  late final _policyRuleRoomContentRecommendationChangePtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentRecommendationChangeReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_recommendation_change");
+
+  late final _policyRuleRoomContentRecommendationChange =
+      _policyRuleRoomContentRecommendationChangePtr
+          .asFunction<
+            _PolicyRuleRoomContentRecommendationChangeReturn Function(int)
+          >();
+  late final _policyRuleRoomContentRecommendationNewValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentRecommendationNewValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_recommendation_new_val");
+
+  late final _policyRuleRoomContentRecommendationNewVal =
+      _policyRuleRoomContentRecommendationNewValPtr
+          .asFunction<
+            _PolicyRuleRoomContentRecommendationNewValReturn Function(int)
+          >();
+  late final _policyRuleRoomContentRecommendationOldValPtr = _lookup<
+    ffi.NativeFunction<
+      _PolicyRuleRoomContentRecommendationOldValReturn Function(ffi.IntPtr)
+    >
+  >("__PolicyRuleRoomContent_recommendation_old_val");
+
+  late final _policyRuleRoomContentRecommendationOldVal =
+      _policyRuleRoomContentRecommendationOldValPtr
+          .asFunction<
+            _PolicyRuleRoomContentRecommendationOldValReturn Function(int)
+          >();
   late final _roomRoomIdStrPtr =
       _lookup<ffi.NativeFunction<_RoomRoomIdStrReturn Function(ffi.IntPtr)>>(
         "__Room_room_id_str",
@@ -20899,6 +21087,23 @@ class Api {
 
   late final _convoRefDetails =
       _convoRefDetailsPtr.asFunction<int Function(int)>();
+  late final _convoSetPolicyRuleRoomPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.UintPtr,
+        ffi.UintPtr,
+        ffi.IntPtr,
+        ffi.UintPtr,
+        ffi.UintPtr,
+      )
+    >
+  >("__Convo_set_policy_rule_room");
+
+  late final _convoSetPolicyRuleRoom =
+      _convoSetPolicyRuleRoomPtr
+          .asFunction<int Function(int, int, int, int, int, int, int)>();
   late final _commentDraftContentTextPtr = _lookup<
     ffi.NativeFunction<
       ffi.Void Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
@@ -23764,6 +23969,23 @@ class Api {
 
   late final _spaceRefDetails =
       _spaceRefDetailsPtr.asFunction<int Function(int)>();
+  late final _spaceSetPolicyRuleRoomPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.UintPtr,
+        ffi.UintPtr,
+        ffi.IntPtr,
+        ffi.UintPtr,
+        ffi.UintPtr,
+      )
+    >
+  >("__Space_set_policy_rule_room");
+
+  late final _spaceSetPolicyRuleRoom =
+      _spaceSetPolicyRuleRoomPtr
+          .asFunction<int Function(int, int, int, int, int, int, int)>();
   late final _memberGetProfilePtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr)>>(
         "__Member_get_profile",
@@ -28529,6 +28751,21 @@ class Api {
           .asFunction<
             _ConvoRefDetailsFuturePollReturn Function(int, int, int)
           >();
+  late final _convoSetPolicyRuleRoomFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _ConvoSetPolicyRuleRoomFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Convo_set_policy_rule_room_future_poll");
+
+  late final _convoSetPolicyRuleRoomFuturePoll =
+      _convoSetPolicyRuleRoomFuturePollPtr
+          .asFunction<
+            _ConvoSetPolicyRuleRoomFuturePollReturn Function(int, int, int)
+          >();
   late final _commentDraftSendFuturePollPtr = _lookup<
     ffi.NativeFunction<
       _CommentDraftSendFuturePollReturn Function(
@@ -29593,6 +29830,21 @@ class Api {
       _spaceRefDetailsFuturePollPtr
           .asFunction<
             _SpaceRefDetailsFuturePollReturn Function(int, int, int)
+          >();
+  late final _spaceSetPolicyRuleRoomFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _SpaceSetPolicyRuleRoomFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Space_set_policy_rule_room_future_poll");
+
+  late final _spaceSetPolicyRuleRoomFuturePoll =
+      _spaceSetPolicyRuleRoomFuturePollPtr
+          .asFunction<
+            _SpaceSetPolicyRuleRoomFuturePollReturn Function(int, int, int)
           >();
   late final _memberIgnoreFuturePollPtr = _lookup<
     ffi.NativeFunction<
@@ -40489,6 +40741,23 @@ class TimelineEventItem {
     return tmp2;
   }
 
+  /// covers m.policy.rule.room
+  PolicyRuleRoomContent? policyRuleRoomContent() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._timelineEventItemPolicyRuleRoomContent(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_PolicyRuleRoomContent");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = PolicyRuleRoomContent._(_api, tmp4_1);
+    return tmp2;
+  }
+
   /// original event id, if this msg is reply to another msg
   String? inReplyTo() {
     var tmp0 = 0;
@@ -41535,6 +41804,285 @@ class JoinRuleBuilder {
     tmp4 = tmp3;
     _api._joinRuleBuilderAddRoom(tmp0, tmp2, tmp3, tmp4);
     return;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class PolicyRuleRoomContent {
+  final Api _api;
+  final _Box _box;
+
+  PolicyRuleRoomContent._(this._api, this._box);
+
+  String? entityChange() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentEntityChange(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String entityNewVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentEntityNewVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? entityOldVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentEntityOldVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? reasonChange() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentReasonChange(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String reasonNewVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentReasonNewVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? reasonOldVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentReasonOldVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? recommendationChange() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentRecommendationChange(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String recommendationNewVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentRecommendationNewVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? recommendationOldVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._policyRuleRoomContentRecommendationOldVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
@@ -44231,6 +44779,60 @@ class Convo {
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp2 = _nativeFuture(tmp3_1, _api.__convoRefDetailsFuturePoll);
     return tmp2;
+  }
+
+  /// set a moderation policy rule which affects room IDs and room aliases.
+  /// entity: #*:example.org
+  /// reason: undesirable content
+  Future<EventId> setPolicyRuleRoom(String entity, String reason) {
+    final tmp1 = entity;
+    final tmp5 = reason;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp8 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5_0 = utf8.encode(tmp5);
+    tmp7 = tmp5_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp6_0 = _api.__allocate(tmp7 * 1, 1);
+    final Uint8List tmp6_1 = tmp6_0.asTypedList(tmp7);
+    tmp6_1.setAll(0, tmp5_0);
+    tmp6 = tmp6_0.address;
+    tmp8 = tmp7;
+    final tmp9 = _api._convoSetPolicyRuleRoom(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+      tmp7,
+      tmp8,
+    );
+    final tmp11 = tmp9;
+    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+    final tmp11_1 = _Box(
+      _api,
+      tmp11_0,
+      "__Convo_set_policy_rule_room_future_drop",
+    );
+    tmp11_1._finalizer = _api._registerFinalizer(tmp11_1);
+    final tmp10 = _nativeFuture(
+      tmp11_1,
+      _api.__convoSetPolicyRuleRoomFuturePoll,
+    );
+    return tmp10;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
@@ -51454,6 +52056,60 @@ class Space {
     tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
     final tmp2 = _nativeFuture(tmp3_1, _api.__spaceRefDetailsFuturePoll);
     return tmp2;
+  }
+
+  /// set a moderation policy rule which affects room IDs and room aliases.
+  /// entity: #*:example.org
+  /// reason: undesirable content
+  Future<EventId> setPolicyRuleRoom(String entity, String reason) {
+    final tmp1 = entity;
+    final tmp5 = reason;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    var tmp6 = 0;
+    var tmp7 = 0;
+    var tmp8 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5_0 = utf8.encode(tmp5);
+    tmp7 = tmp5_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp6_0 = _api.__allocate(tmp7 * 1, 1);
+    final Uint8List tmp6_1 = tmp6_0.asTypedList(tmp7);
+    tmp6_1.setAll(0, tmp5_0);
+    tmp6 = tmp6_0.address;
+    tmp8 = tmp7;
+    final tmp9 = _api._spaceSetPolicyRuleRoom(
+      tmp0,
+      tmp2,
+      tmp3,
+      tmp4,
+      tmp6,
+      tmp7,
+      tmp8,
+    );
+    final tmp11 = tmp9;
+    final ffi.Pointer<ffi.Void> tmp11_0 = ffi.Pointer.fromAddress(tmp11);
+    final tmp11_1 = _Box(
+      _api,
+      tmp11_0,
+      "__Space_set_policy_rule_room_future_drop",
+    );
+    tmp11_1._finalizer = _api._registerFinalizer(tmp11_1);
+    final tmp10 = _nativeFuture(
+      tmp11_1,
+      _api.__spaceSetPolicyRuleRoomFuturePoll,
+    );
+    return tmp10;
   }
 
   /// Manually drops the object and unregisters the FinalizableHandle.
@@ -61032,6 +61688,13 @@ class _TimelineEventItemProfileContentReturn extends ffi.Struct {
   external int arg1;
 }
 
+class _TimelineEventItemPolicyRuleRoomContentReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+}
+
 class _TimelineEventItemInReplyToReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -61308,6 +61971,99 @@ class _TimelineItemDiffValueReturn extends ffi.Struct {
   external int arg0;
   @ffi.IntPtr()
   external int arg1;
+}
+
+class _PolicyRuleRoomContentEntityChangeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _PolicyRuleRoomContentEntityNewValReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _PolicyRuleRoomContentEntityOldValReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _PolicyRuleRoomContentReasonChangeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _PolicyRuleRoomContentReasonNewValReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _PolicyRuleRoomContentReasonOldValReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _PolicyRuleRoomContentRecommendationChangeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _PolicyRuleRoomContentRecommendationNewValReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _PolicyRuleRoomContentRecommendationOldValReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
 }
 
 class _RoomRoomIdStrReturn extends ffi.Struct {
@@ -65184,6 +65940,21 @@ class _ConvoRefDetailsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ConvoSetPolicyRuleRoomFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
 class _CommentDraftSendFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -66269,6 +67040,21 @@ class _SpaceSetCategoriesFuturePollReturn extends ffi.Struct {
 }
 
 class _SpaceRefDetailsFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
+class _SpaceSetPolicyRuleRoomFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()


### PR DESCRIPTION
This PR was split from https://github.com/acterglobal/a3/pull/2815.

- Will handle `TimelineItemContent::OtherState` here.
- Make activity cover the policy rule room event.