### PR TITLE
enable event cache

### DIFF
--- a/.changes/event-cache.md
+++ b/.changes/event-cache.md
@@ -1,0 +1,1 @@
+- We are now storing the chat events in local storage, leading to a lot faster loading of chat rooms after starting the app.

--- a/native/acter/src/api/auth.rs
+++ b/native/acter/src/api/auth.rs
@@ -21,7 +21,7 @@ use matrix_sdk_base::{
     SessionMeta,
 };
 use std::sync::RwLock;
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 use uuid::Uuid;
 
@@ -127,6 +127,9 @@ pub async fn guest_client(
     RUNTIME
         .spawn(async move {
             let client = config.build().await?;
+            if let Err(e) = client.event_cache().enable_storage() {
+                warn!("Failed to enable event cache storage: {e}");
+            }
             let request = assign!(register::v3::Request::new(), {
                 kind: register::RegistrationKind::Guest,
                 initial_device_display_name: device_name,
@@ -184,6 +187,9 @@ pub async fn login_with_token_under_config(
                 },
             };
             client.restore_session(auth_session).await?;
+            if let Err(e) = client.event_cache().enable_storage() {
+                warn!("Failed to enable event cache storage: {e}");
+            }
             let state = ClientStateBuilder::default()
                 .is_guest(is_guest)
                 .db_passphrase(db_passphrase)
@@ -239,6 +245,10 @@ async fn login_client(
         "Successfully logged in user {user_id}, device {:?}",
         client.device_id(),
     );
+
+    if let Err(e) = client.event_cache().enable_storage() {
+        warn!("Failed to enable event cache storage: {e}");
+    }
     Client::new(client.clone(), state).await
 }
 


### PR DESCRIPTION
Turns out, when the rust team changed to the new externalised event-object, it made that a opt-in-feature, meaning we have to actually activate it for the events to be stored (weird, considering that we have an `EventStore`, I know, but whatever). Anyhow, look what enabling this means:

First we go into that chat for the first time after starting up, being already logged in and all. Then I restart the instance and when it comes back and we enter _boom_, right there, no loading \o/ .


https://github.com/user-attachments/assets/3898ade5-fdc4-4034-a83a-9ebb8ea6f473

Fixes https://github.com/acterglobal/a3-meta/issues/914, https://github.com/acterglobal/a3-meta/issues/895

