### PR TITLE
Update dependency to fix compilation error from github ci

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1706,12 +1706,11 @@ packages:
   open_filex:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "7ec56421afc37bb2cc3cb751b9775999cd2d9a61"
-      resolved-ref: "7ec56421afc37bb2cc3cb751b9775999cd2d9a61"
-      url: "https://github.com/mufassalhussain/open_filex"
-    source: git
-    version: "4.6.0"
+      name: open_filex
+      sha256: "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   package_config:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -143,11 +143,7 @@ dependencies:
 
   shake_detector:
     path: ../packages/shake_detector
-#  open_filex: ^4.6.0
-  open_filex:
-    git:
-     url: https://github.com/mufassalhussain/open_filex
-     ref: 7ec56421afc37bb2cc3cb751b9775999cd2d9a61
+  open_filex: ^4.7.0
   phosphor_flutter: ^2.1.0
   device_calendar: #^4.3.3-20240801
     git:


### PR DESCRIPTION
Will fix compilation error due to disappearing of forked `open_filex` from mufassalhussain.
Now other PRs are blocked due to this CI error.
```
Git error. Command: `git clone --mirror https://github.com/mufassalhussain/open_filex /home/runner/.pub-cache/_temp/dirMAQJJR`
```