### PR TITLE
remove AsyncValue.guard where unnecessary

### DIFF
--- a/app/lib/common/providers/notifiers/chat_notifiers.dart
+++ b/app/lib/common/providers/notifiers/chat_notifiers.dart
@@ -37,7 +37,7 @@ class AsyncConvoNotifier extends FamilyAsyncNotifier<Convo?, String> {
     ); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(() async => await client.convo(roomId));
+        state = AsyncValue.data(await client.convo(roomId));
       },
       onError: (e, s) {
         _log.severe('convo stream errored', e, s);
@@ -81,7 +81,7 @@ class AsyncLatestMsgNotifier
     _poller = _listener.listen(
       (data) async {
         _log.info('received new latest message call for $roomId');
-        state = await AsyncValue.guard(() async => await _refresh(roomId));
+        state = AsyncValue.data(await _refresh(roomId));
       },
       onError: (e, s) {
         _log.severe('latest msg stream errored', e, s);

--- a/app/lib/common/providers/notifiers/room_notifiers.dart
+++ b/app/lib/common/providers/notifiers/room_notifiers.dart
@@ -41,7 +41,7 @@ class AsyncMaybeRoomNotifier extends FamilyAsyncNotifier<Room?, String> {
     _poller = _listener.listen(
       (data) async {
         _log.info('seen update for room $arg');
-        state = await AsyncValue.guard(() async => await _getRoom(client));
+        state = AsyncValue.data(await _getRoom(client));
       },
       onError: (e, s) {
         _log.severe('room stream errored', e, s);

--- a/app/lib/common/providers/notifiers/space_notifiers.dart
+++ b/app/lib/common/providers/notifiers/space_notifiers.dart
@@ -23,7 +23,7 @@ class AsyncMaybeSpaceNotifier extends FamilyAsyncNotifier<Space?, String> {
     _poller = _listener.listen(
       (data) async {
         _log.info('seen update $arg');
-        state = await AsyncValue.guard(() async => await _getSpace(client));
+        state = AsyncValue.data(await _getSpace(client));
       },
       onError: (e, s) {
         _log.severe('space stream errored', e, s);

--- a/app/lib/features/activities/providers/notifiers/activities_notifiers.dart
+++ b/app/lib/features/activities/providers/notifiers/activities_notifiers.dart
@@ -33,9 +33,7 @@ class AsyncSpaceActivitiesNotifier
     _poller = _listener.listen(
       (data) async {
         _log.info('space $arg : activities');
-        state = await AsyncValue.guard(
-          () async => await _getSpaceActivities(client),
-        );
+        state = AsyncValue.data(await _getSpaceActivities(client));
       },
       onError: (e, s) {
         _log.severe('space activities stream errored', e, s);

--- a/app/lib/features/attachments/providers/notifiers/attachments_notifiers.dart
+++ b/app/lib/features/attachments/providers/notifiers/attachments_notifiers.dart
@@ -26,13 +26,11 @@ class AttachmentsManagerNotifier
     _listener = manager.subscribeStream(); // keep it resident in memory
     _poller = _listener.listen(
       (e) async {
-        state = await AsyncValue.guard(() async {
-          _log.info('attempting to reload');
-          final newManager = await manager.reload();
-          final count = newManager.attachmentsCount();
-          _log.info('manager updated. attachments: $count');
-          return newManager;
-        });
+        _log.info('attempting to reload');
+        final newManager = await manager.reload();
+        final count = newManager.attachmentsCount();
+        _log.info('manager updated. attachments: $count');
+        state = AsyncValue.data(newManager);
       },
       onError: (e, s) {
         _log.severe('stream errored', e, s);

--- a/app/lib/features/bookmarks/providers/notifiers.dart
+++ b/app/lib/features/bookmarks/providers/notifiers.dart
@@ -19,9 +19,7 @@ class BookmarksManagerNotifier extends AsyncNotifier<Bookmarks> {
     _listener = client.subscribeAccountDataStream('global.acter.bookmarks');
 
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await _getBookmarkManager(client),
-      );
+      state = AsyncValue.data(await _getBookmarkManager(client));
     });
     return await _getBookmarkManager(client);
   }

--- a/app/lib/features/chat_ng/providers/notifiers/reply_messages_notifier.dart
+++ b/app/lib/features/chat_ng/providers/notifiers/reply_messages_notifier.dart
@@ -10,7 +10,7 @@ final _log = Logger('a3::chat::replied_to_notifier');
 class RepliedToMessageNotifier
     extends AutoDisposeFamilyAsyncNotifier<RepliedToMsgState, RoomMsgId> {
   Future<void> retryLoad() async {
-    state = await AsyncValue.guard(() => build(arg));
+    state = AsyncValue.data(await build(arg));
   }
 
   @override

--- a/app/lib/features/comments/providers/comments_providers.dart
+++ b/app/lib/features/comments/providers/comments_providers.dart
@@ -29,7 +29,7 @@ class AsyncCommentsManagerNotifier
     _poller = _listener.listen(
       (data) async {
         // reset
-        state = await AsyncValue.guard(() async => await manager.reload());
+        state = AsyncValue.data(await manager.reload());
       },
       onError: (e, s) {
         _log.severe('msg stream errored', e, s);

--- a/app/lib/features/events/providers/notifiers/event_notifiers.dart
+++ b/app/lib/features/events/providers/notifiers/event_notifiers.dart
@@ -39,9 +39,7 @@ class EventListNotifier
     }
 
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await _getEventList(client, spaceId),
-      );
+      state = AsyncValue.data(await _getEventList(client, spaceId));
     });
     return await _getEventList(client, spaceId);
   }
@@ -63,9 +61,7 @@ class AsyncCalendarEventNotifier
       calEvtId,
     ); // keep it resident in memory
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await _getCalEvent(client, calEvtId),
-      );
+      state = AsyncValue.data(await _getCalEvent(client, calEvtId));
     });
     return await _getCalEvent(client, calEvtId);
   }

--- a/app/lib/features/events/providers/notifiers/participants_notifier.dart
+++ b/app/lib/features/events/providers/notifiers/participants_notifier.dart
@@ -24,9 +24,7 @@ class AsyncParticipantsNotifier
       'rsvp',
     ); // keep it resident in memory
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await _getParticipants(client, calEvtId),
-      );
+      state = AsyncValue.data(await _getParticipants(client, calEvtId));
     });
     return await _getParticipants(client, calEvtId);
   }

