### PR TITLE
Extend timeline event item to cover the room guest access

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1049,6 +1049,9 @@ object TimelineEventItem {
     /// covers m.room.encryption
     fn room_encryption_content() -> Option<RoomEncryptionContent>;
 
+    /// covers m.room.guest_access
+    fn room_guest_access_content() -> Option<RoomGuestAccessContent>;
+
     /// original event id, if this msg is reply to another msg
     fn in_reply_to() -> Option<string>;
 
@@ -1275,6 +1278,12 @@ object RoomEncryptionContent {
     fn algorithm_change() -> Option<string>;
     fn algorithm_new_val() -> string;
     fn algorithm_old_val() -> Option<string>;
+}
+
+object RoomGuestAccessContent {
+    fn change() -> Option<string>;
+    fn new_val() -> string;
+    fn old_val() -> Option<string>;
 }
 
 
@@ -1699,6 +1708,10 @@ object Convo {
     /// set room encryption
     /// m.olm.v1.curve25519-aes-sha2 or m.megolm.v1.aes-sha2
     fn set_encryption(algorithm: string) -> Future<Result<EventId>>;
+
+    /// set room guest access
+    /// can_join or forbidden
+    fn set_guest_access(guest_access: string) -> Future<Result<EventId>>;
 }
 
 
@@ -2769,6 +2782,10 @@ object Space {
     /// set room encryption
     /// m.olm.v1.curve25519-aes-sha2 or m.megolm.v1.aes-sha2
     fn set_encryption(algorithm: string) -> Future<Result<EventId>>;
+
+    /// set room guest access
+    /// can_join or forbidden
+    fn set_guest_access(guest_access: string) -> Future<Result<EventId>>;
 }
 
 enum MembershipStatus {

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -69,7 +69,7 @@ pub use acter_core::{
         status::{
             MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent,
             PolicyRuleUserContent, ProfileContent, RoomAvatarContent, RoomCreateContent,
-            RoomEncryptionContent,
+            RoomEncryptionContent, RoomGuestAccessContent,
         },
         ActerModel, Tag, TextMessageContent,
     },

--- a/native/acter/src/api/timeline/room_event.rs
+++ b/native/acter/src/api/timeline/room_event.rs
@@ -1,6 +1,7 @@
 use acter_core::models::status::{
     MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent, PolicyRuleUserContent,
     ProfileContent, RoomAvatarContent, RoomCreateContent, RoomEncryptionContent,
+    RoomGuestAccessContent,
 };
 use matrix_sdk_base::ruma::events::room::message::MessageType;
 use serde::{Deserialize, Serialize};
@@ -19,6 +20,7 @@ pub enum TimelineEventContent {
     RoomAvatar(RoomAvatarContent),
     RoomCreate(RoomCreateContent),
     RoomEncryption(RoomEncryptionContent),
+    RoomGuestAccess(RoomGuestAccessContent),
 }
 
 impl TryFrom<&MessageType> for TimelineEventContent {

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -18,7 +18,7 @@ use crate::{
         status::{
             MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent,
             PolicyRuleUserContent, ProfileContent, RoomAvatarContent, RoomCreateContent,
-            RoomEncryptionContent,
+            RoomEncryptionContent, RoomGuestAccessContent,
         },
         ActerModel, ActerSupportedRoomStatusEvents, AnyActerModel, EventMeta, Task,
     },
@@ -38,6 +38,7 @@ pub enum ActivityContent {
     RoomAvatar(RoomAvatarContent),
     RoomCreate(RoomCreateContent),
     RoomEncryption(RoomEncryptionContent),
+    RoomGuestAccess(RoomGuestAccessContent),
     RoomName(RoomNameEventContent),
     RoomTopic(RoomTopicEventContent),
     Boost {
@@ -154,6 +155,7 @@ impl Activity {
             ActivityContent::RoomAvatar(_) => "roomAvatar",
             ActivityContent::RoomCreate(_) => "roomCreate",
             ActivityContent::RoomEncryption(_) => "roomEncryption",
+            ActivityContent::RoomGuestAccess(_) => "roomGuestAccess",
             ActivityContent::RoomName(_) => "roomName",
             ActivityContent::RoomTopic(_) => "roomTopic",
             ActivityContent::Comment { .. } => "comment",
@@ -247,6 +249,7 @@ impl Activity {
             | ActivityContent::RoomAvatar(_)
             | ActivityContent::RoomCreate(_)
             | ActivityContent::RoomEncryption(_)
+            | ActivityContent::RoomGuestAccess(_)
             | ActivityContent::RoomName(_)
             | ActivityContent::RoomTopic(_) => None,
 
@@ -350,6 +353,7 @@ impl Activity {
             | ActivityContent::RoomAvatar(_)
             | ActivityContent::RoomCreate(_)
             | ActivityContent::RoomEncryption(_)
+            | ActivityContent::RoomGuestAccess(_)
             | ActivityContent::RoomName(_)
             | ActivityContent::RoomTopic(_) => todo!(),
         }
@@ -405,6 +409,9 @@ impl Activity {
                 }
                 ActerSupportedRoomStatusEvents::RoomEncryption(c) => {
                     Ok(Self::new(meta, ActivityContent::RoomEncryption(c)))
+                }
+                ActerSupportedRoomStatusEvents::RoomGuestAccess(c) => {
+                    Ok(Self::new(meta, ActivityContent::RoomGuestAccess(c)))
                 }
                 ActerSupportedRoomStatusEvents::RoomName(c) => {
                     Ok(Self::new(meta, ActivityContent::RoomName(c)))

--- a/native/core/src/models/status/mod.rs
+++ b/native/core/src/models/status/mod.rs
@@ -23,7 +23,7 @@ pub use membership::MembershipContent;
 pub use profile::{Change, ProfileContent};
 pub use room_state::{
     PolicyRuleRoomContent, PolicyRuleServerContent, PolicyRuleUserContent, RoomAvatarContent,
-    RoomCreateContent, RoomEncryptionContent,
+    RoomCreateContent, RoomEncryptionContent, RoomGuestAccessContent,
 };
 
 use super::{conversion::ParseError, ActerModel, Capability, EventMeta, Store};
@@ -38,6 +38,7 @@ pub enum ActerSupportedRoomStatusEvents {
     RoomAvatar(RoomAvatarContent),
     RoomCreate(RoomCreateContent),
     RoomEncryption(RoomEncryptionContent),
+    RoomGuestAccess(RoomGuestAccessContent),
     RoomName(RoomNameEventContent),
     RoomTopic(RoomTopicEventContent),
 }
@@ -172,6 +173,16 @@ impl TryFrom<AnyStateEvent> for RoomStatus {
                 );
                 Ok(RoomStatus {
                     inner: ActerSupportedRoomStatusEvents::RoomEncryption(content),
+                    meta,
+                })
+            }
+            AnyStateEvent::RoomGuestAccess(StateEvent::Original(inner)) => {
+                let content = RoomGuestAccessContent::new(
+                    inner.content.clone(),
+                    inner.unsigned.prev_content.clone(),
+                );
+                Ok(RoomStatus {
+                    inner: ActerSupportedRoomStatusEvents::RoomGuestAccess(content),
                     meta,
                 })
             }

--- a/native/core/src/models/status/room_state.rs
+++ b/native/core/src/models/status/room_state.rs
@@ -8,6 +8,7 @@ use matrix_sdk_base::ruma::events::{
         avatar::RoomAvatarEventContent,
         create::RoomCreateEventContent,
         encryption::{PossiblyRedactedRoomEncryptionEventContent, RoomEncryptionEventContent},
+        guest_access::{PossiblyRedactedRoomGuestAccessEventContent, RoomGuestAccessEventContent},
     },
 };
 use serde::{Deserialize, Serialize};
@@ -436,6 +437,51 @@ impl RoomEncryptionContent {
         self.prev_content
             .as_ref()
             .and_then(|prev| prev.algorithm.as_ref())
+            .map(ToString::to_string)
+    }
+}
+
+// m.room.guest_access
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoomGuestAccessContent {
+    content: RoomGuestAccessEventContent,
+    prev_content: Option<PossiblyRedactedRoomGuestAccessEventContent>,
+}
+
+impl RoomGuestAccessContent {
+    pub fn new(
+        content: RoomGuestAccessEventContent,
+        prev_content: Option<PossiblyRedactedRoomGuestAccessEventContent>,
+    ) -> Self {
+        RoomGuestAccessContent {
+            content,
+            prev_content,
+        }
+    }
+
+    pub fn change(&self) -> Option<String> {
+        if let Some(prev_guest_access) = self
+            .prev_content
+            .as_ref()
+            .and_then(|prev| prev.guest_access.as_ref())
+        {
+            if self.content.guest_access == *prev_guest_access {
+                return None;
+            } else {
+                return Some("Changed".to_owned());
+            }
+        }
+        Some("Set".to_owned())
+    }
+
+    pub fn new_val(&self) -> String {
+        self.content.guest_access.to_string()
+    }
+
+    pub fn old_val(&self) -> Option<String> {
+        self.prev_content
+            .as_ref()
+            .and_then(|prev| prev.guest_access.as_ref())
             .map(ToString::to_string)
     }
 }

--- a/native/test/src/tests/room/mod.rs
+++ b/native/test/src/tests/room/mod.rs
@@ -4,4 +4,5 @@ mod policy_rule_user;
 mod room_avatar;
 mod room_create;
 mod room_encryption;
+mod room_guest_access;
 mod user_settings;

--- a/native/test/src/tests/room/room_guest_access.rs
+++ b/native/test/src/tests/room/room_guest_access.rs
@@ -1,0 +1,111 @@
+use acter::api::TimelineItem;
+use acter_core::models::status::RoomGuestAccessContent;
+use anyhow::Result;
+use core::time::Duration;
+use futures::{pin_mut, stream::StreamExt, FutureExt};
+use tokio::time::sleep;
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+
+use crate::utils::random_user_with_random_convo;
+
+#[tokio::test]
+async fn test_room_guest_access() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut user, room_id) = random_user_with_random_convo("room_guest_access").await?;
+    let state_sync = user.start_sync();
+    state_sync.await_has_synced_history().await?;
+
+    // wait for sync to catch up
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let fetcher_client = user.clone();
+    let target_id = room_id.clone();
+    Retry::spawn(retry_strategy, move || {
+        let client = fetcher_client.clone();
+        let room_id = target_id.clone();
+        async move { client.convo(room_id.to_string()).await }
+    })
+    .await?;
+
+    let convo = user.convo(room_id.to_string()).await?;
+    let timeline = convo.timeline_stream();
+    let stream = timeline.messages_stream();
+    pin_mut!(stream);
+
+    let guest_access = "can_join";
+    let access_event_id = convo.set_guest_access(guest_access.to_owned()).await?;
+
+    // room state event may reach via pushback action or reset action
+    let mut i = 30;
+    let mut found_result = None;
+    while i > 0 {
+        if let Some(diff) = stream.next().now_or_never().flatten() {
+            match diff.action().as_str() {
+                "PushBack" | "Set" => {
+                    let value = diff
+                        .value()
+                        .expect("diff pushback action should have valid value");
+                    if let Some(result) = match_msg(&value) {
+                        found_result = Some(result);
+                    }
+                }
+                "Reset" => {
+                    let values = diff
+                        .values()
+                        .expect("diff reset action should have valid values");
+                    for value in values.iter() {
+                        if let Some(result) = match_msg(value) {
+                            found_result = Some(result);
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            // yay
+            if found_result.is_some() {
+                break;
+            }
+        }
+        i -= 1;
+        sleep(Duration::from_secs(1)).await;
+    }
+    let (found_event_id, content) =
+        found_result.expect("Even after 30 seconds, room guest access not received");
+    assert_eq!(found_event_id, access_event_id, "event id should match");
+
+    assert_eq!(
+        content.change(),
+        Some("Set".to_owned()),
+        "room guest access should be set"
+    );
+    assert_eq!(
+        content.new_val(),
+        guest_access,
+        "new val of room guest access is invalid"
+    );
+    assert_eq!(
+        content.old_val(),
+        None,
+        "old val of room guest access is invalid"
+    );
+
+    Ok(())
+}
+
+fn match_msg(msg: &TimelineItem) -> Option<(String, RoomGuestAccessContent)> {
+    if msg.is_virtual() {
+        return None;
+    }
+    let event_item = msg.event_item().expect("room msg should have event item");
+    let Some(content) = event_item.room_guest_access_content() else {
+        return None;
+    };
+    let event_id = event_item
+        .event_id()
+        .expect("event item should have event id");
+    Some((event_id, content.clone()))
+}

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -7352,6 +7352,51 @@ class Api {
     return tmp7;
   }
 
+  EventId? __convoSetGuestAccessFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _convoSetGuestAccessFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
   EventId? __commentDraftSendFuturePoll(int boxed, int postCobject, int port) {
     final tmp0 = boxed;
     final tmp2 = postCobject;
@@ -10660,6 +10705,51 @@ class Api {
     tmp3 = tmp2;
     tmp5 = tmp4;
     final tmp6 = _spaceSetEncryptionFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
+  EventId? __spaceSetGuestAccessFuturePoll(
+    int boxed,
+    int postCobject,
+    int port,
+  ) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceSetGuestAccessFuturePoll(tmp1, tmp3, tmp5);
     final tmp8 = tmp6.arg0;
     final tmp9 = tmp6.arg1;
     final tmp10 = tmp6.arg2;
@@ -19946,6 +20036,17 @@ class Api {
           .asFunction<
             _TimelineEventItemRoomEncryptionContentReturn Function(int)
           >();
+  late final _timelineEventItemRoomGuestAccessContentPtr = _lookup<
+    ffi.NativeFunction<
+      _TimelineEventItemRoomGuestAccessContentReturn Function(ffi.IntPtr)
+    >
+  >("__TimelineEventItem_room_guest_access_content");
+
+  late final _timelineEventItemRoomGuestAccessContent =
+      _timelineEventItemRoomGuestAccessContentPtr
+          .asFunction<
+            _TimelineEventItemRoomGuestAccessContentReturn Function(int)
+          >();
   late final _timelineEventItemInReplyToPtr = _lookup<
     ffi.NativeFunction<_TimelineEventItemInReplyToReturn Function(ffi.IntPtr)>
   >("__TimelineEventItem_in_reply_to");
@@ -20629,6 +20730,27 @@ class Api {
           .asFunction<
             _RoomEncryptionContentAlgorithmOldValReturn Function(int)
           >();
+  late final _roomGuestAccessContentChangePtr = _lookup<
+    ffi.NativeFunction<_RoomGuestAccessContentChangeReturn Function(ffi.IntPtr)>
+  >("__RoomGuestAccessContent_change");
+
+  late final _roomGuestAccessContentChange =
+      _roomGuestAccessContentChangePtr
+          .asFunction<_RoomGuestAccessContentChangeReturn Function(int)>();
+  late final _roomGuestAccessContentNewValPtr = _lookup<
+    ffi.NativeFunction<_RoomGuestAccessContentNewValReturn Function(ffi.IntPtr)>
+  >("__RoomGuestAccessContent_new_val");
+
+  late final _roomGuestAccessContentNewVal =
+      _roomGuestAccessContentNewValPtr
+          .asFunction<_RoomGuestAccessContentNewValReturn Function(int)>();
+  late final _roomGuestAccessContentOldValPtr = _lookup<
+    ffi.NativeFunction<_RoomGuestAccessContentOldValReturn Function(ffi.IntPtr)>
+  >("__RoomGuestAccessContent_old_val");
+
+  late final _roomGuestAccessContentOldVal =
+      _roomGuestAccessContentOldValPtr
+          .asFunction<_RoomGuestAccessContentOldValReturn Function(int)>();
   late final _roomRoomIdStrPtr =
       _lookup<ffi.NativeFunction<_RoomRoomIdStrReturn Function(ffi.IntPtr)>>(
         "__Room_room_id_str",
@@ -21711,6 +21833,14 @@ class Api {
 
   late final _convoSetEncryption =
       _convoSetEncryptionPtr.asFunction<int Function(int, int, int, int)>();
+  late final _convoSetGuestAccessPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
+    >
+  >("__Convo_set_guest_access");
+
+  late final _convoSetGuestAccess =
+      _convoSetGuestAccessPtr.asFunction<int Function(int, int, int, int)>();
   late final _commentDraftContentTextPtr = _lookup<
     ffi.NativeFunction<
       ffi.Void Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
@@ -24656,6 +24786,14 @@ class Api {
 
   late final _spaceSetEncryption =
       _spaceSetEncryptionPtr.asFunction<int Function(int, int, int, int)>();
+  late final _spaceSetGuestAccessPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
+    >
+  >("__Space_set_guest_access");
+
+  late final _spaceSetGuestAccess =
+      _spaceSetGuestAccessPtr.asFunction<int Function(int, int, int, int)>();
   late final _memberGetProfilePtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr)>>(
         "__Member_get_profile",
@@ -29474,6 +29612,21 @@ class Api {
           .asFunction<
             _ConvoSetEncryptionFuturePollReturn Function(int, int, int)
           >();
+  late final _convoSetGuestAccessFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _ConvoSetGuestAccessFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Convo_set_guest_access_future_poll");
+
+  late final _convoSetGuestAccessFuturePoll =
+      _convoSetGuestAccessFuturePollPtr
+          .asFunction<
+            _ConvoSetGuestAccessFuturePollReturn Function(int, int, int)
+          >();
   late final _commentDraftSendFuturePollPtr = _lookup<
     ffi.NativeFunction<
       _CommentDraftSendFuturePollReturn Function(
@@ -30598,6 +30751,21 @@ class Api {
       _spaceSetEncryptionFuturePollPtr
           .asFunction<
             _SpaceSetEncryptionFuturePollReturn Function(int, int, int)
+          >();
+  late final _spaceSetGuestAccessFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _SpaceSetGuestAccessFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Space_set_guest_access_future_poll");
+
+  late final _spaceSetGuestAccessFuturePoll =
+      _spaceSetGuestAccessFuturePollPtr
+          .asFunction<
+            _SpaceSetGuestAccessFuturePollReturn Function(int, int, int)
           >();
   late final _memberIgnoreFuturePollPtr = _lookup<
     ffi.NativeFunction<
@@ -41596,6 +41764,23 @@ class TimelineEventItem {
     return tmp2;
   }
 
+  /// covers m.room.guest_access
+  RoomGuestAccessContent? roomGuestAccessContent() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._timelineEventItemRoomGuestAccessContent(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_RoomGuestAccessContent");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = RoomGuestAccessContent._(_api, tmp4_1);
+    return tmp2;
+  }
+
   /// original event id, if this msg is reply to another msg
   String? inReplyTo() {
     var tmp0 = 0;
@@ -43672,6 +43857,107 @@ class RoomEncryptionContent {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._roomEncryptionContentAlgorithmOldVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class RoomGuestAccessContent {
+  final Api _api;
+  final _Box _box;
+
+  RoomGuestAccessContent._(this._api, this._box);
+
+  String? change() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomGuestAccessContentChange(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String newVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomGuestAccessContentNewVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? oldVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomGuestAccessContentOldVal(tmp0);
     final tmp3 = tmp1.arg0;
     final tmp4 = tmp1.arg1;
     final tmp5 = tmp1.arg2;
@@ -46580,6 +46866,32 @@ class Convo {
     final tmp7_1 = _Box(_api, tmp7_0, "__Convo_set_encryption_future_drop");
     tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
     final tmp6 = _nativeFuture(tmp7_1, _api.__convoSetEncryptionFuturePoll);
+    return tmp6;
+  }
+
+  /// set room guest access
+  /// can_join or forbidden
+  Future<EventId> setGuestAccess(String guestAccess) {
+    final tmp1 = guestAccess;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._convoSetGuestAccess(tmp0, tmp2, tmp3, tmp4);
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "__Convo_set_guest_access_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeFuture(tmp7_1, _api.__convoSetGuestAccessFuturePoll);
     return tmp6;
   }
 
@@ -54087,6 +54399,32 @@ class Space {
     final tmp7_1 = _Box(_api, tmp7_0, "__Space_set_encryption_future_drop");
     tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
     final tmp6 = _nativeFuture(tmp7_1, _api.__spaceSetEncryptionFuturePoll);
+    return tmp6;
+  }
+
+  /// set room guest access
+  /// can_join or forbidden
+  Future<EventId> setGuestAccess(String guestAccess) {
+    final tmp1 = guestAccess;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._spaceSetGuestAccess(tmp0, tmp2, tmp3, tmp4);
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "__Space_set_guest_access_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeFuture(tmp7_1, _api.__spaceSetGuestAccessFuturePoll);
     return tmp6;
   }
 
@@ -63698,6 +64036,13 @@ class _TimelineEventItemRoomEncryptionContentReturn extends ffi.Struct {
   external int arg1;
 }
 
+class _TimelineEventItemRoomGuestAccessContentReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+}
+
 class _TimelineEventItemInReplyToReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -64309,6 +64654,37 @@ class _RoomEncryptionContentAlgorithmNewValReturn extends ffi.Struct {
 }
 
 class _RoomEncryptionContentAlgorithmOldValReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomGuestAccessContentChangeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomGuestAccessContentNewValReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _RoomGuestAccessContentOldValReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.IntPtr()
@@ -68286,6 +68662,21 @@ class _ConvoSetEncryptionFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ConvoSetGuestAccessFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
 class _CommentDraftSendFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -69431,6 +69822,21 @@ class _SpaceSetPolicyRuleUserFuturePollReturn extends ffi.Struct {
 }
 
 class _SpaceSetEncryptionFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
+class _SpaceSetGuestAccessFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()


### PR DESCRIPTION
This PR was split from https://github.com/acterglobal/a3/pull/2815.

- Will handle `TimelineItemContent::OtherState` here.
- Make activity cover the room guest access event.