### PR TITLE
Preload activities data

### DIFF
--- a/.changes/preloading.md
+++ b/.changes/preloading.md
@@ -1,0 +1,1 @@
+- We are loading the activities a lot faster now.

--- a/app/lib/features/activities/providers/activities_providers.dart
+++ b/app/lib/features/activities/providers/activities_providers.dart
@@ -39,7 +39,7 @@ final supportedActivityTypes = [
   PushStyles.kickedAndBanned,
   PushStyles.knocked,
   PushStyles.banned,
-  PushStyles.unbanned
+  PushStyles.unbanned,
 ];
 
 final hasActivitiesProvider = StateProvider((ref) {
@@ -184,3 +184,20 @@ final spaceActivitiesProviderByDate =
         return activityDateOnly.isAtSameMomentAs(params.date);
       }).toList();
     });
+
+final activitiesPreloader = FutureProvider<void>((ref) async {
+  final dates = await ref.watch(activityDatesProvider.future);
+  if (dates.isNotEmpty) {
+    final firstDate = dates.first;
+    // nothing to preload
+    final roomIds = await ref.watch(roomIdsByDateProvider(firstDate).future);
+    if (roomIds.isNotEmpty) {
+      await ref.watch(
+        spaceActivitiesProviderByDate((
+          roomId: roomIds.first,
+          date: firstDate,
+        )).future,
+      );
+    }
+  }
+});

--- a/app/lib/features/main/app_shell.dart
+++ b/app/lib/features/main/app_shell.dart
@@ -40,7 +40,7 @@ final _log = Logger('a3::config::home_shell');
 final ScreenshotController screenshotController = ScreenshotController();
 
 class _TopLevelShell extends ConsumerWidget {
-  const _TopLevelShell({super.key});
+  const _TopLevelShell();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
So that both link opening preference and activities load faster, right after startup:


https://github.com/user-attachments/assets/322009e3-8872-4be7-bb8f-3dfb9603f9a2

