### PR TITLE
Improve sentry logging

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -474,4 +474,5 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_RELEASE: ${{ inputs.version }}
+          SENTRY_ENVIRONMENT: ${{ inputs.release_env }}
         run: flutter packages pub run sentry_dart_plugin

--- a/app/lib/features/labs/providers/labs_providers.dart
+++ b/app/lib/features/labs/providers/labs_providers.dart
@@ -15,7 +15,7 @@ final asyncFeaturesProvider = FutureProvider<Features<LabsFeature>>((
   final currentData = prefInstance.getString(labsKey) ?? '[]';
   final features = featureFlagsFromJson<LabsFeature>(
     json.decode(currentData),
-    (name) => LabsFeature.values.byName(name),
+    (name) => LabsFeature.values.asNameMap()[name],
     throwOnMissing: false, // we want to ignore missing features
   );
   return Features<LabsFeature>(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:video_player_media_kit/video_player_media_kit.dart';
+import 'package:sentry_logging/sentry_logging.dart';
 
 void main(List<String> args) async {
   configSetup();
@@ -102,6 +103,7 @@ Future<void> _startAppInner(Widget app, bool withAnalytics) async {
       options.dsn = Env.sentryDsn;
       options.environment = Env.sentryEnvironment;
       options.release = Env.sentryRelease;
+      options.addIntegration(LoggingIntegration());
 
       // allows us to check whether the user has activated tracing
       // and prevent reporting otherwise.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2289,6 +2289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.14.2"
+  sentry_logging:
+    dependency: "direct main"
+    description:
+      name: sentry_logging
+      sha256: "16b54d77819193bc7e268461eda399ec4c566e20b73864847849508fa867e8ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
   settings_ui:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -172,6 +172,7 @@ dependencies:
   launch_at_startup: ^0.5.1
   package_info_plus: ^8.3.0
   matomo_tracker: ^6.0.0
+  sentry_logging: ^8.14.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
nothing was really wrong, needed an update of the self-hosted instance it seems, but this improves the situation somewhat by:

- [x] adding sentry logging for automatic logging of all `log.severe`
- [x] passing of the release env when uploading the debug bindings (nightlies are considered releases at the moment it from the backend)
- [x] clear an unnecessary `log.severe` by the labs features.  