### PR TITLE
Ensure the chat ng input min height is respected regardless of contentHeight

### DIFF
--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -287,7 +287,10 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 150),
       width: MediaQuery.sizeOf(context).width,
-      height: contentHeight,
+      height: max(
+        contentHeight,
+        ChatEditorUtils.baseHeight,
+      ), // always stay above the base height
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primaryContainer,
         borderRadius: BorderRadius.only(


### PR DESCRIPTION
Don't know why but debugging shows the size is sometimes bound to be `6`. That ever won't work. forcing the base height with this change.

![dropping-too-low](https://github.com/user-attachments/assets/e431c6b5-e53d-494a-9088-e641440d4e54)


Fixes https://github.com/acterglobal/a3-meta/issues/951