### PR TITLE
auto-expanding inner HTML editor

### DIFF
--- a/.changes/meta-901-fix.md
+++ b/.changes/meta-901-fix.md
@@ -1,0 +1,1 @@
+- Fix: chat editor sometimes not appearing on some devices

--- a/app/lib/common/widgets/html_editor/html_editor.dart
+++ b/app/lib/common/widgets/html_editor/html_editor.dart
@@ -9,7 +9,6 @@ import 'package:acter/common/widgets/html_editor/models/mention_attributes.dart'
 import 'package:acter/common/widgets/html_editor/models/mention_type.dart';
 import 'package:acter/common/widgets/html_editor/services/constants.dart';
 import 'package:acter/common/widgets/html_editor/services/mention_shortcuts.dart';
-import 'package:acter/features/chat_ng/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' show MsgContent;
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:collection/collection.dart';
@@ -324,19 +323,6 @@ class _HtmlEditorState extends State<HtmlEditor> {
 
     updateEditorState(widget.editorState ?? EditorState.blank());
   }
-
-  // int _getActualLineCount(String text) {
-  //   //Considering 50 is the width of the emoji picker and send button
-  //   final editorWidth = MediaQuery.sizeOf(context).width - 50;
-
-  //   final textStyle = Theme.of(context).textTheme.bodyLarge;
-  //   final textPainter = TextPainter(
-  //     text: TextSpan(text: text, style: textStyle),
-  //     textDirection: TextDirection.ltr,
-  //   )..layout(maxWidth: editorWidth);
-  //   // Get the number of lines the text actually occupies
-  //   return textPainter.computeLineMetrics().length;
-  // }
 
   void _updateContentHeight() {
     final scrollService = editorState.scrollableState;

--- a/app/lib/common/widgets/html_editor/html_editor.dart
+++ b/app/lib/common/widgets/html_editor/html_editor.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:acter/common/extensions/options.dart';
 import 'package:acter/common/toolkit/buttons/primary_action_button.dart';
@@ -8,6 +9,7 @@ import 'package:acter/common/widgets/html_editor/models/mention_attributes.dart'
 import 'package:acter/common/widgets/html_editor/models/mention_type.dart';
 import 'package:acter/common/widgets/html_editor/services/constants.dart';
 import 'package:acter/common/widgets/html_editor/services/mention_shortcuts.dart';
+import 'package:acter/features/chat_ng/utils.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart' show MsgContent;
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:collection/collection.dart';
@@ -264,11 +266,12 @@ class HtmlEditor extends StatefulWidget {
   final String? hintText;
   final Widget? header;
   final Widget? footer;
+  final double? minHeight;
+  final double? maxHeight;
   final bool editable;
   final bool shrinkWrap;
   final bool disableAutoScroll;
   final EditorState? editorState;
-  final EditorScrollController? scrollController;
   final TextStyleConfiguration? textStyleConfiguration;
   final ExportCallback? onSave;
   final ExportCallback? onChanged;
@@ -286,18 +289,24 @@ class HtmlEditor extends StatefulWidget {
     this.editable = false,
     this.shrinkWrap = false,
     this.disableAutoScroll = false,
-    this.scrollController,
     this.header,
     this.footer,
+    this.minHeight,
+    this.maxHeight,
   });
 
   @override
-  HtmlEditorState createState() => HtmlEditorState();
+  State<HtmlEditor> createState() => _HtmlEditorState();
 }
 
