### PR TITLE
Chat-NG : Fixes short message overlay is unreachable

### DIFF
--- a/app/lib/features/chat_ng/dialogs/message_actions.dart
+++ b/app/lib/features/chat_ng/dialogs/message_actions.dart
@@ -39,6 +39,7 @@ void messageActions({
           Positioned(
             left: messagePosition.dx,
             top: 0,
+            width: messageBox.size.width,
             height: MediaQuery.sizeOf(context).height,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/2993 by bringing older code back.


https://github.com/user-attachments/assets/7fc396e9-2975-4207-9ef4-f1668710b726

But it leads to re-open issue https://github.com/acterglobal/a3/issues/2980