### PR TITLE
Remove invites we dealt with

### DIFF
--- a/.changes/2898-invitations.md
+++ b/.changes/2898-invitations.md
@@ -1,0 +1,1 @@
+- Fix: remove invitations that have been accepted or rejected

--- a/native/acter/src/api/invitations/manager.rs
+++ b/native/acter/src/api/invitations/manager.rs
@@ -13,6 +13,7 @@ use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 
 use super::RoomInvitation;
 
+#[derive(Debug, Clone)]
 pub struct InvitationsManager {
     client: Client,
 }

--- a/native/acter/src/api/invitations/manager.rs
+++ b/native/acter/src/api/invitations/manager.rs
@@ -7,6 +7,7 @@ use acter_core::{
 };
 use anyhow::Result;
 use futures::{stream::select, Stream};
+use log::{trace, warn};
 use ruma::OwnedRoomId;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
@@ -25,11 +26,16 @@ impl InvitationsManager {
 
     pub fn subscribe_stream(&self) -> impl Stream<Item = bool> {
         let mut prev_set: BTreeSet<OwnedRoomId> = Default::default();
+        let core = self.client.core.clone();
         let room_stream = BroadcastStream::new(self.client.subscribe_to_all_room_updates())
             .filter_map(move |u| {
-                let Ok(update) = u else { return None };
-                let new_set: BTreeSet<OwnedRoomId> =
-                    update.invited.keys().map(Clone::clone).collect();
+                // an update was seen, check if the set of rooms we are invited to has changed
+                let new_set: BTreeSet<OwnedRoomId> = core
+                    .client()
+                    .invited_rooms()
+                    .iter()
+                    .map(|r| r.room_id().to_owned())
+                    .collect();
                 if (new_set != prev_set) {
                     prev_set = new_set;
                     Some(true)
@@ -38,9 +44,9 @@ impl InvitationsManager {
                 }
             });
 
-        let object_invites = BroadcastStream::new(self.client.subscribe(ExecuteReference::Index(
-            IndexKey::Special(SpecialListsIndex::InvitedTo),
-        )))
+        let object_invites = tokio_stream::wrappers::BroadcastStream::new(self.client.subscribe(
+            ExecuteReference::Index(IndexKey::Special(SpecialListsIndex::InvitedTo)),
+        ))
         .map(|_| true);
 
         select(room_stream, object_invites)

--- a/native/test/src/tests/invitation.rs
+++ b/native/test/src/tests/invitation.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
-use futures::StreamExt;
-use matrix_sdk::RoomState;
+use acter::{matrix_sdk_ui::timeline::{MsgLikeContent, MsgLikeKind, RoomExt, TimelineItemContent}, Client, Room};
+use anyhow::{bail, Result};
+use futures::{FutureExt, StreamExt};
+use matrix_sdk::{ruma::{events::room::message::RoomMessageEventContent, OwnedRoomId, UserId}, RoomState};
 use tokio_retry::{
     strategy::{jitter, FibonacciBackoff},
     Retry,
@@ -54,6 +55,22 @@ async fn chat_invitation_shows_up() -> Result<()> {
     Ok(())
 }
 
+
+
+async fn invite_user(client: &Client, room_id: &OwnedRoomId, other_user_id: &UserId) -> Result<Room> {
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+
+    let room = Retry::spawn(retry_strategy.clone(), || async {
+        client.room(room_id.as_str().into()).await
+    })
+    .await?;
+
+    room.invite_user_by_id(&other_user_id).await?;
+
+    Ok(room)
+}
+
+
 #[tokio::test]
 async fn space_invitation_shows_up() -> Result<()> {
     let _ = env_logger::try_init();
@@ -66,15 +83,11 @@ async fn space_invitation_shows_up() -> Result<()> {
 
     let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
 
-    let space = Retry::spawn(retry_strategy.clone(), || async {
-        sisko.space(room_id.as_str().into()).await
-    })
-    .await?;
-
     let invites = kyra.invitations();
     let stream = invites.subscribe_stream();
     let mut stream = stream.fuse();
-    space.invite_user_by_id(&kyra.user_id()?).await?;
+
+    invite_user(&sisko, &room_id, &kyra.user_id()?).await?;
 
     let invited = Retry::spawn(retry_strategy.clone(), || async {
         let invited = kyra.invitations().room_invitations().await?;
@@ -95,6 +108,328 @@ async fn space_invitation_shows_up() -> Result<()> {
     assert_eq!(room.state(), RoomState::Invited);
     assert!(room.is_space());
     assert_eq!(room.sender_id(), sisko.user_id()?);
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn space_invitation_disappears_when_joined() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut sisko, room_id) = random_user_with_random_space("spI").await?;
+    let _sisko_syncer = sisko.start_sync();
+
+    let mut kyra = random_user("spI").await?;
+    let _kyra_syncer = kyra.start_sync();
+
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+
+
+    let invites = kyra.invitations();
+    let stream = invites.subscribe_stream();
+    let mut stream = stream.fuse();
+
+    invite_user(&sisko, &room_id, &kyra.user_id()?).await?;
+
+    let manager = invites.clone();
+
+    let invited = Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.is_empty() {
+            Err(anyhow::anyhow!("No pending invitations found"))
+        } else {
+            Ok(invited)
+        }
+    })
+    .await?;
+
+    // stream triggered
+    assert_eq!(stream.next().await, Some(true));
+
+    assert_eq!(invited.len(), 1);
+    let room = invited.first().unwrap();
+    assert_eq!(room.room_id(), room_id);
+    assert_eq!(room.state(), RoomState::Invited);
+    assert!(room.is_space());
+    assert_eq!(room.sender_id(), sisko.user_id()?);
+
+    // second stream
+
+    room.join().await?;
+    let manager = invites.clone();
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if !invited.is_empty() {
+            Err(anyhow::anyhow!("still pending invitations found"))
+        } else {
+            Ok(true)
+        }
+    })
+    .await?;
+
+    // we have seen an update on the stream as well
+    assert_eq!(stream.next().await, Some(true));
+
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn invitations_update_count_when_joined() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut sisko, sisko_room_id) = random_user_with_random_space("spI").await?;
+    let (mut worf, worf_room_id) = random_user_with_random_space("sp2").await?;
+    let (mut gundom, gundom_room_id) = random_user_with_random_space("sp3").await?;
+    let _sisko_syncer = sisko.start_sync();
+    let _worf_syncer = worf.start_sync();
+    let _gundom_syncer = gundom.start_sync();
+
+    let mut kyra = random_user("spI").await?;
+    let _kyra_syncer = kyra.start_sync();
+
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let invites = kyra.invitations();
+    let stream = invites.subscribe_stream();
+    let mut stream = stream.fuse();
+
+    invite_user(&sisko, &sisko_room_id, &kyra.user_id()?).await?;
+
+    // sisko's invite
+
+
+    let manager = invites.clone();
+
+    let invited = Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.is_empty() {
+            Err(anyhow::anyhow!("No pending invitations found"))
+        } else {
+            Ok(invited)
+        }
+    })
+    .await?;
+
+    // stream triggered
+    assert_eq!(stream.next().await, Some(true));
+
+    assert_eq!(invited.len(), 1);
+    let room = invited.first().unwrap();
+    assert_eq!(room.room_id(), sisko_room_id);
+    assert_eq!(room.state(), RoomState::Invited);
+    assert!(room.is_space());
+    assert_eq!(room.sender_id(), sisko.user_id()?);
+
+    invite_user(&worf, &worf_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+
+    invite_user(&gundom, &gundom_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+    
+
+    room.join().await?;
+    let manager = invites.clone();
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.len() != 2  {
+            Err(anyhow::anyhow!("not yet updated"))
+        } else {
+            Ok(true)
+        }
+    })
+    .await?;
+
+    // we have seen an update on the stream as well
+    assert_eq!(stream.next().await, Some(true));
+    // and no further updates
+    assert_eq!(stream.next().now_or_never(), None);
+
+    Ok(())
+
+}
+
+#[tokio::test]
+async fn no_invite_count_update_on_message() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut sisko, sisko_room_id) = random_user_with_random_space("spI").await?;
+    let (mut worf, worf_room_id) = random_user_with_random_space("sp2").await?;
+    let (mut gundom, gundom_room_id) = random_user_with_random_space("sp3").await?;
+    let _sisko_syncer = sisko.start_sync();
+    let _worf_syncer = worf.start_sync();
+    let _gundom_syncer = gundom.start_sync();
+
+    let mut kyra = random_user("spI").await?;
+    let _kyra_syncer = kyra.start_sync();
+
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let invites = kyra.invitations();
+    let stream = invites.subscribe_stream();
+    let mut stream = stream.fuse();
+
+    let sisko_room = invite_user(&sisko, &sisko_room_id, &kyra.user_id()?).await?;
+
+    // sisko's invite
+
+
+    let manager = invites.clone();
+
+    let invited = Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.is_empty() {
+            Err(anyhow::anyhow!("No pending invitations found"))
+        } else {
+            Ok(invited)
+        }
+    })
+    .await?;
+
+    // stream triggered
+    assert_eq!(stream.next().await, Some(true));
+
+    assert_eq!(invited.len(), 1);
+    let room = invited.first().unwrap();
+    assert_eq!(room.room_id(), sisko_room_id);
+    assert_eq!(room.state(), RoomState::Invited);
+    assert!(room.is_space());
+    assert_eq!(room.sender_id(), sisko.user_id()?);
+
+    invite_user(&worf, &worf_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+
+    invite_user(&gundom, &gundom_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+
+    room.join().await?;
+    let manager = invites.clone();
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.len() != 2  {
+            Err(anyhow::anyhow!("not yet updated"))
+        } else {
+            Ok(true)
+        }
+    })
+    .await?;
+
+    // we have seen an update on the stream as well
+    assert_eq!(stream.next().await, Some(true));
+    // and no further updates
+    assert_eq!(stream.next().now_or_never(), None);
+
+    // now let there be something happening in the room
+    let room = kyra.room(sisko_room_id.as_str().into()).await?;
+    let timeline = room.timeline().await?;
+
+    sisko_room.send(RoomMessageEventContent::text_plain("hello")).await?;
+
+    // ensure we received the message
+    Retry::spawn(retry_strategy.clone(), || async {
+        let Some(event) = timeline.latest_event().await else {
+            bail!("no event");
+        };
+        let TimelineItemContent::MsgLike(MsgLikeContent{ kind: MsgLikeKind::Message(msg), .. }) = event.content() else {
+            bail!("not a text message");
+        };
+        if msg.body() == "hello" {
+            Ok(true)
+        } else {
+            Err(anyhow::anyhow!("wrong message"))
+        }
+    })
+    .await?;
+
+    // without that triggereing an update
+
+    assert_eq!(stream.next().now_or_never(), None);
+
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn invitations_update_count_when_rejected() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (mut sisko, sisko_room_id) = random_user_with_random_space("spI").await?;
+    let (mut worf, worf_room_id) = random_user_with_random_space("sp2").await?;
+    let (mut gundom, gundom_room_id) = random_user_with_random_space("sp3").await?;
+    let _sisko_syncer = sisko.start_sync();
+    let _worf_syncer = worf.start_sync();
+    let _gundom_syncer = gundom.start_sync();
+
+    let mut kyra = random_user("spI").await?;
+    let _kyra_syncer = kyra.start_sync();
+
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    let invites = kyra.invitations();
+    let stream = invites.subscribe_stream();
+    let mut stream = stream.fuse();
+
+    invite_user(&sisko, &sisko_room_id, &kyra.user_id()?).await?;
+
+    // sisko's invite
+
+
+    let manager = invites.clone();
+
+    let invited = Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.is_empty() {
+            Err(anyhow::anyhow!("No pending invitations found"))
+        } else {
+            Ok(invited)
+        }
+    })
+    .await?;
+
+    // stream triggered
+    assert_eq!(stream.next().await, Some(true));
+
+    assert_eq!(invited.len(), 1);
+    let room = invited.first().unwrap();
+    assert_eq!(room.room_id(), sisko_room_id);
+    assert_eq!(room.state(), RoomState::Invited);
+    assert!(room.is_space());
+    assert_eq!(room.sender_id(), sisko.user_id()?);
+
+    // second stream
+
+
+    invite_user(&worf, &worf_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+
+    invite_user(&gundom, &gundom_room_id, &kyra.user_id()?).await?;
+    // and has been seen
+    assert_eq!(stream.next().await, Some(true));
+
+    room.reject().await?;
+    let manager = invites.clone();
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        let invited = manager.room_invitations().await?;
+        if invited.len() != 2  {
+            Err(anyhow::anyhow!("not yet updated"))
+        } else {
+            Ok(true)
+        }
+    })
+    .await?;
+
+    // we have seen an update on the stream as well
+    assert_eq!(stream.next().await, Some(true));
+
 
     Ok(())
 }