-class HtmlEditorState extends State<HtmlEditor> {
+const innnerMargin = 4.0;
+const defaultMinHeight = 40.0;
+
+class _HtmlEditorState extends State<HtmlEditor> {
   late EditorState editorState;
   late EditorScrollController editorScrollController;
+
+  late ValueNotifier<double> _contentHeightNotifier;
 
   // we store this to the stream stays alive
   StreamSubscription<EditorTransactionValue>? _changeListener;
@@ -305,34 +314,83 @@ class HtmlEditorState extends State<HtmlEditor> {
   @override
   void initState() {
     super.initState();
-    updateEditorState(widget.editorState ?? EditorState.blank());
+    _contentHeightNotifier = ValueNotifier(
+      widget.minHeight ?? defaultMinHeight,
+    );
     AppFlowyRichTextKeys.partialSliced.addAll([
       userMentionChar,
       roomMentionChar,
     ]);
+
+    updateEditorState(widget.editorState ?? EditorState.blank());
+  }
+
+  // int _getActualLineCount(String text) {
+  //   //Considering 50 is the width of the emoji picker and send button
+  //   final editorWidth = MediaQuery.sizeOf(context).width - 50;
+
+  //   final textStyle = Theme.of(context).textTheme.bodyLarge;
+  //   final textPainter = TextPainter(
+  //     text: TextSpan(text: text, style: textStyle),
+  //     textDirection: TextDirection.ltr,
+  //   )..layout(maxWidth: editorWidth);
+  //   // Get the number of lines the text actually occupies
+  //   return textPainter.computeLineMetrics().length;
+  // }
+
+  void _updateContentHeight() {
+    final scrollService = editorState.scrollableState;
+    final innerHeight = scrollService?.position.maxScrollExtent;
+    if (innerHeight == null || innerHeight <= 0) {
+      final minHeight = widget.minHeight;
+      if (minHeight != null) {
+        _contentHeightNotifier.value = minHeight;
+      }
+      return;
+    }
+
+    double newHeight =
+        innerHeight +
+        (scrollService?.position.viewportDimension ?? 0) +
+        innnerMargin;
+
+    final maxHeight = widget.maxHeight;
+    if (maxHeight != null) {
+      newHeight = min(newHeight, maxHeight);
+    }
+    final minHeight = widget.minHeight;
+    if (minHeight != null) {
+      newHeight = max(newHeight, minHeight);
+    }
+    if (_contentHeightNotifier.value != newHeight) {
+      _contentHeightNotifier.value = newHeight;
+    }
   }
 
   void updateEditorState(EditorState newEditorState) {
-    setState(() {
-      editorState = newEditorState;
+    editorState = newEditorState;
 
-      editorScrollController = EditorScrollController(
-        editorState: editorState,
-        shrinkWrap: widget.shrinkWrap,
+    editorScrollController = EditorScrollController(
+      editorState: editorState,
+      shrinkWrap: widget.shrinkWrap,
+      // scrollController: widget.scrollController,
+    );
+
+    editorScrollController.visibleRangeNotifier.addListener(() {
+      _updateContentHeight();
+    });
+
+    _changeListener?.cancel();
+    widget.onChanged.map((cb) {
+      _changeListener = editorState.transactionStream.listen(
+        (data) => _triggerExport(cb),
+        onError: (e, s) {
+          _log.severe('tx stream errored', e, s);
+        },
+        onDone: () {
+          _log.info('tx stream ended');
+        },
       );
-
-      _changeListener?.cancel();
-      widget.onChanged.map((cb) {
-        _changeListener = editorState.transactionStream.listen(
-          (data) => _triggerExport(cb),
-          onError: (e, s) {
-            _log.severe('tx stream errored', e, s);
-          },
-          onDone: () {
-            _log.info('tx stream ended');
-          },
-        );
-      });
     });
   }
 
@@ -347,9 +405,6 @@ class HtmlEditorState extends State<HtmlEditor> {
   @override
   void dispose() {
     editorState.selectionNotifier.dispose();
-    if (widget.scrollController == null) {
-      editorScrollController.dispose();
-    }
     _changeListener?.cancel();
     super.dispose();
   }
@@ -426,47 +481,28 @@ class HtmlEditorState extends State<HtmlEditor> {
     return null;
   }
 
-  Widget desktopEditor(String? roomId) {
-    return FloatingToolbar(
-      items: [
-        paragraphItem,
-        ...headingItems,
-        ...markdownFormatItems,
-        quoteItem,
-        bulletedListItem,
-        numberedListItem,
-        linkItem,
-      ],
+  Widget desktopEditor(String? roomId) => FloatingToolbar(
+    items: [
+      paragraphItem,
+      ...headingItems,
+      ...markdownFormatItems,
+      quoteItem,
+      bulletedListItem,
+      numberedListItem,
+      linkItem,
+    ],
+    textDirection: Directionality.of(context),
+    editorState: editorState,
+    editorScrollController: editorScrollController,
+    style: FloatingToolbarStyle(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      toolbarActiveColor: Theme.of(context).colorScheme.tertiary,
+    ),
+    child: Directionality(
       textDirection: Directionality.of(context),
-      editorState: editorState,
-      editorScrollController: editorScrollController,
-      style: FloatingToolbarStyle(
-        backgroundColor: Theme.of(context).colorScheme.surface,
-        toolbarActiveColor: Theme.of(context).colorScheme.tertiary,
-      ),
-      child: Directionality(
-        textDirection: Directionality.of(context),
-        child: AppFlowyEditor(
-          // widget pass through
-          editable: widget.editable,
-          shrinkWrap: widget.shrinkWrap,
-          autoFocus: true,
-          header: widget.header,
-          // local states
-          editorScrollController:
-              widget.scrollController ?? editorScrollController,
-          editorState: editorState,
-          editorStyle: desktopEditorStyle(),
-          footer: generateFooter(),
-          blockComponentBuilders: _buildBlockComponentBuilders(),
-          characterShortcutEvents: _buildCharacterShortcutEvents(),
-          commandShortcutEvents: standardCommandShortcutEvents,
-          disableAutoScroll: widget.disableAutoScroll,
-          autoScrollEdgeOffset: 20,
-        ),
-      ),
-    );
-  }
+      child: _editor(editorStyle: desktopEditorStyle(), autoFocus: true),
+    ),
+  );
 
   Widget mobileEditor(String? roomId) {
     return MobileToolbarV2(
@@ -488,7 +524,7 @@ class HtmlEditorState extends State<HtmlEditor> {
         quoteMobileToolbarItem,
         codeMobileToolbarItem,
       ],
-      toolbarHeight: 50,
+      toolbarHeight: 40,
       editorState: editorState,
       child: MobileFloatingToolbar(
         editorScrollController: editorScrollController,
@@ -511,25 +547,43 @@ class HtmlEditorState extends State<HtmlEditor> {
             anchors: TextSelectionToolbarAnchors(primaryAnchor: anchor),
           );
         },
-        child: AppFlowyEditor(
-          // widget pass through
-          editable: widget.editable,
-          shrinkWrap: widget.shrinkWrap,
-          autoFocus: false,
-          header: widget.header,
-          // local states
-          editorState: editorState,
-          editorScrollController:
-              widget.scrollController ?? editorScrollController,
-          editorStyle: mobileEditorStyle(),
-          footer: generateFooter(),
-          blockComponentBuilders: _buildBlockComponentBuilders(),
-          characterShortcutEvents: _buildCharacterShortcutEvents(),
-          commandShortcutEvents: standardCommandShortcutEvents,
-          disableAutoScroll: false,
-          autoScrollEdgeOffset: 20,
-        ),
+        child: _editor(editorStyle: mobileEditorStyle(), autoFocus: true),
       ),
+    );
+  }
+
+  Widget _editor({required EditorStyle editorStyle, required bool autoFocus}) {
+    final editor = AppFlowyEditor(
+      // widget pass through
+      editable: widget.editable,
+      shrinkWrap: widget.shrinkWrap,
+      autoFocus: autoFocus,
+      header: widget.header,
+      // local states
+      editorState: editorState,
+      editorScrollController: editorScrollController,
+      editorStyle: editorStyle,
+      footer: generateFooter(),
+      blockComponentBuilders: _buildBlockComponentBuilders(),
+      characterShortcutEvents: _buildCharacterShortcutEvents(),
+      commandShortcutEvents: standardCommandShortcutEvents,
+      disableAutoScroll: false,
+      autoScrollEdgeOffset: 20,
+    );
+
+    if (widget.maxHeight == null && widget.minHeight == null) {
+      return editor;
+    }
+
+    return ValueListenableBuilder(
+      valueListenable: _contentHeightNotifier,
+      builder:
+          (context, value, child) => AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: MediaQuery.sizeOf(context).width,
+            height: max(value, widget.minHeight ?? 50),
+            child: editor,
+          ),
     );
   }
 

--- a/app/lib/features/chat_ng/utils.dart
+++ b/app/lib/features/chat_ng/utils.dart
@@ -54,17 +54,6 @@ bool isStateEvent(String eventType) {
 bool isMemberEvent(String eventType) =>
     ['MembershipChange', 'ProfileChange'].contains(eventType);
 
-class ChatEditorUtils {
-  /// base height for the editor (single line)
-  static const double baseHeight = 56.0;
-
-  /// toolbar offset for the editor
-  static const double toolbarOffset = 50.0;
-
-  /// max height for the editor
-  static const double maxHeight = 200.0;
-}
-
 /// The Material Design accent color swatches.
 const List<MaterialAccentColor> chatBubbleDisplayNameColors =
     <MaterialAccentColor>[

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:acter/common/providers/chat_providers.dart';
-import 'package:acter/common/providers/keyboard_visbility_provider.dart';
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/utils/utils.dart';
 import 'package:acter/common/widgets/html_editor/html_editor.dart';

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -40,35 +40,23 @@ class ChatEditor extends ConsumerStatefulWidget {
 
 class _ChatEditorState extends ConsumerState<ChatEditor> {
   EditorState textEditorState = EditorState.blank();
-  late EditorScrollController scrollController;
+  // late EditorScrollController scrollController;
   StreamSubscription<EditorTransactionValue>? _updateListener;
   final ValueNotifier<bool> _isInputEmptyNotifier = ValueNotifier(true);
-  final ValueNotifier<double> _contentHeightNotifier = ValueNotifier(
-    ChatEditorUtils.baseHeight,
-  );
   Timer? _debounceTimer;
 
   @override
   void initState() {
     super.initState();
-    scrollController = EditorScrollController(editorState: textEditorState);
+    // scrollController = EditorScrollController(editorState: textEditorState);
     _updateListener?.cancel();
     // listener for editor input state
     _updateListener = textEditorState.transactionStream.listen((data) {
       _editorUpdate(data.$2);
-      _updateContentHeight();
+      // _updateContentHeight();
     });
 
     WidgetsBinding.instance.addPostFrameCallback((_) => _loadDraft());
-
-    // apply toolbar offset when keyboard is visible
-    ref.listenManual(keyboardVisibleProvider, (prev, next) {
-      if (next.valueOrNull == true) {
-        _contentHeightNotifier.value += ChatEditorUtils.toolbarOffset;
-      } else {
-        _contentHeightNotifier.value -= ChatEditorUtils.toolbarOffset;
-      }
-    });
 
     ref.listenManual(chatEditorStateProvider, (prev, next) async {
       final body = textEditorState.intoMarkdown();
@@ -97,7 +85,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
   void dispose() {
     _updateListener?.cancel();
     _debounceTimer?.cancel();
-    _contentHeightNotifier.dispose();
     super.dispose();
   }
 
@@ -132,8 +119,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
       Selection.collapsed(pos),
       reason: SelectionUpdateReason.uiEvent,
     );
-
-    _updateContentHeight();
   }
 
   void _editorUpdate(Transaction data) {
@@ -197,43 +182,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     }
   }
 
-  int _getActualLineCount(String text) {
-    //Considering 50 is the width of the emoji picker and send button
-    final editorWidth = MediaQuery.sizeOf(context).width - 50;
-
-    final textStyle = Theme.of(context).textTheme.bodyLarge;
-    final textPainter = TextPainter(
-      text: TextSpan(text: text, style: textStyle),
-      textDirection: TextDirection.ltr,
-    )..layout(maxWidth: editorWidth);
-    // Get the number of lines the text actually occupies
-    return textPainter.computeLineMetrics().length;
-  }
-
-  void _updateContentHeight() {
-    final text = textEditorState.intoMarkdown();
-    final actualLineCount = _getActualLineCount(text) - 1;
-
-    double newHeight = ChatEditorUtils.baseHeight;
-
-    if (text.isEmpty || actualLineCount < 2) {
-      newHeight = ChatEditorUtils.baseHeight;
-    } else {
-      final offset = 15 * (actualLineCount - 1);
-      newHeight = min(
-        ChatEditorUtils.maxHeight,
-        ChatEditorUtils.baseHeight + offset,
-      );
-    }
-
-    final isKeyboardVisible = ref.watch(keyboardVisibleProvider).valueOrNull;
-    if (isKeyboardVisible == true) {
-      newHeight += ChatEditorUtils.toolbarOffset;
-    }
-
-    _contentHeightNotifier.value = newHeight;
-  }
-
   @override
   Widget build(BuildContext context) {
     final emojiPickerVisible = ref.watch(
@@ -260,12 +208,7 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     return Column(
       children: <Widget>[
         if (previewWidget != null) previewWidget,
-        ValueListenableBuilder<double>(
-          valueListenable: _contentHeightNotifier,
-          builder: (context, height, _) {
-            return renderEditorUI(emojiPickerVisible, isEncrypted, height);
-          },
-        ),
+        renderEditorUI(emojiPickerVisible, isEncrypted),
 
         // Emoji Picker UI
         if (emojiPickerVisible) ChatEmojiPicker(editorState: textEditorState),
@@ -274,23 +217,13 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
   }
 
   // chat editor UI
-  Widget renderEditorUI(
-    bool emojiPickerVisible,
-    bool isEncrypted,
-    double contentHeight,
-  ) {
+  Widget renderEditorUI(bool emojiPickerVisible, bool isEncrypted) {
     final chatEditorState = ref.watch(chatEditorStateProvider);
     final isPreviewOpen =
         chatEditorState.isReplying || chatEditorState.isEditing;
     final radiusVal = isPreviewOpen ? 2.0 : 15.0;
 
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 150),
-      width: MediaQuery.sizeOf(context).width,
-      height: max(
-        contentHeight,
-        ChatEditorUtils.baseHeight,
-      ), // always stay above the base height
+    return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primaryContainer,
         borderRadius: BorderRadius.only(
@@ -317,13 +250,10 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
   }
 
   Widget editorField(bool isEncrypted) {
-    final hintText = isEncrypted.map(
-      (v) =>
-          v == true
-              ? L10n.of(context).newEncryptedMessage
-              : L10n.of(context).newMessage,
-      orElse: () => L10n.of(context).newMessage,
-    );
+    final hintText =
+        isEncrypted == true
+            ? L10n.of(context).newEncryptedMessage
+            : L10n.of(context).newMessage;
 
     return CallbackShortcuts(
       bindings: <ShortcutActivator, VoidCallback>{
@@ -341,11 +271,11 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
           LogicalKeySet(LogicalKeyboardKey.enter, LogicalKeyboardKey.shift):
               () => textEditorState.insertNewLine(),
       },
-      child: _renderEditor(hintText),
+      child: _renderEditor(context, hintText),
     );
   }
 
-  Widget _renderEditor(String? hintText) {
+  Widget _renderEditor(BuildContext context, String hintText) {
     return Padding(
       padding: const EdgeInsets.only(top: 15),
       child: HtmlEditor(
@@ -357,7 +287,9 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
         shrinkWrap: false,
         disableAutoScroll: false,
         editorState: textEditorState,
-        scrollController: scrollController,
+        // scrollController: scrollController,
+        maxHeight: MediaQuery.sizeOf(context).height * 0.5,
+        minHeight: 24,
         onChanged: (body, html) {
           final isTyping = html != null ? html.isNotEmpty : body.isNotEmpty;
           widget.onTyping?.call(isTyping);

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_loading.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_loading.dart
@@ -1,4 +1,3 @@
-import 'package:acter/common/widgets/html_editor/html_editor.dart';
 import 'package:atlas_icons/atlas_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -29,13 +28,7 @@ class ChatEditorLoading extends StatelessWidget {
                 borderRadius: BorderRadius.circular(12),
               ),
               child: const SingleChildScrollView(
-                child: IntrinsicHeight(
-                  child: HtmlEditor(
-                    footer: null,
-                    editable: true,
-                    shrinkWrap: true,
-                  ),
-                ),
+                child: IntrinsicHeight(child: Text('Loading...')),
               ),
             ),
           ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -123,10 +123,11 @@ packages:
   appflowy_editor:
     dependency: "direct main"
     description:
-      name: appflowy_editor
-      sha256: "77e7a8da4474b3ee95aee860d782a48400ed57bbf4f8bd574231cfb21218dabb"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: ben-mobile-expandable-editor
+      resolved-ref: f8dbf8a43c61d0aebead83e1b71af8c2c4c53a79
+      url: "https://github.com/acterglobal/appflowy-editor"
+    source: git
     version: "5.2.0"
   archive:
     dependency: transitive

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -61,7 +61,11 @@ dependencies:
       ref: main
 
   flutter_easyloading: ^3.0.5
-  appflowy_editor: ^5.2.0
+  appflowy_editor: #^5.2.0
+    # path: ../../appflowy-editor
+    git:
+      url: https://github.com/acterglobal/appflowy-editor
+      ref: ben-mobile-expandable-editor
   acter_trigger_auto_complete:
     path: ../packages/acter_trigger_auto_complete
   acter_notifify:

--- a/app/test/features/chat_ng/widgets/chat_editor/editor_height-auto-scroll_test.dart
+++ b/app/test/features/chat_ng/widgets/chat_editor/editor_height-auto-scroll_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:async';
 
 import 'package:acter/common/providers/keyboard_visbility_provider.dart';
-import 'package:acter/features/chat_ng/utils.dart';
 import 'package:acter/common/widgets/html_editor/html_editor.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';

--- a/app/test/features/chat_ng/widgets/chat_editor/editor_height-auto-scroll_test.dart
+++ b/app/test/features/chat_ng/widgets/chat_editor/editor_height-auto-scroll_test.dart
@@ -50,88 +50,39 @@ class TestableEditor extends ConsumerStatefulWidget {
 class _TestableEditorState extends ConsumerState<TestableEditor> {
   final EditorState editorState = EditorState.blank();
   late EditorScrollController scrollController;
-  final ValueNotifier<double> _contentHeightNotifier = ValueNotifier(
-    ChatEditorUtils.baseHeight,
-  );
-
   @override
   void initState() {
     super.initState();
     scrollController = EditorScrollController(editorState: editorState);
-
-    // Set initial height based on keyboard visibility
-    if (widget.initialKeyboardVisible) {
-      _contentHeightNotifier.value += ChatEditorUtils.toolbarOffset;
-    }
-  }
-
-  @override
-  void dispose() {
-    _contentHeightNotifier.dispose();
-    super.dispose();
-  }
-
-  void updateContentHeight(String text) {
-    final lineCount = text.split('\n').length - 1;
-
-    double newHeight =
-        lineCount > 1 ? ChatEditorUtils.maxHeight : ChatEditorUtils.baseHeight;
-
-    final isKeyboardVisible = ref.read(keyboardVisibleProvider).valueOrNull;
-    if (isKeyboardVisible == true) {
-      newHeight += ChatEditorUtils.toolbarOffset;
-    }
-
-    setState(() {
-      _contentHeightNotifier.value = newHeight;
-    });
   }
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<double>(
-      valueListenable: _contentHeightNotifier,
-      builder: (context, height, _) {
-        return AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          width: MediaQuery.of(context).size.width,
-          height: height,
-          decoration: BoxDecoration(
-            color: Colors.grey[200],
-            borderRadius: BorderRadius.circular(15.0),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(top: 4, left: 4),
+          child: IconButton(
+            onPressed: null,
+            icon: Icon(Icons.emoji_emotions, size: 20),
           ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Padding(
-                padding: EdgeInsets.only(top: 4, left: 4),
-                child: IconButton(
-                  onPressed: null,
-                  icon: Icon(Icons.emoji_emotions, size: 20),
-                ),
-              ),
-              Expanded(
-                child: HtmlEditor(
-                  footer: null,
-                  hintText: 'Test hint',
-                  editable: true,
-                  shrinkWrap: false,
-                  disableAutoScroll: false,
-                  editorState: editorState,
-                  scrollController: scrollController,
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.only(top: 4, left: 4, right: 4),
-                child: IconButton(
-                  onPressed: null,
-                  icon: Icon(Icons.send, size: 20),
-                ),
-              ),
-            ],
+        ),
+        Expanded(
+          child: HtmlEditor(
+            footer: null,
+            hintText: 'Test hint',
+            editable: true,
+            shrinkWrap: false,
+            disableAutoScroll: false,
+            editorState: editorState,
           ),
-        );
-      },
+        ),
+        const Padding(
+          padding: EdgeInsets.only(top: 4, left: 4, right: 4),
+          child: IconButton(onPressed: null, icon: Icon(Icons.send, size: 20)),
+        ),
+      ],
     );
   }
 }
@@ -239,11 +190,6 @@ void main() {
       );
       editorState.apply(transaction);
 
-      final state = tester.state<_TestableEditorState>(
-        find.byType(TestableEditor),
-      );
-      state.updateContentHeight('Line 1\nLine 2\nLine 3\nLine 4');
-
       // update height delay
       await tester.pump(const Duration(milliseconds: 100));
       await tester.pumpAndSettle();
@@ -296,14 +242,6 @@ void main() {
         );
         editorState.apply(transaction);
 
-        final state = tester.state<_TestableEditorState>(
-          find.byType(TestableEditor),
-        );
-
-        // Directly set the height for testing
-        state._contentHeightNotifier.value =
-            ChatEditorUtils.maxHeight + ChatEditorUtils.toolbarOffset;
-
         // update height delay
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
@@ -311,12 +249,6 @@ void main() {
         await expectLater(
           find.byType(TestableEditor),
           matchesGoldenFile('goldens/editor_multiline_with_keyboard.png'),
-        );
-
-        // verify the height is at max + toolbar offset
-        expect(
-          state._contentHeightNotifier.value,
-          equals(ChatEditorUtils.maxHeight + ChatEditorUtils.toolbarOffset),
         );
 
         await tester.binding.setSurfaceSize(null);
@@ -347,39 +279,11 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // Initial height check
-      final initialState = tester.state<_TestableEditorState>(
-        find.byType(TestableEditor),
-      );
-      expect(
-        initialState._contentHeightNotifier.value,
-        equals(ChatEditorUtils.baseHeight),
-      );
-
-      // Make keyboard visible and manually set height
-      initialState._contentHeightNotifier.value =
-          ChatEditorUtils.baseHeight + ChatEditorUtils.toolbarOffset;
-
       await tester.pump();
       await tester.pumpAndSettle();
 
-      // Check height increased
-      expect(
-        initialState._contentHeightNotifier.value,
-        equals(ChatEditorUtils.baseHeight + ChatEditorUtils.toolbarOffset),
-      );
-
-      // Make keyboard invisible again and manually reset height
-      initialState._contentHeightNotifier.value = ChatEditorUtils.baseHeight;
-
       await tester.pump();
       await tester.pumpAndSettle();
-
-      // Check height decreased
-      expect(
-        initialState._contentHeightNotifier.value,
-        equals(ChatEditorUtils.baseHeight),
-      );
 
       await tester.binding.setSurfaceSize(null);
       keyboardStateController.close(); // Don't forget to close the controller
@@ -431,15 +335,6 @@ void main() {
       );
       editorState.apply(transaction);
 
-      final state = tester.state<_TestableEditorState>(
-        find.byType(TestableEditor),
-      );
-
-      state.updateContentHeight(longText);
-
-      state._contentHeightNotifier.value =
-          ChatEditorUtils.maxHeight + ChatEditorUtils.toolbarOffset;
-
       await tester.pump(const Duration(milliseconds: 100));
       await tester.pumpAndSettle();
 
@@ -447,15 +342,6 @@ void main() {
         find.byType(TestableEditor),
         matchesGoldenFile('goldens/editor_long_text_without_breaks.png'),
       );
-
-      final height = state._contentHeightNotifier.value;
-
-      // verify that the height is at max + toolbar offset
-      expect(
-        height,
-        equals(ChatEditorUtils.maxHeight + ChatEditorUtils.toolbarOffset),
-      );
-
       await tester.binding.setSurfaceSize(null);
       keyboardStateController.close();
     });


### PR DESCRIPTION
Fixes [#meta-901](https://github.com/acterglobal/a3-meta/issues/901) .


This moves the Animated expanding box around HtmlEditor into the inner Editor. This is necessary to ensure that the mobile toolbar isn't inside the animated box as that causes overflows in the inner type upon keyboard opens (as there isn't enough space during render).

By moving that login into the inner editor and make it peg against the actual inner size rather than some "guessed" line count, this is more accurately updating the text box while simultanously avoding to cut the mobile toolbar.

Unfortunately the way that the mobile toolbar is wrapped, this fails with a hasSize error on `main` so this is using a slightly modified fork, which allows for an unknown-sized box.

Live in action:

## on desktop

https://github.com/user-attachments/assets/c886c04c-dcdf-4fcf-a901-274d1edd0d7d

## on android (device):


https://github.com/user-attachments/assets/4e0cb54d-7bc7-4238-bd34-d982857ec973


