### PR TITLE
[smallfix] Update l10n for activity about room state change

### DIFF
--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomAvatar.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomAvatar.dart
@@ -1,24 +1,72 @@
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_space_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_avatar/acter_avatar.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('a3::activities::widgets::room_avatar_change');
+
 class ActivityRoomAvatarItemWidget extends ConsumerWidget {
   final Activity activity;
+
   const ActivityRoomAvatarItemWidget({super.key, required this.activity});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final lang = L10n.of(context);
+
+    final roomId = activity.roomIdStr();
+    final senderId = activity.senderIdStr();
+    final myId = ref.watch(myUserIdStrProvider);
+    final firstName =
+        ref
+            .watch(
+              memberDisplayNameProvider((roomId: roomId, userId: senderId)),
+            )
+            .valueOrNull;
+    final senderName = firstName ?? simplifyUserId(senderId) ?? senderId;
+
+    final stateMsg = getMessage(lang, myId == senderId, senderName);
+
     final avatarInfo = ref.watch(roomAvatarInfoProvider(activity.roomIdStr()));
-     final memberInfo = ref.watch(
-      memberAvatarInfoProvider((roomId: activity.roomIdStr(), userId: activity.senderIdStr())),
-    );
     return ActivitySpaceProfileChangeContainerWidget(
       leadingWidget: ActerAvatar(options: AvatarOptions(avatarInfo, size: 50)),
-      titleText: L10n.of(context).spaceAvatarUpdate(memberInfo.displayName ?? activity.senderIdStr()),
+      titleText: stateMsg ?? '',
       originServerTs: activity.originServerTs(),
     );
+  }
+
+  String? getMessage(L10n lang, bool isMe, String senderName) {
+    final content = activity.roomAvatarContent();
+    if (content == null) {
+      _log.severe('failed to get content of room avatar change');
+      return null;
+    }
+    switch (content.urlChange()) {
+      case 'Changed':
+        if (isMe) {
+          return lang.roomStateRoomAvatarUrlYouChanged;
+        } else {
+          return lang.roomStateRoomAvatarUrlOtherChanged(senderName);
+        }
+      case 'Set':
+        if (isMe) {
+          return lang.roomStateRoomAvatarUrlYouSet;
+        } else {
+          return lang.roomStateRoomAvatarUrlOtherSet(senderName);
+        }
+      case 'Unset':
+        if (isMe) {
+          return lang.roomStateRoomAvatarUrlYouUnset;
+        } else {
+          return lang.roomStateRoomAvatarUrlOtherUnset(senderName);
+        }
+    }
+    return null;
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
@@ -45,7 +45,7 @@ class ActivityRoomNameItemWidget extends ConsumerWidget {
   String? getMessage(L10n lang, bool isMe, String senderName) {
     final content = activity.roomNameContent();
     if (content == null) {
-      _log.severe('failed to get content of room avatar change');
+      _log.severe('failed to get content of room name change');
       return null;
     }
     switch (content.change()) {

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
@@ -1,31 +1,80 @@
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_space_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+final _log = Logger('a3::activities::widgets::room_name_change');
 
 class ActivityRoomNameItemWidget extends ConsumerWidget {
   final Activity activity;
+
   const ActivityRoomNameItemWidget({super.key, required this.activity});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { 
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lang = L10n.of(context);
+
+    final roomId = activity.roomIdStr();
+    final senderId = activity.senderIdStr();
+    final myId = ref.watch(myUserIdStrProvider);
+    final firstName =
+        ref
+            .watch(
+              memberDisplayNameProvider((roomId: roomId, userId: senderId)),
+            )
+            .valueOrNull;
+    final senderName = firstName ?? simplifyUserId(senderId) ?? senderId;
+
+    final stateMsg = getMessage(lang, myId == senderId, senderName);
+
     final subTitle = activity.roomName() ?? '';
-     final memberInfo = ref.watch(
-      memberAvatarInfoProvider((roomId: activity.roomIdStr(), userId: activity.senderIdStr())),
-    );
     return ActivitySpaceProfileChangeContainerWidget(
-      leadingWidget: Icon(PhosphorIconsRegular.pencilSimpleLine, size: 40),   
-      titleText: L10n.of(context).spaceNameUpdate(memberInfo.displayName ?? activity.senderIdStr()),  
-      subtitleWidget: Text( 
-        subTitle, 
-        style: Theme.of(context).textTheme.labelMedium,  
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,  
-      ), 
+      leadingWidget: Icon(PhosphorIconsRegular.pencilSimpleLine, size: 40),
+      titleText: stateMsg ?? '',
+      subtitleWidget: getSubtitle(context, subTitle),
       originServerTs: activity.originServerTs(),
-    );  
+    );
+  }
+
+  String? getMessage(L10n lang, bool isMe, String senderName) {
+    final content = activity.roomNameContent();
+    if (content == null) {
+      _log.severe('failed to get content of room avatar change');
+      return null;
+    }
+    switch (content.change()) {
+      case 'Changed':
+        final newVal = content.newVal();
+        final oldVal = content.oldVal() ?? '';
+        if (isMe) {
+          return lang.roomStateRoomNameYouChanged(newVal, oldVal);
+        } else {
+          return lang.roomStateRoomNameOtherChanged(senderName, newVal, oldVal);
+        }
+      case 'Set':
+        final newVal = content.newVal();
+        if (isMe) {
+          return lang.roomStateRoomNameYouSet(newVal);
+        } else {
+          return lang.roomStateRoomNameOtherSet(senderName, newVal);
+        }
+    }
+    return null;
+  }
+
+  Widget? getSubtitle(BuildContext context, String? stateMsg) {
+    if (stateMsg == null) return null;
+    return Text(
+      stateMsg,
+      style: Theme.of(context).textTheme.labelMedium,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
@@ -1,31 +1,80 @@
+import 'package:acter/common/providers/common_providers.dart';
 import 'package:acter/common/providers/room_providers.dart';
+import 'package:acter/common/utils/utils.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_space_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+final _log = Logger('a3::activities::widgets::room_topic_change');
 
 class ActivityRoomTopicItemWidget extends ConsumerWidget {
   final Activity activity;
+
   const ActivityRoomTopicItemWidget({super.key, required this.activity});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-   final subTitle = activity.roomTopic() ?? '';
-    final memberInfo = ref.watch(
-      memberAvatarInfoProvider((roomId: activity.roomIdStr(), userId: activity.senderIdStr())),
-    );
+    final lang = L10n.of(context);
+
+    final roomId = activity.roomIdStr();
+    final senderId = activity.senderIdStr();
+    final myId = ref.watch(myUserIdStrProvider);
+    final firstName =
+        ref
+            .watch(
+              memberDisplayNameProvider((roomId: roomId, userId: senderId)),
+            )
+            .valueOrNull;
+    final senderName = firstName ?? simplifyUserId(senderId) ?? senderId;
+
+    final stateMsg = getMessage(lang, myId == senderId, senderName);
+
+    final subTitle = activity.roomTopic() ?? '';
     return ActivitySpaceProfileChangeContainerWidget(
       leadingWidget: Icon(PhosphorIconsRegular.pencilSimpleLine, size: 40),
-      titleText: L10n.of(context).spaceDescriptionUpdate(memberInfo.displayName ?? activity.senderIdStr()), 
-      subtitleWidget: Text(
-        subTitle,
-        style: Theme.of(context).textTheme.labelMedium,
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-      ),
+      titleText: stateMsg ?? '',
+      subtitleWidget: getSubtitle(context, subTitle),
       originServerTs: activity.originServerTs(),
+    );
+  }
+
+  String? getMessage(L10n lang, bool isMe, String senderName) {
+    final content = activity.roomNameContent();
+    if (content == null) {
+      _log.severe('failed to get content of room avatar change');
+      return null;
+    }
+    switch (content.change()) {
+      case 'Changed':
+        final newVal = content.newVal();
+        final oldVal = content.oldVal() ?? '';
+        if (isMe) {
+          return lang.roomStateRoomNameYouChanged(newVal, oldVal);
+        } else {
+          return lang.roomStateRoomNameOtherChanged(senderName, newVal, oldVal);
+        }
+      case 'Set':
+        final newVal = content.newVal();
+        if (isMe) {
+          return lang.roomStateRoomNameYouSet(newVal);
+        } else {
+          return lang.roomStateRoomNameOtherSet(senderName, newVal);
+        }
+    }
+    return null;
+  }
+
+  Widget? getSubtitle(BuildContext context, String? stateMsg) {
+    if (stateMsg == null) return null;
+    return Text(
+      stateMsg,
+      style: Theme.of(context).textTheme.labelMedium,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
     );
   }
 }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
@@ -43,9 +43,9 @@ class ActivityRoomTopicItemWidget extends ConsumerWidget {
   }
 
   String? getMessage(L10n lang, bool isMe, String senderName) {
-    final content = activity.roomNameContent();
+    final content = activity.roomTopicContent();
     if (content == null) {
-      _log.severe('failed to get content of room avatar change');
+      _log.severe('failed to get content of room topic change');
       return null;
     }
     switch (content.change()) {

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
@@ -53,16 +53,20 @@ class ActivityRoomTopicItemWidget extends ConsumerWidget {
         final newVal = content.newVal();
         final oldVal = content.oldVal() ?? '';
         if (isMe) {
-          return lang.roomStateRoomNameYouChanged(newVal, oldVal);
+          return lang.roomStateRoomTopicYouChanged(newVal, oldVal);
         } else {
-          return lang.roomStateRoomNameOtherChanged(senderName, newVal, oldVal);
+          return lang.roomStateRoomTopicOtherChanged(
+            senderName,
+            newVal,
+            oldVal,
+          );
         }
       case 'Set':
         final newVal = content.newVal();
         if (isMe) {
-          return lang.roomStateRoomNameYouSet(newVal);
+          return lang.roomStateRoomTopicYouSet(newVal);
         } else {
-          return lang.roomStateRoomNameOtherSet(senderName, newVal);
+          return lang.roomStateRoomTopicOtherSet(senderName, newVal);
         }
     }
     return null;

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2462,8 +2462,6 @@
   "@spacesLoadingError": {},
   "spaceDescriptionUpdate": "{username} aktualisierte Raumbeschreibung",
   "@spaceDescriptionUpdate": {},
-  "spaceNameUpdate": "{username} hat den Spacenamen geändert",
-  "@spaceNameUpdate": {},
   "chatMembershipOtherBannedOther": "{senderId} hat {userId} verbannt.",
   "@chatMembershipOtherBannedOther": {},
   "chatMembershipOtherBannedYou": "{senderId} hat dich verbannt.",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2464,8 +2464,6 @@
   "@spaceDescriptionUpdate": {},
   "spaceNameUpdate": "{username} hat den Spacenamen geändert",
   "@spaceNameUpdate": {},
-  "spaceAvatarUpdate": "{username} aktualisierter Raum-Avatar",
-  "@spaceAvatarUpdate": {},
   "chatMembershipOtherBannedOther": "{senderId} hat {userId} verbannt.",
   "@chatMembershipOtherBannedOther": {},
   "chatMembershipOtherBannedYou": "{senderId} hat dich verbannt.",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2460,8 +2460,6 @@
   "@analyticsMoreDetails": {},
   "spacesLoadingError": "Laden der verbundenen Spaces & Chats fehlgeschlagen",
   "@spacesLoadingError": {},
-  "spaceDescriptionUpdate": "{username} aktualisierte Raumbeschreibung",
-  "@spaceDescriptionUpdate": {},
   "chatMembershipOtherBannedOther": "{senderId} hat {userId} verbannt.",
   "@chatMembershipOtherBannedOther": {},
   "chatMembershipOtherBannedYou": "{senderId} hat dich verbannt.",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2862,8 +2862,6 @@
   "@userHasNotAllowed": {},
   "calendarSyncDesc": "Acter can sync Events you are invited to or agreed to go to directly to your device Calendar for your convenience. Events you declined will not show there.",
   "@calendarSyncDesc": {},
-  "spaceNameUpdate": "{username} updated space name",
-  "@spaceNameUpdate": {},
   "spaceDescriptionUpdate": "{username}  updated space description",
   "@spaceDescriptionUpdate": {},
   "desktopSetup": "Desktop Setup",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2866,8 +2866,6 @@
   "@spaceNameUpdate": {},
   "spaceDescriptionUpdate": "{username}  updated space description",
   "@spaceDescriptionUpdate": {},
-  "spaceAvatarUpdate": "{username}  updated space avatar",
-  "@spaceAvatarUpdate": {},
   "desktopSetup": "Desktop Setup",
   "@desktopSetup": {},
   "desktopSetupInfo": "When you close the Acter Window, Acter won't directly exit the program but minimize to the system tray to keep listening for notifications for you. If you want to exit Acter you need to do that from the system tray.",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2862,8 +2862,6 @@
   "@userHasNotAllowed": {},
   "calendarSyncDesc": "Acter can sync Events you are invited to or agreed to go to directly to your device Calendar for your convenience. Events you declined will not show there.",
   "@calendarSyncDesc": {},
-  "spaceDescriptionUpdate": "{username}  updated space description",
-  "@spaceDescriptionUpdate": {},
   "desktopSetup": "Desktop Setup",
   "@desktopSetup": {},
   "desktopSetupInfo": "When you close the Acter Window, Acter won't directly exit the program but minimize to the system tray to keep listening for notifications for you. If you want to exit Acter you need to do that from the system tray.",

--- a/app/test/features/activity/item_widgets/activity_space_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_space_item_widget_test.dart
@@ -28,7 +28,7 @@ void main() {
     await tester.pump();
 
     // Verify the change text is displayed
-    expect(find.textContaining('updated space name'), findsOneWidget);
+    expect(find.textContaining('changed the room name'), findsOneWidget);
 
     // Verify icon is present
     expect(find.byIcon(PhosphorIconsRegular.pencilSimpleLine), findsOneWidget);
@@ -36,7 +36,7 @@ void main() {
 
   testWidgets('Room topic update', (tester) async {
     MockActivity mockActivity = MockActivity(
-      mockType: PushStyles.roomName.name,
+      mockType: PushStyles.roomTopic.name,
       mockRoomId: 'room-id',
       mockSenderId: 'sender-id',
       mockObject: MockActivityObject(mockType: 'roomTopic'),
@@ -51,7 +51,7 @@ void main() {
     await tester.pump();
 
     // Verify the change text is displayed
-    expect(find.textContaining('updated space description'), findsOneWidget);
+    expect(find.textContaining('changed the room topic'), findsOneWidget);
 
     // Verify icon is present
     expect(find.byIcon(PhosphorIconsRegular.pencilSimpleLine), findsOneWidget);
@@ -59,7 +59,7 @@ void main() {
 
   testWidgets('Room avatar update', (tester) async {
     MockActivity mockActivity = MockActivity(
-      mockType: PushStyles.roomName.name,
+      mockType: PushStyles.roomAvatar.name,
       mockRoomId: 'room-id',
       mockSenderId: 'sender-id',
       mockObject: MockActivityObject(mockType: 'roomAvatar'),
@@ -75,6 +75,6 @@ void main() {
     // Verify the avatar is displayed
     expect(find.byType(ActerAvatar), findsOneWidget);
     // Verify the change text is displayed
-    expect(find.textContaining('updated space avatar'), findsOneWidget);
+    expect(find.textContaining('changed the room avatar url'), findsOneWidget);
   });
 }

--- a/app/test/features/activity/item_widgets/activity_space_item_widget_test.dart
+++ b/app/test/features/activity/item_widgets/activity_space_item_widget_test.dart
@@ -9,6 +9,9 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../../../helpers/test_util.dart';
 import '../mock_data/mock_activity.dart';
 import '../mock_data/mock_activity_object.dart';
+import '../mock_data/mock_room_avatar_change.dart';
+import '../mock_data/mock_room_name_change.dart';
+import '../mock_data/mock_room_topic_change.dart';
 
 void main() {
   testWidgets('Room name update', (tester) async {
@@ -17,6 +20,7 @@ void main() {
       mockRoomId: 'room-id',
       mockSenderId: 'sender-id',
       mockObject: MockActivityObject(mockType: 'roomName'),
+      mockRoomNameContent: MockRoomNameContent(mockNewVal: 'mock-new-val'),
     );
 
     await tester.pumpProviderWidget(
@@ -40,6 +44,7 @@ void main() {
       mockRoomId: 'room-id',
       mockSenderId: 'sender-id',
       mockObject: MockActivityObject(mockType: 'roomTopic'),
+      mockRoomTopicContent: MockRoomTopicContent(mockNewVal: 'mock-new-val'),
     );
 
     await tester.pumpProviderWidget(
@@ -63,6 +68,7 @@ void main() {
       mockRoomId: 'room-id',
       mockSenderId: 'sender-id',
       mockObject: MockActivityObject(mockType: 'roomAvatar'),
+      mockRoomAvatarContent: MockRoomAvatarContent(),
     );
 
     await tester.pumpProviderWidget(

--- a/app/test/features/activity/mock_data/mock_activity.dart
+++ b/app/test/features/activity/mock_data/mock_activity.dart
@@ -11,6 +11,9 @@ class MockActivity extends Mock implements Activity {
   final ActivityObject? mockObject;
   final MsgContent? mockMsgContent;
   final MembershipContent? mockMembershipContent;
+  final RoomAvatarContent? mockRoomAvatarContent;
+  final RoomNameContent? mockRoomNameContent;
+  final RoomTopicContent? mockRoomTopicContent;
   final int? mockOriginServerTs;
   final RefDetails? mockRefDetails;
 
@@ -24,6 +27,9 @@ class MockActivity extends Mock implements Activity {
     this.mockObject,
     this.mockMsgContent,
     this.mockMembershipContent,
+    this.mockRoomAvatarContent,
+    this.mockRoomNameContent,
+    this.mockRoomTopicContent,
     this.mockOriginServerTs,
     this.mockRefDetails,
   });
@@ -60,4 +66,13 @@ class MockActivity extends Mock implements Activity {
 
   @override
   MembershipContent? membershipContent() => mockMembershipContent;
+
+  @override
+  RoomAvatarContent? roomAvatarContent() => mockRoomAvatarContent;
+
+  @override
+  RoomNameContent? roomNameContent() => mockRoomNameContent;
+
+  @override
+  RoomTopicContent? roomTopicContent() => mockRoomTopicContent;
 }

--- a/app/test/features/activity/mock_data/mock_membership_change.dart
+++ b/app/test/features/activity/mock_data/mock_membership_change.dart
@@ -6,13 +6,10 @@ class MockMembershipContent extends Mock implements MembershipContent {
   final String? mockUserId;
   final String? mockChange;
 
-  MockMembershipContent({
-    this.mockUserId,
-    this.mockChange,
-  });
+  MockMembershipContent({this.mockUserId, this.mockChange});
 
   @override
-  String change() => mockChange ?? 'mock-change';
+  String change() => mockChange ?? 'joined';
 
   @override
   UserId userId() => MockUserId(mockUserId ?? 'mock-user-id');

--- a/app/test/features/activity/mock_data/mock_room_avatar_change.dart
+++ b/app/test/features/activity/mock_data/mock_room_avatar_change.dart
@@ -1,0 +1,23 @@
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockRoomAvatarContent extends Mock implements RoomAvatarContent {
+  final String? mockUrlChange;
+  final String? mockUrlNewVal;
+  final String? mockUrlOldVal;
+
+  MockRoomAvatarContent({
+    this.mockUrlChange,
+    this.mockUrlNewVal,
+    this.mockUrlOldVal,
+  });
+
+  @override
+  String? urlChange() => mockUrlChange ?? 'Changed';
+
+  @override
+  String? urlNewVal() => mockUrlNewVal ?? 'mock-url-new-val';
+
+  @override
+  String? urlOldVal() => mockUrlOldVal ?? 'mock-url-old-val';
+}

--- a/app/test/features/activity/mock_data/mock_room_name_change.dart
+++ b/app/test/features/activity/mock_data/mock_room_name_change.dart
@@ -1,0 +1,23 @@
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockRoomNameContent extends Mock implements RoomNameContent {
+  final String? mockChange;
+  final String mockNewVal;
+  final String? mockOldVal;
+
+  MockRoomNameContent({
+    this.mockChange,
+    required this.mockNewVal,
+    this.mockOldVal,
+  });
+
+  @override
+  String? change() => mockChange ?? 'Changed';
+
+  @override
+  String newVal() => mockNewVal;
+
+  @override
+  String? oldVal() => mockOldVal ?? 'mock-old-val';
+}

--- a/app/test/features/activity/mock_data/mock_room_topic_change.dart
+++ b/app/test/features/activity/mock_data/mock_room_topic_change.dart
@@ -1,0 +1,23 @@
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockRoomTopicContent extends Mock implements RoomTopicContent {
+  final String? mockChange;
+  final String mockNewVal;
+  final String? mockOldVal;
+
+  MockRoomTopicContent({
+    this.mockChange,
+    required this.mockNewVal,
+    this.mockOldVal,
+  });
+
+  @override
+  String? change() => mockChange ?? 'Changed';
+
+  @override
+  String newVal() => mockNewVal;
+
+  @override
+  String? oldVal() => mockOldVal ?? 'mock-old-val';
+}


### PR DESCRIPTION
We will use [the already defined translations](https://github.com/acterglobal/a3/pull/2903) for room state change events.

- Update l10n for activity of room avatar change
- Update l10n for activity of room name change
- Update l10n for activity of room topic change
- Fix bug that activity test doesn't work about above events