### PR TITLE
Have a key on swipeTo ensure correct callbacks

### DIFF
--- a/.changes/swipe-to-reply.md
+++ b/.changes/swipe-to-reply.md
@@ -1,0 +1,1 @@
+- Fix in Chat-NG: swipe to reply doesn't confuse items anymore.

--- a/app/lib/features/chat_ng/widgets/events/message_event_item.dart
+++ b/app/lib/features/chat_ng/widgets/events/message_event_item.dart
@@ -44,6 +44,7 @@ class MessageEventItem extends ConsumerWidget {
     final hasReactions = ref.watch(messageReactionsProvider(item)).isNotEmpty;
     final sendingState = item.sendState();
     return SwipeTo(
+      key: Key(messageId), // needed or swipe doesn't work reliably in listview
       onRightSwipe: (_) => _handleReplySwipe(ref, item),
       child: Column(
         crossAxisAlignment:


### PR DESCRIPTION
When the chat ng list of items was updated, swipe-to failed to select the right item and instead would cause the wrong item to be selected. After some debugging the cause turned out to be that swipe-to is stateful and needs to be informed about updates. In listviews this needs to be done by providing a key, as the docs state:

![Bildschirmfoto_2025-04-30_18-39-59](https://github.com/user-attachments/assets/7d10c9ac-f1f1-4528-ad48-0c0122798bbe)

And indeed, as soon as I added that, the swipe to works perfectly, even if I sent new messages and thus cause the list view to swap items:


https://github.com/user-attachments/assets/71a60b05-f869-4287-a7c8-662e60f25aa7

Fixes #2840 .