--- a/app/lib/features/events/providers/notifiers/rsvp_notifier.dart
+++ b/app/lib/features/events/providers/notifiers/rsvp_notifier.dart
@@ -30,9 +30,7 @@ class AsyncRsvpStatusNotifier
       'rsvp',
     ); // keep it resident in memory
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await _getMyResponse(client, calEvtId),
-      );
+      state = AsyncValue.data(await _getMyResponse(client, calEvtId));
     });
     return await _getMyResponse(client, calEvtId);
   }

--- a/app/lib/features/home/providers/task_providers.dart
+++ b/app/lib/features/home/providers/task_providers.dart
@@ -19,9 +19,7 @@ class MyOpenTasksNotifier extends AsyncNotifier<List<Task>> {
         client.subscribeMyOpenTasksStream(); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(
-          () async => await fetchMyOpenTask(client),
-        );
+        state = AsyncValue.data(await fetchMyOpenTask(client));
       },
       onError: (e, s) {
         _log.severe('stream errored', e, s);

--- a/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
+++ b/app/lib/features/pins/providers/notifiers/pins_notifiers.dart
@@ -27,9 +27,7 @@ class AsyncPinNotifier
     ); // keep it resident in memory
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(
-          () async => await _getPin(client, pinId),
-        );
+        state = AsyncValue.data(await _getPin(client, pinId));
       },
       onError: (e, s) {
         _log.severe('stream errored', e, s);
@@ -64,9 +62,7 @@ class AsyncPinListNotifier
 
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(
-          () async => await _getPinList(client, spaceId),
-        );
+        state = AsyncValue.data(await _getPinList(client, spaceId));
       },
       onError: (e, s) {
         _log.severe('stream errored', e, s);

--- a/app/lib/features/read_receipts/providers/read_receipts.dart
+++ b/app/lib/features/read_receipts/providers/read_receipts.dart
@@ -29,7 +29,7 @@ class AsyncReadReceiptsManagerNotifier
     _poller = _listener.listen(
       (data) async {
         // reset
-        state = await AsyncValue.guard(() async => await manager.reload());
+        state = AsyncValue.data(await manager.reload());
       },
       onError: (e, s) {
         _log.severe('read receipt reload stream errored', e, s);

--- a/app/lib/features/settings/providers/notifications_mode_provider.dart
+++ b/app/lib/features/settings/providers/notifications_mode_provider.dart
@@ -16,9 +16,7 @@ class AsyncNotificationSettingNotifier
     final settings = await client.notificationSettings();
     _listener = settings.changesStream(); // stay up to date
     _listener.forEach((e) async {
-      state = await AsyncValue.guard(
-        () async => await client.notificationSettings(),
-      );
+      state = AsyncValue.data(await client.notificationSettings());
     });
     return settings;
   }

--- a/app/lib/features/settings/providers/notifiers/devices_notifier.dart
+++ b/app/lib/features/settings/providers/notifiers/devices_notifier.dart
@@ -24,7 +24,7 @@ class AsyncDevicesNotifier extends AsyncNotifier<List<DeviceRecord>> {
     _listener = client.deviceEventRx();
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(() async => await _getSessions(manager));
+        state = AsyncValue.data(await _getSessions(manager));
       },
       onError: (e, s) {
         _log.severe('stream errored', e, s);

--- a/app/lib/features/tasks/providers/notifiers.dart
+++ b/app/lib/features/tasks/providers/notifiers.dart
@@ -41,10 +41,7 @@ class TaskItemsListNotifier
     _poller = _listener.listen(
       (data) async {
         _log.info('got tasks list update');
-        state = await AsyncValue.guard(() async {
-          final freshTaskList = await taskList.refresh();
-          return await _refresh(freshTaskList);
-        });
+        state = AsyncValue.data(await _refresh(taskList));
       },
       onError: (e, s) {
         _log.severe('tasks overview stream errored', e, s);
@@ -76,7 +73,7 @@ class TaskListItemNotifier extends FamilyAsyncNotifier<TaskList, String> {
     _poller = _listener.listen(
       (data) async {
         _log.info('got taskList update');
-        state = await AsyncValue.guard(() async => await _refresh(client, arg));
+        state = AsyncValue.data(await _refresh(client, arg));
       },
       onError: (e, s) {
         _log.severe('tasklist stream errored', e, s);
@@ -103,7 +100,7 @@ class TaskItemNotifier extends FamilyAsyncNotifier<Task, Task> {
     _poller = _listener.listen(
       (data) async {
         _log.info('got tasks list update');
-        state = await AsyncValue.guard(() async => await task.refresh());
+        state = AsyncValue.data(await task.refresh());
       },
       onError: (e, s) {
         _log.severe('task stream errored', e, s);
@@ -132,7 +129,7 @@ class AsyncAllTaskListsNotifier extends AsyncNotifier<List<TaskList>> {
 
     _poller = _listener.listen(
       (data) async {
-        state = await AsyncValue.guard(() async => await _getTasksList(client));
+        state = AsyncValue.data(await _getTasksList(client));
       },
       onError: (e, s) {
         _log.severe('all tasks stream errored', e, s);


### PR DESCRIPTION
like everywhere ... we basically never need this. We can just await the new value and set it. The guard leads to a needless loading and refreshing cycle in the UI. See the difference, left is the nighthly _release build_ (so usually a lot more performant), right the one with this change:


https://github.com/user-attachments/assets/c04104d4-7763-4430-8ced-aee03b3ff41f


There's still some flickers, due to unnecessary reloading of related attributes, but it is _a lot_ better.