--- a/native/test/src/tests/room/room_server_acl.rs
+++ b/native/test/src/tests/room/room_server_acl.rs
@@ -89,9 +89,8 @@ async fn test_room_server_acl() -> Result<()> {
         Some("Set".to_owned()),
         "allow ip literals in room server acl should be set"
     );
-    assert_eq!(
+    assert!(
         content.allow_ip_literals_new_val(),
-        true,
         "new val of allow ip literals in room server acl is invalid"
     );
 

--- a/native/test/src/tests/room/room_tombstone.rs
+++ b/native/test/src/tests/room/room_tombstone.rs
@@ -112,7 +112,7 @@ fn gen_id(len: usize) -> String {
     let alphabet: [char; 16] = [
         '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f',
     ];
-    return nanoid!(len, &alphabet);
+    nanoid!(len, &alphabet)
 }
 
 fn match_msg(msg: &TimelineItem) -> Option<(String, RoomTombstoneContent)> {

--- a/native/test/src/tests/room/space_child.rs
+++ b/native/test/src/tests/room/space_child.rs
@@ -62,7 +62,7 @@ async fn test_space_child() -> Result<()> {
                         .values()
                         .expect("diff reset action should have valid values");
                     for value in values.iter() {
-                        if let Some(result) = match_msg(&value) {
+                        if let Some(result) = match_msg(value) {
                             found_result = Some(result);
                             break;
                         }

--- a/native/test/src/tests/room/space_parent.rs
+++ b/native/test/src/tests/room/space_parent.rs
@@ -62,7 +62,7 @@ async fn test_space_parent() -> Result<()> {
                         .values()
                         .expect("diff reset action should have valid values");
                     for value in values.iter() {
-                        if let Some(result) = match_msg(&value) {
+                        if let Some(result) = match_msg(value) {
                             found_result = Some(result);
                             break;
                         }


### PR DESCRIPTION
fixes #2898 by actually checking the room list not just the _updates_ giving in the sync response (which is empty too often).

See it in action:

https://github.com/user-attachments/assets/1ef6ad46-1af9-47bd-b60e-dfe30384064e

also works for rejections:


https://github.com/user-attachments/assets/6b2dc77b-920f-46ec-8074-683af6136747



Unfortunately none of the additional tests was able to catch it ... But then doing it manually I can confirm it was broken before and then worked with the fix.