### PR TITLE
Reduced space activities count from 100 to 25.

### DIFF
--- a/.changes/2909-reduce-activity-list-count.md
+++ b/.changes/2909-reduce-activity-list-count.md
@@ -1,0 +1,1 @@
+- [Fix] : Previously, up to 100 entries were shown at once in activities page, which led to excessive scrolling. Now, it's reduced the default visible count to 25 entries.

--- a/app/lib/features/activities/providers/notifiers/activities_notifiers.dart
+++ b/app/lib/features/activities/providers/notifiers/activities_notifiers.dart
@@ -21,7 +21,7 @@ class AsyncSpaceActivitiesNotifier
 
     // Get new activities for the space
     _activities = client.activitiesForRoom(arg);
-    final activitiesIds = await _activities?.getIds(0, 100);
+    final activitiesIds = await _activities?.getIds(0, 25);
     if (activitiesIds == null) return [];
     return asDartStringList(activitiesIds);
   }


### PR DESCRIPTION
Fixed, https://github.com/acterglobal/a3/issues/2908

- To enhance usability and improve the overall experience for our users, I have optimized the display of space activity data.
- Previously, up to 100 entries were shown at once, which led to excessive scrolling. Now,  I have reduced the default visible count to 25 entries.
- This change ensures that the most recent and relevant data is easily accessible.

Reference video :

https://github.com/user-attachments/assets/2e5aa68d-a561-42f6-a681-07eaf34354ab
