### PR TITLE
Fix golden test

### DIFF
--- a/.github/workflows/check-flutter-unittest.yml
+++ b/.github/workflows/check-flutter-unittest.yml
@@ -38,7 +38,14 @@ jobs:
         run: |
           flutter pub get
           flutter test --coverage
-
+      - name: Archieve Golden Failures
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Golden failures
+          retention-days: 2
+          path: |
+            **/test/**/failures/**/*.*
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v4

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -32,9 +32,11 @@ bool isValidUrl(String url) {
   return urlPattern.hasMatch(url);
 }
 
-String jiffyTime(BuildContext context, int timeInterval) {
+String jiffyTime(BuildContext context, int timeInterval, {DateTime? toWhen}) {
   final jiffyTime = Jiffy.parseFromMillisecondsSinceEpoch(timeInterval);
-  final now = Jiffy.now().startOf(Unit.day);
+  final now = Jiffy.parseFromDateTime(
+    toWhen ?? DateTime.now().toUtc(),
+  ).startOf(Unit.day);
   if (now.isSame(jiffyTime, unit: Unit.day)) {
     return jiffyTime.jm;
   } else {

--- a/app/lib/common/utils/utils.dart
+++ b/app/lib/common/utils/utils.dart
@@ -39,17 +39,18 @@ String jiffyTime(BuildContext context, int timeInterval, {DateTime? toWhen}) {
   ).startOf(Unit.day);
   if (now.isSame(jiffyTime, unit: Unit.day)) {
     return jiffyTime.jm;
-  } else {
-    final yesterday = now.subtract(days: 1);
-    final week = now.subtract(weeks: 1);
-    if (jiffyTime.isBetween(yesterday, now)) {
-      return 'Yesterday';
-    } else if (jiffyTime.isBetween(week, now)) {
-      return jiffyTime.EEEE;
-    } else {
-      return jiffyTime.yMd;
-    }
   }
+
+  final yesterday = now.subtract(days: 1);
+  if (jiffyTime.isBetween(yesterday, now)) {
+    return L10n.of(context).yesterday;
+  }
+
+  final week = now.subtract(weeks: 1);
+  if (jiffyTime.isBetween(week, now)) {
+    return jiffyTime.EEEE;
+  }
+  return jiffyTime.yMd;
 }
 
 String jiffyDateForActvity(BuildContext context, int timeInterval) {

--- a/app/lib/features/chat_ng/widgets/chat_item/last_message_time_widget.dart
+++ b/app/lib/features/chat_ng/widgets/chat_item/last_message_time_widget.dart
@@ -1,6 +1,7 @@
 import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/chat/providers/chat_providers.dart';
+import 'package:acter/features/datetime/providers/utc_now_provider.dart';
 import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -45,7 +46,11 @@ class LastMessageTimeWidget extends ConsumerWidget {
     if (eventItem == null) return const SizedBox.shrink();
 
     return Text(
-      jiffyTime(context, eventItem.originServerTs()),
+      jiffyTime(
+        context,
+        eventItem.originServerTs(),
+        toWhen: ref.watch(utcNowProvider),
+      ),
       style: theme.textTheme.bodySmall?.copyWith(
         color: timeColor,
         fontSize: 12,

--- a/app/test/.gitignore
+++ b/app/test/.gitignore
@@ -1,0 +1,1 @@
+**/failures/**.png

--- a/app/test/features/chat_ng/widgets/chat_item/selected_chat_item_test.dart
+++ b/app/test/features/chat_ng/widgets/chat_item/selected_chat_item_test.dart
@@ -2,6 +2,7 @@ import 'package:acter/common/providers/chat_providers.dart';
 import 'package:acter/features/chat/widgets/chat_list_widget.dart';
 import 'package:acter/features/chat_ng/widgets/chat_item_widget.dart';
 import 'package:acter/features/chat_ui_showcase/models/convo_showcase_data.dart';
+import 'package:acter/features/datetime/providers/utc_now_provider.dart';
 import 'package:acter/features/labs/model/labs_features.dart';
 import 'package:acter/features/labs/providers/labs_providers.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -9,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../helpers/mock_event_providers.dart';
 import '../../../../helpers/test_util.dart';
 import '../../../../helpers/font_loader.dart';
 
@@ -24,6 +26,9 @@ void main() {
         overrides: [
           isActiveProvider(LabsFeature.chatNG).overrideWith((ref) => true),
           isActiveProvider(LabsFeature.chatUnread).overrideWith((ref) => true),
+          utcNowProvider.overrideWith(
+            (ref) => MockUtcNowNotifier(ts: 1744707051000),
+          ), // April 15th, 2025
         ],
         child: ChatListWidget(
           chatListProvider: chatListprovider,


### PR DESCRIPTION
Several smaller things here:
- fe26f1d6c30aef58a7a8341c70c06340535fa44f : fixes the test by linking the timedate widget of latest message to the utcNowProvider (which it should do anyways to keep up to date with the actual time) and overwrite the value to a specific time in relation to the one we are expecting in the golden test.
- 02016e374ebe06148ab42bed975dbfab4fa096b9 : adds a gitignore for golden failures for convenience
- a28a29defd00e8c3975f9f79abf68019e978beb1 : adds a job to the CI to upload the golden failures to the artifacts, so it is easier to debug
- 3eafcab4d7a281519487eb37b391d27cb29c77fc : refactors the jiffyTime helper for legibility & L10n support