### PR TITLE
Make listener not late

### DIFF
--- a/app/lib/features/news/pages/news_list_page.dart
+++ b/app/lib/features/news/pages/news_list_page.dart
@@ -40,7 +40,7 @@ class _NewsListPageState extends ConsumerState<NewsListPage> {
   final ValueNotifier<bool> useGridMode = ValueNotifier(true);
   final ValueNotifier<bool> stillLoadingForSelectedItem = ValueNotifier(false);
   final ValueNotifier<int> currentIndex = ValueNotifier(0);
-  late ProviderSubscription<AsyncValue<List<UpdateEntry>>>? listener;
+  ProviderSubscription<AsyncValue<List<UpdateEntry>>>? listener;
 
   @override
   void initState() {


### PR DESCRIPTION
fixes #2852 .

Found the listener that fails, seems to be happening due to a callback that is run _faster_ than the actual code setting happens.