### PR TITLE
Extend timeline event item to cover the room join rules

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1055,6 +1055,9 @@ object TimelineEventItem {
     /// covers m.room.history_visibility
     fn room_history_visibility_content() -> Option<RoomHistoryVisibilityContent>;
 
+    /// covers m.room.join_rules
+    fn room_join_rules_content() -> Option<RoomJoinRulesContent>;
+
     /// original event id, if this msg is reply to another msg
     fn in_reply_to() -> Option<string>;
 
@@ -1290,6 +1293,12 @@ object RoomGuestAccessContent {
 }
 
 object RoomHistoryVisibilityContent {
+    fn change() -> Option<string>;
+    fn new_val() -> string;
+    fn old_val() -> Option<string>;
+}
+
+object RoomJoinRulesContent {
     fn change() -> Option<string>;
     fn new_val() -> string;
     fn old_val() -> Option<string>;
@@ -1725,6 +1734,10 @@ object Convo {
     /// set room history visibility
     /// invited, joined, shared, or world_readable
     fn set_history_visibility(history_visibility: string) -> Future<Result<EventId>>;
+
+    /// set room join rules
+    /// invite, knock, private, or public
+    fn set_join_rules(join_rule: string) -> Future<Result<EventId>>;
 }
 
 
@@ -2803,6 +2816,10 @@ object Space {
     /// set room history visibility
     /// invited, joined, shared, or world_readable
     fn set_history_visibility(history_visibility: string) -> Future<Result<EventId>>;
+
+    /// set room join rules
+    /// invite, knock, private, or public
+    fn set_join_rules(join_rule: string) -> Future<Result<EventId>>;
 }
 
 enum MembershipStatus {

--- a/native/acter/src/api.rs
+++ b/native/acter/src/api.rs
@@ -70,6 +70,7 @@ pub use acter_core::{
             MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent,
             PolicyRuleUserContent, ProfileContent, RoomAvatarContent, RoomCreateContent,
             RoomEncryptionContent, RoomGuestAccessContent, RoomHistoryVisibilityContent,
+            RoomJoinRulesContent,
         },
         ActerModel, Tag, TextMessageContent,
     },

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -2,7 +2,7 @@ use acter_core::{
     models::status::{
         MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent, PolicyRuleUserContent,
         ProfileContent, RoomAvatarContent, RoomCreateContent, RoomEncryptionContent,
-        RoomGuestAccessContent, RoomHistoryVisibilityContent,
+        RoomGuestAccessContent, RoomHistoryVisibilityContent, RoomJoinRulesContent,
     },
     util::do_vecs_match,
 };
@@ -357,6 +357,14 @@ impl TimelineEventItem {
         }
     }
 
+    pub fn room_join_rules_content(&self) -> Option<RoomJoinRulesContent> {
+        if let Some(TimelineEventContent::RoomJoinRules(c)) = &self.content {
+            Some(c.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn in_reply_to(&self) -> Option<String> {
         self.in_reply_to.as_ref().map(ToString::to_string)
     }
@@ -538,36 +546,13 @@ impl TimelineEventItemBuilder {
                 let c = RoomHistoryVisibilityContent::new(content.clone(), prev_content.clone());
                 self.content(Some(TimelineEventContent::RoomHistoryVisibility(c)));
             }
-            AnyOtherFullStateEventContent::RoomJoinRules(c) => {
+            AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Original {
+                content,
+                prev_content,
+            }) => {
                 self.event_type("m.room.join_rules".to_owned());
-                let msg_content = match c {
-                    FullStateEventContent::Original {
-                        content,
-                        prev_content,
-                    } => {
-                        if let Some(old) = prev_content {
-                            let mut result = vec![];
-                            if old.join_rule.ne(&content.join_rule) {
-                                result.push(format!(
-                                    "changed '{}' -> '{}'",
-                                    old.join_rule.as_str(),
-                                    &content.join_rule.as_str()
-                                ));
-                            }
-                            if result.is_empty() {
-                                MsgContent::from_text("empty content".to_owned())
-                            } else {
-                                MsgContent::from_text(result.join(", "))
-                            }
-                        } else {
-                            MsgContent::from_text(content.join_rule.as_str().to_owned())
-                        }
-                    }
-                    FullStateEventContent::Redacted(r) => {
-                        MsgContent::from_text("deleted room join rule".to_owned())
-                    }
-                };
-                self.content(Some(TimelineEventContent::Message(msg_content)));
+                let c = RoomJoinRulesContent::new(content.clone(), prev_content.clone());
+                self.content(Some(TimelineEventContent::RoomJoinRules(c)));
             }
             AnyOtherFullStateEventContent::RoomName(c) => {
                 self.event_type("m.room.name".to_owned());

--- a/native/acter/src/api/timeline/room_event.rs
+++ b/native/acter/src/api/timeline/room_event.rs
@@ -1,7 +1,7 @@
 use acter_core::models::status::{
     MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent, PolicyRuleUserContent,
     ProfileContent, RoomAvatarContent, RoomCreateContent, RoomEncryptionContent,
-    RoomGuestAccessContent, RoomHistoryVisibilityContent,
+    RoomGuestAccessContent, RoomHistoryVisibilityContent, RoomJoinRulesContent,
 };
 use matrix_sdk_base::ruma::events::room::message::MessageType;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ pub enum TimelineEventContent {
     RoomEncryption(RoomEncryptionContent),
     RoomGuestAccess(RoomGuestAccessContent),
     RoomHistoryVisibility(RoomHistoryVisibilityContent),
+    RoomJoinRules(RoomJoinRulesContent),
 }
 
 impl TryFrom<&MessageType> for TimelineEventContent {

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -19,6 +19,7 @@ use crate::{
             MembershipContent, PolicyRuleRoomContent, PolicyRuleServerContent,
             PolicyRuleUserContent, ProfileContent, RoomAvatarContent, RoomCreateContent,
             RoomEncryptionContent, RoomGuestAccessContent, RoomHistoryVisibilityContent,
+            RoomJoinRulesContent,
         },
         ActerModel, ActerSupportedRoomStatusEvents, AnyActerModel, EventMeta, Task,
     },
@@ -40,6 +41,7 @@ pub enum ActivityContent {
     RoomEncryption(RoomEncryptionContent),
     RoomGuestAccess(RoomGuestAccessContent),
     RoomHistoryVisibility(RoomHistoryVisibilityContent),
+    RoomJoinRules(RoomJoinRulesContent),
     RoomName(RoomNameEventContent),
     RoomTopic(RoomTopicEventContent),
     Boost {
@@ -158,6 +160,7 @@ impl Activity {
             ActivityContent::RoomEncryption(_) => "roomEncryption",
             ActivityContent::RoomGuestAccess(_) => "roomGuestAccess",
             ActivityContent::RoomHistoryVisibility(_) => "roomHistoryVisibility",
+            ActivityContent::RoomJoinRules(_) => "roomJoinRules",
             ActivityContent::RoomName(_) => "roomName",
             ActivityContent::RoomTopic(_) => "roomTopic",
             ActivityContent::Comment { .. } => "comment",
@@ -253,6 +256,7 @@ impl Activity {
             | ActivityContent::RoomEncryption(_)
             | ActivityContent::RoomGuestAccess(_)
             | ActivityContent::RoomHistoryVisibility(_)
+            | ActivityContent::RoomJoinRules(_)
             | ActivityContent::RoomName(_)
             | ActivityContent::RoomTopic(_) => None,
 
@@ -358,6 +362,7 @@ impl Activity {
             | ActivityContent::RoomEncryption(_)
             | ActivityContent::RoomGuestAccess(_)
             | ActivityContent::RoomHistoryVisibility(_)
+            | ActivityContent::RoomJoinRules(_)
             | ActivityContent::RoomName(_)
             | ActivityContent::RoomTopic(_) => todo!(),
         }
@@ -419,6 +424,9 @@ impl Activity {
                 }
                 ActerSupportedRoomStatusEvents::RoomHistoryVisibility(c) => {
                     Ok(Self::new(meta, ActivityContent::RoomHistoryVisibility(c)))
+                }
+                ActerSupportedRoomStatusEvents::RoomJoinRules(c) => {
+                    Ok(Self::new(meta, ActivityContent::RoomJoinRules(c)))
                 }
                 ActerSupportedRoomStatusEvents::RoomName(c) => {
                     Ok(Self::new(meta, ActivityContent::RoomName(c)))

--- a/native/core/src/models/status/mod.rs
+++ b/native/core/src/models/status/mod.rs
@@ -24,6 +24,7 @@ pub use profile::{Change, ProfileContent};
 pub use room_state::{
     PolicyRuleRoomContent, PolicyRuleServerContent, PolicyRuleUserContent, RoomAvatarContent,
     RoomCreateContent, RoomEncryptionContent, RoomGuestAccessContent, RoomHistoryVisibilityContent,
+    RoomJoinRulesContent,
 };
 
 use super::{conversion::ParseError, ActerModel, Capability, EventMeta, Store};
@@ -40,6 +41,7 @@ pub enum ActerSupportedRoomStatusEvents {
     RoomEncryption(RoomEncryptionContent),
     RoomGuestAccess(RoomGuestAccessContent),
     RoomHistoryVisibility(RoomHistoryVisibilityContent),
+    RoomJoinRules(RoomJoinRulesContent),
     RoomName(RoomNameEventContent),
     RoomTopic(RoomTopicEventContent),
 }
@@ -194,6 +196,16 @@ impl TryFrom<AnyStateEvent> for RoomStatus {
                 );
                 Ok(RoomStatus {
                     inner: ActerSupportedRoomStatusEvents::RoomHistoryVisibility(content),
+                    meta,
+                })
+            }
+            AnyStateEvent::RoomJoinRules(StateEvent::Original(inner)) => {
+                let content = RoomJoinRulesContent::new(
+                    inner.content.clone(),
+                    inner.unsigned.prev_content.clone(),
+                );
+                Ok(RoomStatus {
+                    inner: ActerSupportedRoomStatusEvents::RoomJoinRules(content),
                     meta,
                 })
             }

--- a/native/core/src/models/status/room_state.rs
+++ b/native/core/src/models/status/room_state.rs
@@ -10,6 +10,7 @@ use matrix_sdk_base::ruma::events::{
         encryption::{PossiblyRedactedRoomEncryptionEventContent, RoomEncryptionEventContent},
         guest_access::{PossiblyRedactedRoomGuestAccessEventContent, RoomGuestAccessEventContent},
         history_visibility::RoomHistoryVisibilityEventContent,
+        join_rules::RoomJoinRulesEventContent,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -525,5 +526,46 @@ impl RoomHistoryVisibilityContent {
         self.prev_content
             .as_ref()
             .map(|prev| prev.history_visibility.to_string())
+    }
+}
+
+// m.room.join_rules
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoomJoinRulesContent {
+    content: RoomJoinRulesEventContent,
+    prev_content: Option<RoomJoinRulesEventContent>,
+}
+
+impl RoomJoinRulesContent {
+    pub fn new(
+        content: RoomJoinRulesEventContent,
+        prev_content: Option<RoomJoinRulesEventContent>,
+    ) -> Self {
+        RoomJoinRulesContent {
+            content,
+            prev_content,
+        }
+    }
+
+    pub fn change(&self) -> Option<String> {
+        if let Some(prev_content) = &self.prev_content {
+            if self.content.join_rule == prev_content.join_rule {
+                None
+            } else {
+                Some("Changed".to_owned())
+            }
+        } else {
+            Some("Set".to_owned())
+        }
+    }
+
+    pub fn new_val(&self) -> String {
+        self.content.join_rule.as_str().to_owned()
+    }
+
+    pub fn old_val(&self) -> Option<String> {
+        self.prev_content
+            .as_ref()
+            .map(|prev| prev.join_rule.as_str().to_owned())
     }
 }

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -7442,6 +7442,47 @@ class Api {
     return tmp7;
   }
 
+  EventId? __convoSetJoinRulesFuturePoll(int boxed, int postCobject, int port) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _convoSetJoinRulesFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
   EventId? __commentDraftSendFuturePoll(int boxed, int postCobject, int port) {
     final tmp0 = boxed;
     final tmp2 = postCobject;
@@ -10840,6 +10881,47 @@ class Api {
     tmp3 = tmp2;
     tmp5 = tmp4;
     final tmp6 = _spaceSetHistoryVisibilityFuturePoll(tmp1, tmp3, tmp5);
+    final tmp8 = tmp6.arg0;
+    final tmp9 = tmp6.arg1;
+    final tmp10 = tmp6.arg2;
+    final tmp11 = tmp6.arg3;
+    final tmp12 = tmp6.arg4;
+    final tmp13 = tmp6.arg5;
+    if (tmp8 == 0) {
+      return null;
+    }
+    if (tmp9 == 0) {
+      debugAllocation("handle error", tmp10, tmp11);
+      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+      final tmp9_0 = utf8.decode(
+        tmp10_0.asTypedList(tmp11),
+        allowMalformed: true,
+      );
+      if (tmp11 > 0) {
+        final ffi.Pointer<ffi.Void> tmp10_0;
+        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
+        this.__deallocate(tmp10_0, tmp12, 1);
+      }
+      throw tmp9_0;
+    }
+    final ffi.Pointer<ffi.Void> tmp13_0 = ffi.Pointer.fromAddress(tmp13);
+    final tmp13_1 = _Box(this, tmp13_0, "drop_box_EventId");
+    tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
+    final tmp7 = EventId._(this, tmp13_1);
+    return tmp7;
+  }
+
+  EventId? __spaceSetJoinRulesFuturePoll(int boxed, int postCobject, int port) {
+    final tmp0 = boxed;
+    final tmp2 = postCobject;
+    final tmp4 = port;
+    var tmp1 = 0;
+    var tmp3 = 0;
+    var tmp5 = 0;
+    tmp1 = tmp0;
+    tmp3 = tmp2;
+    tmp5 = tmp4;
+    final tmp6 = _spaceSetJoinRulesFuturePoll(tmp1, tmp3, tmp5);
     final tmp8 = tmp6.arg0;
     final tmp9 = tmp6.arg1;
     final tmp10 = tmp6.arg2;
@@ -20148,6 +20230,17 @@ class Api {
           .asFunction<
             _TimelineEventItemRoomHistoryVisibilityContentReturn Function(int)
           >();
+  late final _timelineEventItemRoomJoinRulesContentPtr = _lookup<
+    ffi.NativeFunction<
+      _TimelineEventItemRoomJoinRulesContentReturn Function(ffi.IntPtr)
+    >
+  >("__TimelineEventItem_room_join_rules_content");
+
+  late final _timelineEventItemRoomJoinRulesContent =
+      _timelineEventItemRoomJoinRulesContentPtr
+          .asFunction<
+            _TimelineEventItemRoomJoinRulesContentReturn Function(int)
+          >();
   late final _timelineEventItemInReplyToPtr = _lookup<
     ffi.NativeFunction<_TimelineEventItemInReplyToReturn Function(ffi.IntPtr)>
   >("__TimelineEventItem_in_reply_to");
@@ -20885,6 +20978,27 @@ class Api {
           .asFunction<
             _RoomHistoryVisibilityContentOldValReturn Function(int)
           >();
+  late final _roomJoinRulesContentChangePtr = _lookup<
+    ffi.NativeFunction<_RoomJoinRulesContentChangeReturn Function(ffi.IntPtr)>
+  >("__RoomJoinRulesContent_change");
+
+  late final _roomJoinRulesContentChange =
+      _roomJoinRulesContentChangePtr
+          .asFunction<_RoomJoinRulesContentChangeReturn Function(int)>();
+  late final _roomJoinRulesContentNewValPtr = _lookup<
+    ffi.NativeFunction<_RoomJoinRulesContentNewValReturn Function(ffi.IntPtr)>
+  >("__RoomJoinRulesContent_new_val");
+
+  late final _roomJoinRulesContentNewVal =
+      _roomJoinRulesContentNewValPtr
+          .asFunction<_RoomJoinRulesContentNewValReturn Function(int)>();
+  late final _roomJoinRulesContentOldValPtr = _lookup<
+    ffi.NativeFunction<_RoomJoinRulesContentOldValReturn Function(ffi.IntPtr)>
+  >("__RoomJoinRulesContent_old_val");
+
+  late final _roomJoinRulesContentOldVal =
+      _roomJoinRulesContentOldValPtr
+          .asFunction<_RoomJoinRulesContentOldValReturn Function(int)>();
   late final _roomRoomIdStrPtr =
       _lookup<ffi.NativeFunction<_RoomRoomIdStrReturn Function(ffi.IntPtr)>>(
         "__Room_room_id_str",
@@ -21984,6 +22098,14 @@ class Api {
   late final _convoSetHistoryVisibility =
       _convoSetHistoryVisibilityPtr
           .asFunction<int Function(int, int, int, int)>();
+  late final _convoSetJoinRulesPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
+    >
+  >("__Convo_set_join_rules");
+
+  late final _convoSetJoinRules =
+      _convoSetJoinRulesPtr.asFunction<int Function(int, int, int, int)>();
   late final _commentDraftContentTextPtr = _lookup<
     ffi.NativeFunction<
       ffi.Void Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
@@ -24946,6 +25068,14 @@ class Api {
   late final _spaceSetHistoryVisibility =
       _spaceSetHistoryVisibilityPtr
           .asFunction<int Function(int, int, int, int)>();
+  late final _spaceSetJoinRulesPtr = _lookup<
+    ffi.NativeFunction<
+      ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr, ffi.UintPtr, ffi.UintPtr)
+    >
+  >("__Space_set_join_rules");
+
+  late final _spaceSetJoinRules =
+      _spaceSetJoinRulesPtr.asFunction<int Function(int, int, int, int)>();
   late final _memberGetProfilePtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr)>>(
         "__Member_get_profile",
@@ -29794,6 +29924,21 @@ class Api {
           .asFunction<
             _ConvoSetHistoryVisibilityFuturePollReturn Function(int, int, int)
           >();
+  late final _convoSetJoinRulesFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _ConvoSetJoinRulesFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Convo_set_join_rules_future_poll");
+
+  late final _convoSetJoinRulesFuturePoll =
+      _convoSetJoinRulesFuturePollPtr
+          .asFunction<
+            _ConvoSetJoinRulesFuturePollReturn Function(int, int, int)
+          >();
   late final _commentDraftSendFuturePollPtr = _lookup<
     ffi.NativeFunction<
       _CommentDraftSendFuturePollReturn Function(
@@ -30948,6 +31093,21 @@ class Api {
       _spaceSetHistoryVisibilityFuturePollPtr
           .asFunction<
             _SpaceSetHistoryVisibilityFuturePollReturn Function(int, int, int)
+          >();
+  late final _spaceSetJoinRulesFuturePollPtr = _lookup<
+    ffi.NativeFunction<
+      _SpaceSetJoinRulesFuturePollReturn Function(
+        ffi.IntPtr,
+        ffi.IntPtr,
+        ffi.Int64,
+      )
+    >
+  >("__Space_set_join_rules_future_poll");
+
+  late final _spaceSetJoinRulesFuturePoll =
+      _spaceSetJoinRulesFuturePollPtr
+          .asFunction<
+            _SpaceSetJoinRulesFuturePollReturn Function(int, int, int)
           >();
   late final _memberIgnoreFuturePollPtr = _lookup<
     ffi.NativeFunction<
@@ -41980,6 +42140,23 @@ class TimelineEventItem {
     return tmp2;
   }
 
+  /// covers m.room.join_rules
+  RoomJoinRulesContent? roomJoinRulesContent() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._timelineEventItemRoomJoinRulesContent(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    if (tmp3 == 0) {
+      return null;
+    }
+    final ffi.Pointer<ffi.Void> tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+    final tmp4_1 = _Box(_api, tmp4_0, "drop_box_RoomJoinRulesContent");
+    tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
+    final tmp2 = RoomJoinRulesContent._(_api, tmp4_1);
+    return tmp2;
+  }
+
   /// original event id, if this msg is reply to another msg
   String? inReplyTo() {
     var tmp0 = 0;
@@ -44258,6 +44435,107 @@ class RoomHistoryVisibilityContent {
     var tmp0 = 0;
     tmp0 = _box.borrow();
     final tmp1 = _api._roomHistoryVisibilityContentOldVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  /// Manually drops the object and unregisters the FinalizableHandle.
+  void drop() {
+    _box.drop();
+  }
+}
+
+class RoomJoinRulesContent {
+  final Api _api;
+  final _Box _box;
+
+  RoomJoinRulesContent._(this._api, this._box);
+
+  String? change() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomJoinRulesContentChange(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    final tmp6 = tmp1.arg3;
+    if (tmp3 == 0) {
+      return null;
+    }
+    if (tmp5 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp4_ptr = ffi.Pointer.fromAddress(tmp4);
+    List<int> tmp4_buf = [];
+    final tmp4_precast = tmp4_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp5; i++) {
+      int char = tmp4_precast.elementAt(i).value;
+      tmp4_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp4_buf, allowMalformed: true);
+    if (tmp6 > 0) {
+      final ffi.Pointer<ffi.Void> tmp4_0;
+      tmp4_0 = ffi.Pointer.fromAddress(tmp4);
+      _api.__deallocate(tmp4_0, tmp6 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String newVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomJoinRulesContentNewVal(tmp0);
+    final tmp3 = tmp1.arg0;
+    final tmp4 = tmp1.arg1;
+    final tmp5 = tmp1.arg2;
+    if (tmp4 == 0) {
+      print("returning empty string");
+      return "";
+    }
+    final ffi.Pointer<ffi.Uint8> tmp3_ptr = ffi.Pointer.fromAddress(tmp3);
+    List<int> tmp3_buf = [];
+    final tmp3_precast = tmp3_ptr.cast<ffi.Uint8>();
+    for (int i = 0; i < tmp4; i++) {
+      int char = tmp3_precast.elementAt(i).value;
+      tmp3_buf.add(char);
+    }
+    final tmp2 = utf8.decode(tmp3_buf, allowMalformed: true);
+    if (tmp5 > 0) {
+      final ffi.Pointer<ffi.Void> tmp3_0;
+      tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+      _api.__deallocate(tmp3_0, tmp5 * 1, 1);
+    }
+    return tmp2;
+  }
+
+  String? oldVal() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._roomJoinRulesContentOldVal(tmp0);
     final tmp3 = tmp1.arg0;
     final tmp4 = tmp1.arg1;
     final tmp5 = tmp1.arg2;
@@ -47225,6 +47503,32 @@ class Convo {
       tmp7_1,
       _api.__convoSetHistoryVisibilityFuturePoll,
     );
+    return tmp6;
+  }
+
+  /// set room join rules
+  /// invite, knock, private, or public
+  Future<EventId> setJoinRules(String joinRule) {
+    final tmp1 = joinRule;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._convoSetJoinRules(tmp0, tmp2, tmp3, tmp4);
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "__Convo_set_join_rules_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeFuture(tmp7_1, _api.__convoSetJoinRulesFuturePoll);
     return tmp6;
   }
 
@@ -54791,6 +55095,32 @@ class Space {
       tmp7_1,
       _api.__spaceSetHistoryVisibilityFuturePoll,
     );
+    return tmp6;
+  }
+
+  /// set room join rules
+  /// invite, knock, private, or public
+  Future<EventId> setJoinRules(String joinRule) {
+    final tmp1 = joinRule;
+    var tmp0 = 0;
+    var tmp2 = 0;
+    var tmp3 = 0;
+    var tmp4 = 0;
+    tmp0 = _box.borrow();
+    final tmp1_0 = utf8.encode(tmp1);
+    tmp3 = tmp1_0.length;
+
+    final ffi.Pointer<ffi.Uint8> tmp2_0 = _api.__allocate(tmp3 * 1, 1);
+    final Uint8List tmp2_1 = tmp2_0.asTypedList(tmp3);
+    tmp2_1.setAll(0, tmp1_0);
+    tmp2 = tmp2_0.address;
+    tmp4 = tmp3;
+    final tmp5 = _api._spaceSetJoinRules(tmp0, tmp2, tmp3, tmp4);
+    final tmp7 = tmp5;
+    final ffi.Pointer<ffi.Void> tmp7_0 = ffi.Pointer.fromAddress(tmp7);
+    final tmp7_1 = _Box(_api, tmp7_0, "__Space_set_join_rules_future_drop");
+    tmp7_1._finalizer = _api._registerFinalizer(tmp7_1);
+    final tmp6 = _nativeFuture(tmp7_1, _api.__spaceSetJoinRulesFuturePoll);
     return tmp6;
   }
 
@@ -64416,6 +64746,13 @@ class _TimelineEventItemRoomHistoryVisibilityContentReturn extends ffi.Struct {
   external int arg1;
 }
 
+class _TimelineEventItemRoomJoinRulesContentReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+}
+
 class _TimelineEventItemInReplyToReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -65089,6 +65426,37 @@ class _RoomHistoryVisibilityContentNewValReturn extends ffi.Struct {
 }
 
 class _RoomHistoryVisibilityContentOldValReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomJoinRulesContentChangeReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.IntPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+}
+
+class _RoomJoinRulesContentNewValReturn extends ffi.Struct {
+  @ffi.IntPtr()
+  external int arg0;
+  @ffi.UintPtr()
+  external int arg1;
+  @ffi.UintPtr()
+  external int arg2;
+}
+
+class _RoomJoinRulesContentOldValReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.IntPtr()
@@ -69096,6 +69464,21 @@ class _ConvoSetHistoryVisibilityFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
+class _ConvoSetJoinRulesFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
 class _CommentDraftSendFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -70271,6 +70654,21 @@ class _SpaceSetGuestAccessFuturePollReturn extends ffi.Struct {
 }
 
 class _SpaceSetHistoryVisibilityFuturePollReturn extends ffi.Struct {
+  @ffi.Uint8()
+  external int arg0;
+  @ffi.Uint8()
+  external int arg1;
+  @ffi.IntPtr()
+  external int arg2;
+  @ffi.UintPtr()
+  external int arg3;
+  @ffi.UintPtr()
+  external int arg4;
+  @ffi.IntPtr()
+  external int arg5;
+}
+
+class _SpaceSetJoinRulesFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
   @ffi.Uint8()


### PR DESCRIPTION
This PR was split from https://github.com/acterglobal/a3/pull/2815.

- Will handle `TimelineItemContent::OtherState` here.
- Make activity cover the room join rules event.