### PR TITLE
Activities forwarding

### DIFF
--- a/.github/workflows/check-rust-integration-tests.yml
+++ b/.github/workflows/check-rust-integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: michaelkaye/setup-matrix-synapse@main
         with:
-          installer: poetry
+          installer: venv
           uploadLogs: false
           httpPort: 8118
           disableRateLimiting: true

--- a/app/lib/router/router.dart
+++ b/app/lib/router/router.dart
@@ -98,7 +98,7 @@ Future<String?> forwardRedirect(
       _log.severe(
         'Received forward without roomId failed: ${state.uri.queryParameters}.',
       );
-      return state.namedLocation(Routes.main.name);
+      return state.namedLocation(Routes.activities.name);
     }
 
     final room = await client.room(roomId);
@@ -115,7 +115,7 @@ Future<String?> forwardRedirect(
       // final eventId = state.uri.queryParameters['eventId'];
       // with the event ID or further information we could figure out the specific action
       return state.namedLocation(
-        Routes.space.name,
+        Routes.activities.name,
         pathParameters: {'spaceId': roomId},
       );
     }

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -385,7 +385,7 @@ impl Activity {
             | ActivityContent::RoomTombstone(_)
             | ActivityContent::RoomTopic(_)
             | ActivityContent::SpaceChild(_)
-            | ActivityContent::SpaceParent(_) => todo!(),
+            | ActivityContent::SpaceParent(_) => "/activities".to_string(), // fallback for state events
         }
     }
 
@@ -837,7 +837,9 @@ impl Activity {
                 "Converting model into activity not yet supported".to_string(),
             )),
             #[cfg(any(test, feature = "testing"))]
-            AnyActerModel::TestModel(_) => todo!(),
+            AnyActerModel::TestModel(_) => Err(crate::Error::Custom(
+                "Converting test model into activity not supported".to_string(),
+            )),
         }
     }
 }

--- a/native/core/src/activities/object.rs
+++ b/native/core/src/activities/object.rs
@@ -158,7 +158,10 @@ impl TryFrom<&AnyActerModel> for ActivityObject {
                 Err(())
             }
             #[cfg(any(test, feature = "testing"))]
-            AnyActerModel::TestModel(_test_model) => todo!(),
+            AnyActerModel::TestModel(_test_model) => {
+                tracing::warn!("Converting a a test model failed");
+                Err(())
+            }
         }
     }
 }

--- a/native/test/src/tests/activities/space.rs
+++ b/native/test/src/tests/activities/space.rs
@@ -35,6 +35,7 @@ async fn change_space_name() -> Result<()> {
         .expect("space name should be already assigned");
     // for example, it-room-change-space-name-9a2b3db1-d3f9-4f58-a471-81c04bdaa9f4
     assert!(room_name.contains("change-space-name"));
+    assert_eq!(activity.target_url(), "/activities");
 
     // let new_name = new_room_name("update-space-name");
     // let room = admin.room(room_id.to_string()).await?;
@@ -74,6 +75,7 @@ async fn change_space_avatar() -> Result<()> {
         .room_avatar()
         .expect("space topic should be already assigned");
     assert_eq!(room_avatar.as_str(), uri.as_str());
+    assert_eq!(activity.target_url(), "/activities");
 
     Ok(())
 }
@@ -95,6 +97,7 @@ async fn change_space_topic() -> Result<()> {
         .room_topic()
         .expect("space topic should be already assigned");
     assert_eq!(room_topic, "Here is playground");
+    assert_eq!(activity.target_url(), "/activities");
 
     Ok(())
 }

--- a/native/test/src/tests/room/room_server_acl.rs
+++ b/native/test/src/tests/room/room_server_acl.rs
@@ -89,9 +89,8 @@ async fn test_room_server_acl() -> Result<()> {
         Some("Set".to_owned()),
         "allow ip literals in room server acl should be set"
     );
-    assert_eq!(
+    assert!(
         content.allow_ip_literals_new_val(),
-        true,
         "new val of allow ip literals in room server acl is invalid"
     );
 

--- a/native/test/src/tests/room/room_tombstone.rs
+++ b/native/test/src/tests/room/room_tombstone.rs
@@ -112,7 +112,7 @@ fn gen_id(len: usize) -> String {
     let alphabet: [char; 16] = [
         '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f',
     ];
-    return nanoid!(len, &alphabet);
+    nanoid!(len, &alphabet)
 }
 
 fn match_msg(msg: &TimelineItem) -> Option<(String, RoomTombstoneContent)> {

--- a/native/test/src/tests/room/space_child.rs
+++ b/native/test/src/tests/room/space_child.rs
@@ -62,7 +62,7 @@ async fn test_space_child() -> Result<()> {
                         .values()
                         .expect("diff reset action should have valid values");
                     for value in values.iter() {
-                        if let Some(result) = match_msg(&value) {
+                        if let Some(result) = match_msg(value) {
                             found_result = Some(result);
                             break;
                         }

--- a/native/test/src/tests/room/space_parent.rs
+++ b/native/test/src/tests/room/space_parent.rs
@@ -62,7 +62,7 @@ async fn test_space_parent() -> Result<()> {
                         .values()
                         .expect("diff reset action should have valid values");
                     for value in values.iter() {
-                        if let Some(result) = match_msg(&value) {
+                        if let Some(result) = match_msg(value) {
                             found_result = Some(result);
                             break;
                         }


### PR DESCRIPTION
from backend: by removing `todo!` that causes crashes ( fixes https://github.com/acterglobal/a3-meta/issues/946 ) and on the regular forwarding code on the flutter side, fixes #2897 . Run-by clippy fixes as well.