### PR TITLE
[smallfix] Refactor the string manipulation

### DIFF
--- a/native/acter/build.rs
+++ b/native/acter/build.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // whether the target is 32bits or 64bits
     let is32bit = std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH")
-        .unwrap_or("64".to_string())
+        .unwrap_or("64".to_owned())
         .as_str()
         == "32";
 

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -103,7 +103,7 @@ impl Attachment {
     }
 
     pub async fn can_redact(&self) -> Result<bool> {
-        let sender = self.inner.meta.sender.to_owned();
+        let sender = self.inner.meta.sender.clone();
         let room = self.room.clone();
 
         RUNTIME

--- a/native/acter/src/api/attachments.rs
+++ b/native/acter/src/api/attachments.rs
@@ -310,7 +310,7 @@ impl Attachment {
                     .state_store()
                     .set_custom_value_no_read(&key, path_text.as_bytes().to_vec())
                     .await?;
-                Ok(OptionString::new(Some(path_text.to_string())))
+                Ok(OptionString::new(Some(path_text.to_owned())))
             })
             .await?
     }
@@ -362,7 +362,7 @@ impl Attachment {
                 let Some(path_vec) = client.state_store().get_custom_value(&key).await? else {
                     return Ok(OptionString::new(None));
                 };
-                let path_str = std::str::from_utf8(&path_vec)?.to_string();
+                let path_str = std::str::from_utf8(&path_vec)?.to_owned();
                 if matches!(exists(&path_str), Ok(true)) {
                     return Ok(OptionString::new(Some(path_str)));
                 }

--- a/native/acter/src/api/client.rs
+++ b/native/acter/src/api/client.rs
@@ -270,7 +270,7 @@ impl Client {
             CustomAuthSession {
                 user_id: session.meta().user_id.clone(),
                 device_id: session.meta().device_id.clone(),
-                access_token: session.access_token().to_string(),
+                access_token: session.access_token().to_owned(),
             },
             homeurl,
             is_guest,

--- a/native/acter/src/api/comments.rs
+++ b/native/acter/src/api/comments.rs
@@ -71,7 +71,7 @@ impl Comment {
     }
 
     pub async fn can_redact(&self) -> Result<bool> {
-        let sender = self.sender().to_owned();
+        let sender = self.sender();
         let room = self.room.clone();
 
         RUNTIME

--- a/native/acter/src/api/common.rs
+++ b/native/acter/src/api/common.rs
@@ -231,9 +231,9 @@ impl ComposeDraft {
 
     pub fn draft_type(&self) -> String {
         match &(self.inner.draft_type) {
-            ComposerDraftType::NewMessage => "new".to_string(),
-            ComposerDraftType::Edit { event_id } => "edit".to_string(),
-            ComposerDraftType::Reply { event_id } => "reply".to_string(),
+            ComposerDraftType::NewMessage => "new".to_owned(),
+            ComposerDraftType::Edit { event_id } => "edit".to_owned(),
+            ComposerDraftType::Reply { event_id } => "reply".to_owned(),
         }
     }
 }

--- a/native/acter/src/api/convo.rs
+++ b/native/acter/src/api/convo.rs
@@ -301,12 +301,10 @@ impl Convo {
 
                 Ok(OptionComposeDraft::new(draft.map(|composer_draft| {
                     let (msg_type, event_id) = match composer_draft.draft_type {
-                        ComposerDraftType::NewMessage => ("new".to_string(), None),
-                        ComposerDraftType::Edit { event_id } => {
-                            ("edit".to_string(), Some(event_id))
-                        }
+                        ComposerDraftType::NewMessage => ("new".to_owned(), None),
+                        ComposerDraftType::Edit { event_id } => ("edit".to_owned(), Some(event_id)),
                         ComposerDraftType::Reply { event_id } => {
-                            ("reply".to_string(), Some(event_id))
+                            ("reply".to_owned(), Some(event_id))
                         }
                     };
                     ComposeDraft::new(

--- a/native/acter/src/api/device.rs
+++ b/native/acter/src/api/device.rs
@@ -79,13 +79,13 @@ impl DeviceController {
                 if let Some(user_devices) = device_updates.new.get(my_id) {
                     for (dev_id, dev) in user_devices {
                         info!("device-new device id: {}", dev_id);
-                        new_devices.push(dev_id.to_owned());
+                        new_devices.push(dev_id.clone());
                     }
                 }
                 if let Some(user_devices) = device_updates.changed.get(my_id) {
                     for (dev_id, dev) in user_devices {
                         info!("device-changed device id: {}", dev_id);
-                        changed_devices.push(dev_id.to_owned());
+                        changed_devices.push(dev_id.clone());
                     }
                 }
                 if !new_devices.is_empty() || !changed_devices.is_empty() {

--- a/native/acter/src/api/invitations/object_manager.rs
+++ b/native/acter/src/api/invitations/object_manager.rs
@@ -103,7 +103,7 @@ impl ObjectInvitationsManager {
     pub async fn reload(&self) -> Result<Self> {
         let client = self.client.clone();
         let room = self.room.clone();
-        let event_id = self.inner.event_id().to_owned();
+        let event_id = self.inner.event_id();
         RUNTIME
             .spawn(async move { ObjectInvitationsManager::new(client, room, event_id).await })
             .await?

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -118,7 +118,7 @@ impl NewsSlide {
     }
 
     pub fn colors(&self) -> Option<Colorize> {
-        self.inner.colors.to_owned()
+        self.inner.colors.clone()
     }
 
     pub fn msg_content(&self) -> MsgContent {
@@ -519,7 +519,7 @@ impl NewsEntryDraft {
             .spawn(async move {
                 let mut slides = vec![];
                 for slide in &slides_drafts {
-                    let saved_slide = slide.to_owned().build(&client, &room).await?;
+                    let saved_slide = slide.clone().build(&client, &room).await?;
                     slides.push(saved_slide);
                 }
                 builder.slides(slides);

--- a/native/acter/src/api/profile.rs
+++ b/native/acter/src/api/profile.rs
@@ -30,7 +30,7 @@ impl PublicProfile {
             return Ok(None);
         };
         let request = MediaRequestParameters {
-            source: MediaSource::Plain(url.to_owned()),
+            source: MediaSource::Plain(url.clone()),
             format,
         };
         let buf = self

--- a/native/acter/src/api/push/notification_item.rs
+++ b/native/acter/src/api/push/notification_item.rs
@@ -325,7 +325,7 @@ impl NotificationItem {
         self.thread_id.clone()
     }
     pub fn room_invite_str(&self) -> Option<String> {
-        self.inner.room_invite().map(|r| r.to_string())
+        self.inner.room_invite().as_deref().map(ToString::to_string)
     }
     pub fn mentions_you(&self) -> bool {
         self.mentions_you

--- a/native/acter/src/api/push/notification_item.rs
+++ b/native/acter/src/api/push/notification_item.rs
@@ -199,7 +199,7 @@ impl NotificationItemInner {
                 encode(device_id.as_str()),
                 encode(room_id.as_str())
             ),
-            NotificationItemInner::Invite { room_id } => "/activities/invites".to_string(),
+            NotificationItemInner::Invite { room_id } => "/activities/invites".to_owned(),
             NotificationItemInner::ChatMessage { room_id, .. } => format!("/chat/{room_id}"),
             NotificationItemInner::Activity(a) => a.target_url(),
         }
@@ -537,7 +537,7 @@ impl NotificationItemBuilder {
                     builder.title(match details {
                         RefDetails::CalendarEvent { .. } => format!("🗓️ {title}"),
                         RefDetails::Pin { .. } => format!("📌 {title}"),
-                        RefDetails::News { .. } => "🚀 boost".to_string(),
+                        RefDetails::News { .. } => "🚀 boost".to_owned(),
                         RefDetails::Task { .. } => format!("☑️ {title}"),
                         RefDetails::TaskList { .. } => format!("📋 {title}"),
                         RefDetails::Link { .. } => format!("🔗 {title}"),

--- a/native/acter/src/api/push/notification_settings.rs
+++ b/native/acter/src/api/push/notification_settings.rs
@@ -85,7 +85,7 @@ fn make_push_rule(parent_id: &str, sub_type: Option<&String>) -> NewConditionalP
     if let Some(event_type) = sub_type {
         conditions.push(PushCondition::EventPropertyIs {
             key: "type".to_owned(),
-            value: event_type.to_owned().into(),
+            value: event_type.clone().into(),
         })
     }
     NewConditionalPushRule::new(push_key, conditions, vec![Action::Notify])

--- a/native/acter/src/api/room.rs
+++ b/native/acter/src/api/room.rs
@@ -1145,7 +1145,7 @@ impl Room {
                 room.user_defined_notification_mode()
                     .await
                     .map(|x| room_notification_mode_name(&x))
-                    .unwrap_or("none".to_string())
+                    .unwrap_or("none".to_owned())
             })
             .await?)
     }
@@ -1338,11 +1338,11 @@ impl Room {
 
     pub fn room_type(&self) -> String {
         match self.room.state() {
-            RoomState::Joined => "joined".to_string(),
-            RoomState::Left => "left".to_string(),
-            RoomState::Invited => "invited".to_string(),
-            RoomState::Knocked => "knocked".to_string(),
-            RoomState::Banned => "banned".to_string(),
+            RoomState::Joined => "joined".to_owned(),
+            RoomState::Left => "left".to_owned(),
+            RoomState::Invited => "invited".to_owned(),
+            RoomState::Knocked => "knocked".to_owned(),
+            RoomState::Banned => "banned".to_owned(),
         }
     }
 
@@ -1655,7 +1655,7 @@ impl Room {
                     .state_store()
                     .set_custom_value_no_read(&key, path_text.as_bytes().to_vec())
                     .await?;
-                Ok(OptionString::new(Some(path_text.to_string())))
+                Ok(OptionString::new(Some(path_text.to_owned())))
             })
             .await?
     }
@@ -1711,7 +1711,7 @@ impl Room {
                 let Some(path_vec) = client.state_store().get_custom_value(&key).await? else {
                     return Ok(OptionString::new(None));
                 };
-                let path_str = std::str::from_utf8(&path_vec)?.to_string();
+                let path_str = std::str::from_utf8(&path_vec)?.to_owned();
                 if matches!(exists(&path_str), Ok(true)) {
                     return Ok(OptionString::new(Some(path_str)));
                 }

--- a/native/acter/src/api/room/preview.rs
+++ b/native/acter/src/api/room/preview.rs
@@ -73,12 +73,12 @@ impl RoomPreview {
 
     pub fn state_str(&self) -> String {
         match self.inner.state {
-            None => "unknown".to_string(),
-            Some(RoomState::Invited) => "invited".to_string(),
-            Some(RoomState::Joined) => "joined".to_string(),
-            Some(RoomState::Left) => "left".to_string(),
-            Some(RoomState::Knocked) => "knocked".to_string(),
-            Some(RoomState::Banned) => "banned".to_string(),
+            None => "unknown".to_owned(),
+            Some(RoomState::Invited) => "invited".to_owned(),
+            Some(RoomState::Joined) => "joined".to_owned(),
+            Some(RoomState::Left) => "left".to_owned(),
+            Some(RoomState::Knocked) => "knocked".to_owned(),
+            Some(RoomState::Banned) => "banned".to_owned(),
         }
     }
 

--- a/native/acter/src/api/search.rs
+++ b/native/acter/src/api/search.rs
@@ -113,7 +113,7 @@ impl PublicSearchResultItem {
         match self.chunk.room_type {
             None => "Chat".to_owned(),
             Some(RoomType::Space) => "Space".to_owned(),
-            Some(RoomType::_Custom(_)) => "Custom".to_string(),
+            Some(RoomType::_Custom(_)) => "Custom".to_owned(),
             _ => "unknown".to_owned(),
         }
     }

--- a/native/acter/src/api/stories.rs
+++ b/native/acter/src/api/stories.rs
@@ -116,7 +116,7 @@ impl StorySlide {
     }
 
     pub fn colors(&self) -> Option<Colorize> {
-        self.inner.colors.to_owned()
+        self.inner.colors.clone()
     }
 
     pub fn msg_content(&self) -> MsgContent {
@@ -494,7 +494,7 @@ impl StoryDraft {
             .spawn(async move {
                 let mut slides = vec![];
                 for slide in &slides_drafts {
-                    let saved_slide = slide.to_owned().build(&client, &room).await?;
+                    let saved_slide = slide.clone().build(&client, &room).await?;
                     slides.push(saved_slide);
                 }
                 builder.slides(slides);

--- a/native/acter/src/api/tasks.rs
+++ b/native/acter/src/api/tasks.rs
@@ -249,7 +249,7 @@ impl Deref for TaskList {
 /// helpers for content
 impl TaskList {
     pub fn name(&self) -> String {
-        self.content.name.to_owned()
+        self.content.name.clone()
     }
 
     pub fn description(&self) -> Option<MsgContent> {
@@ -285,7 +285,7 @@ impl TaskList {
         // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for keyword in &self.content.keywords {
-            result.push(keyword.to_owned());
+            result.push(keyword.clone());
         }
         result
     }
@@ -296,7 +296,7 @@ impl TaskList {
         // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for category in &self.content.categories {
-            result.push(category.to_owned());
+            result.push(category.clone());
         }
         result
     }
@@ -491,7 +491,7 @@ impl Deref for Task {
 /// helpers for content
 impl Task {
     pub fn title(&self) -> String {
-        self.content.title().to_owned()
+        self.content.title().clone()
     }
 
     pub fn event_id_str(&self) -> String {
@@ -563,7 +563,7 @@ impl Task {
         // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for keyword in &self.content.keywords {
-            result.push(keyword.to_owned());
+            result.push(keyword.clone());
         }
         result
     }
@@ -574,7 +574,7 @@ impl Task {
         // apply this way for only function that string vector is calculated indirectly.
         let mut result = vec![];
         for category in &self.content.categories {
-            result.push(category.to_owned());
+            result.push(category.clone());
         }
         result
     }

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -52,13 +52,13 @@ pub struct EventSendState {
 impl EventSendState {
     fn new(inner: &SdkEventSendState, send_handle: Option<SendHandle>) -> Self {
         let (state, error, event_id) = match inner {
-            SdkEventSendState::NotSentYet => ("NotSentYet".to_string(), None, None),
+            SdkEventSendState::NotSentYet => ("NotSentYet".to_owned(), None, None),
             SdkEventSendState::SendingFailed {
                 error,
                 is_recoverable,
-            } => ("SendingFailed".to_string(), Some(error.to_string()), None),
+            } => ("SendingFailed".to_owned(), Some(error.to_string()), None),
             SdkEventSendState::Sent { event_id } => {
-                ("Sent".to_string(), None, Some(event_id.clone()))
+                ("Sent".to_owned(), None, Some(event_id.clone()))
             }
         };
         EventSendState {
@@ -138,7 +138,7 @@ impl TimelineEventItemBuilder {
                 MsgLikeKind::Message(msg) => {
                     self.event_type("m.room.message".to_owned());
                     let msg_type = msg.msgtype();
-                    self.msg_type(Some(msg_type.msgtype().to_string()));
+                    self.msg_type(Some(msg_type.msgtype().to_owned()));
                     self.content(TimelineEventContent::try_from(msg_type).ok());
                     if let Some(in_reply_to) = &msg_like.in_reply_to {
                         self.in_reply_to_id(Some(in_reply_to.event_id.clone()));
@@ -157,21 +157,21 @@ impl TimelineEventItemBuilder {
                 }
                 MsgLikeKind::Redacted => {
                     info!("Edit event applies to a redacted message");
-                    self.event_type("m.room.redaction".to_string());
+                    self.event_type("m.room.redaction".to_owned());
                 }
                 MsgLikeKind::Sticker(s) => {
-                    self.event_type("m.sticker".to_string());
+                    self.event_type("m.sticker".to_owned());
                     // FIXME: proper sticker support needed
                     // self.msg_content(Some(MsgContent::from(s.content())));
                 }
                 MsgLikeKind::UnableToDecrypt(encrypted_msg) => {
                     info!("Edit event applies to event that couldn’t be decrypted");
-                    self.event_type("m.room.encrypted".to_string());
+                    self.event_type("m.room.encrypted".to_owned());
                 }
 
                 MsgLikeKind::Poll(s) => {
                     info!("Edit event applies to a poll state");
-                    self.event_type("m.poll.start".to_string());
+                    self.event_type("m.poll.start".to_owned());
                     if let Some(fallback) = s.fallback_text() {
                         let msg_content = MsgContent::from_text(fallback);
                         self.content(Some(TimelineEventContent::Message(msg_content)));
@@ -180,14 +180,14 @@ impl TimelineEventItemBuilder {
             },
             SdkTimelineItemContent::MembershipChange(m) => {
                 info!("Edit event applies to membership change event");
-                self.event_type("MembershipChange".to_string());
+                self.event_type("MembershipChange".to_owned());
                 if let Ok(content) = MembershipContent::try_from(m) {
                     self.content(Some(TimelineEventContent::MembershipChange(content)));
                 }
             }
             SdkTimelineItemContent::ProfileChange(p) => {
                 info!("Edit event applies to profile change event");
-                self.event_type("ProfileChange".to_string());
+                self.event_type("ProfileChange".to_owned());
                 let content = ProfileContent::from(p);
                 self.content(Some(TimelineEventContent::ProfileChange(content)));
             }
@@ -478,7 +478,7 @@ impl TimelineEventItem {
         // apply this way for only function that string vector is calculated indirectly.
         let mut users = vec![];
         for seen_by in self.read_receipts.keys() {
-            users.push(seen_by.to_string());
+            users.push(seen_by.clone());
         }
         users
     }
@@ -790,16 +790,16 @@ impl From<&VirtualTimelineItem> for TimelineVirtualItem {
                     None
                 };
                 TimelineVirtualItem {
-                    event_type: "DayDivider".to_string(),
+                    event_type: "DayDivider".to_owned(),
                     desc,
                 }
             }
             VirtualTimelineItem::TimelineStart => TimelineVirtualItem {
-                event_type: "TimelineStart".to_string(),
+                event_type: "TimelineStart".to_owned(),
                 desc: None,
             },
             VirtualTimelineItem::ReadMarker => TimelineVirtualItem {
-                event_type: "ReadMarker".to_string(),
+                event_type: "ReadMarker".to_owned(),
                 desc: None,
             },
         }

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -56,12 +56,7 @@ impl EventSendState {
             SdkEventSendState::SendingFailed {
                 error,
                 is_recoverable,
-            } => (
-                "SendingFailed".to_string(),
-                Some(error.to_owned().to_string()),
-                None,
-            ),
-
+            } => ("SendingFailed".to_string(), Some(error.to_string()), None),
             SdkEventSendState::Sent { event_id } => {
                 ("Sent".to_string(), None, Some(event_id.clone()))
             }
@@ -502,7 +497,7 @@ impl TimelineEventItem {
         // apply this way for only function that string vector is calculated indirectly.
         let mut keys = vec![];
         for key in self.reactions.keys() {
-            keys.push(key.to_owned());
+            keys.push(key.clone());
         }
         keys
     }

--- a/native/acter/src/api/utils.rs
+++ b/native/acter/src/api/utils.rs
@@ -40,7 +40,7 @@ where
 impl<T> ApiVectorDiff<T> {
     pub fn current_items(values: Vec<T>) -> Self {
         ApiVectorDiff {
-            action: "Reset".to_string(),
+            action: "Reset".to_owned(),
             values: Some(values),
             index: None,
             value: None,
@@ -57,76 +57,76 @@ where
     match diff {
         // Append the given elements at the end of the `Vector` and notify subscribers
         VectorDiff::Append { values } => ApiVectorDiff {
-            action: "Append".to_string(),
+            action: "Append".to_owned(),
             values: Some(values.into_iter().map(mapper).collect()),
             index: None,
             value: None,
         },
         // Insert an element at the given position and notify subscribers
         VectorDiff::Insert { index, value } => ApiVectorDiff {
-            action: "Insert".to_string(),
+            action: "Insert".to_owned(),
             values: None,
             index: Some(index),
             value: Some(mapper(value)),
         },
         // Replace the element at the given position, notify subscribers and return the previous element at that position
         VectorDiff::Set { index, value } => ApiVectorDiff {
-            action: "Set".to_string(),
+            action: "Set".to_owned(),
             values: None,
             index: Some(index),
             value: Some(mapper(value)),
         },
         // Remove the element at the given position, notify subscribers and return the element
         VectorDiff::Remove { index } => ApiVectorDiff {
-            action: "Remove".to_string(),
+            action: "Remove".to_owned(),
             values: None,
             index: Some(index),
             value: None,
         },
         // Add an element at the back of the list and notify subscribers
         VectorDiff::PushBack { value } => ApiVectorDiff {
-            action: "PushBack".to_string(),
+            action: "PushBack".to_owned(),
             values: None,
             index: None,
             value: Some(mapper(value)),
         },
         // Add an element at the front of the list and notify subscribers
         VectorDiff::PushFront { value } => ApiVectorDiff {
-            action: "PushFront".to_string(),
+            action: "PushFront".to_owned(),
             values: None,
             index: None,
             value: Some(mapper(value)),
         },
         // Remove the last element, notify subscribers and return the element
         VectorDiff::PopBack => ApiVectorDiff {
-            action: "PopBack".to_string(),
+            action: "PopBack".to_owned(),
             values: None,
             index: None,
             value: None,
         },
         // Remove the first element, notify subscribers and return the element
         VectorDiff::PopFront => ApiVectorDiff {
-            action: "PopFront".to_string(),
+            action: "PopFront".to_owned(),
             values: None,
             index: None,
             value: None,
         },
         // Clear out all of the elements in this `Vector` and notify subscribers
         VectorDiff::Clear => ApiVectorDiff {
-            action: "Clear".to_string(),
+            action: "Clear".to_owned(),
             values: None,
             index: None,
             value: None,
         },
         VectorDiff::Reset { values } => ApiVectorDiff {
-            action: "Reset".to_string(),
+            action: "Reset".to_owned(),
             values: Some(values.into_iter().map(mapper).collect()),
             index: None,
             value: None,
         },
         // Truncate the vector to `len` elements and notify subscribers
         VectorDiff::Truncate { length } => ApiVectorDiff {
-            action: "Truncate".to_string(),
+            action: "Truncate".to_owned(),
             values: None,
             index: Some(length),
             value: None,

--- a/native/acter/src/api/verification.rs
+++ b/native/acter/src/api/verification.rs
@@ -344,7 +344,7 @@ async fn request_verification_handler(
         match state {
             VerificationRequestState::Created { our_methods } => {
                 let device_id = client.device_id()?;
-                let event_type = "VerificationRequestState::Created".to_string();
+                let event_type = "VerificationRequestState::Created".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -358,7 +358,7 @@ async fn request_verification_handler(
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(",");
-                msg.set_content("our_methods".to_string(), methods);
+                msg.set_content("our_methods".to_owned(), methods);
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
@@ -368,7 +368,7 @@ async fn request_verification_handler(
                 other_device_data,
             } => {
                 let device_id = client.device_id()?;
-                let event_type = "VerificationRequestState::Requested".to_string();
+                let event_type = "VerificationRequestState::Requested".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -382,9 +382,9 @@ async fn request_verification_handler(
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(",");
-                msg.set_content("their_methods".to_string(), methods);
+                msg.set_content("their_methods".to_owned(), methods);
                 msg.set_content(
-                    "other_device_id".to_string(),
+                    "other_device_id".to_owned(),
                     other_device_data.device_id().to_string(),
                 );
                 if let Err(e) = controller.event_tx.send(msg) {
@@ -397,7 +397,7 @@ async fn request_verification_handler(
                 other_device_data,
             } => {
                 let device_id = client.device_id()?;
-                let event_type = "VerificationRequestState::Ready".to_string();
+                let event_type = "VerificationRequestState::Ready".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -411,15 +411,15 @@ async fn request_verification_handler(
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(",");
-                msg.set_content("their_methods".to_string(), methods);
+                msg.set_content("their_methods".to_owned(), methods);
                 let methods = our_methods
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(",");
-                msg.set_content("our_methods".to_string(), methods);
+                msg.set_content("our_methods".to_owned(), methods);
                 msg.set_content(
-                    "other_device_id".to_string(),
+                    "other_device_id".to_owned(),
                     other_device_data.device_id().to_string(),
                 );
                 if let Err(e) = controller.event_tx.send(msg) {
@@ -429,7 +429,7 @@ async fn request_verification_handler(
             VerificationRequestState::Transitioned { verification } => {
                 if let Verification::SasV1(s) = verification {
                     let device_id = client.device_id()?;
-                    let event_type = "VerificationRequestState::Transitioned".to_string();
+                    let event_type = "VerificationRequestState::Transitioned".to_owned();
                     info!("{} got {}", device_id, event_type);
                     let msg = VerificationEvent::new(
                         client.core.client().clone(),
@@ -445,7 +445,7 @@ async fn request_verification_handler(
             }
             VerificationRequestState::Done => {
                 let device_id = client.device_id()?;
-                let event_type = "VerificationRequestState::Done".to_string();
+                let event_type = "VerificationRequestState::Done".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -461,7 +461,7 @@ async fn request_verification_handler(
             }
             VerificationRequestState::Cancelled(cancel_info) => {
                 let device_id = client.device_id()?;
-                let event_type = "VerificationRequestState::Cancelled".to_string();
+                let event_type = "VerificationRequestState::Cancelled".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -471,10 +471,10 @@ async fn request_verification_handler(
                     sender.clone(),
                 );
                 msg.set_content(
-                    "cancel_code".to_string(),
+                    "cancel_code".to_owned(),
                     cancel_info.cancel_code().to_string(),
                 );
-                msg.set_content("reason".to_string(), cancel_info.reason().to_string());
+                msg.set_content("reason".to_owned(), cancel_info.reason().to_string());
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
@@ -497,7 +497,7 @@ async fn sas_verification_handler(
         match state {
             SasState::KeysExchanged { emojis, decimals } => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::KeysExchanged".to_string();
+                let event_type = "SasState::KeysExchanged".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -521,7 +521,7 @@ async fn sas_verification_handler(
                         return Err(e.into());
                     }
                 };
-                msg.set_content("decimals".to_string(), value);
+                msg.set_content("decimals".to_owned(), value);
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
@@ -531,7 +531,7 @@ async fn sas_verification_handler(
                 verified_identities,
             } => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::Done".to_string();
+                let event_type = "SasState::Done".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -544,12 +544,12 @@ async fn sas_verification_handler(
                     .iter()
                     .map(|x| x.device_id().to_string())
                     .collect::<Vec<String>>();
-                msg.set_content("verified_devices".to_string(), devices.join(","));
+                msg.set_content("verified_devices".to_owned(), devices.join(","));
                 let identifiers = verified_identities
                     .iter()
                     .map(|x| x.user_id().to_string())
                     .collect::<Vec<String>>();
-                msg.set_content("verified_identities".to_string(), identifiers.join(","));
+                msg.set_content("verified_identities".to_owned(), identifiers.join(","));
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
@@ -557,7 +557,7 @@ async fn sas_verification_handler(
             }
             SasState::Cancelled(cancel_info) => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::Cancelled".to_string();
+                let event_type = "SasState::Cancelled".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -567,10 +567,10 @@ async fn sas_verification_handler(
                     sender.clone(),
                 );
                 msg.set_content(
-                    "cancel_code".to_string(),
+                    "cancel_code".to_owned(),
                     cancel_info.cancel_code().to_string(),
                 );
-                msg.set_content("reason".to_string(), cancel_info.reason().to_string());
+                msg.set_content("reason".to_owned(), cancel_info.reason().to_string());
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
@@ -578,7 +578,7 @@ async fn sas_verification_handler(
             }
             SasState::Started { protocols } => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::Started".to_string();
+                let event_type = "SasState::Started".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -593,7 +593,7 @@ async fn sas_verification_handler(
                     .map(ToString::to_string)
                     .collect::<Vec<String>>();
                 msg.set_content(
-                    "key_agreement_protocols".to_string(),
+                    "key_agreement_protocols".to_owned(),
                     key_agreement_protocols.join(","),
                 );
                 let hashes = protocols
@@ -601,14 +601,14 @@ async fn sas_verification_handler(
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>();
-                msg.set_content("hashes".to_string(), hashes.join(","));
+                msg.set_content("hashes".to_owned(), hashes.join(","));
                 let message_authentication_codes = protocols
                     .message_authentication_codes
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>();
                 msg.set_content(
-                    "message_authentication_codes".to_string(),
+                    "message_authentication_codes".to_owned(),
                     message_authentication_codes.join(","),
                 );
                 let short_authentication_string = protocols
@@ -617,7 +617,7 @@ async fn sas_verification_handler(
                     .map(ToString::to_string)
                     .collect::<Vec<String>>();
                 msg.set_content(
-                    "short_authentication_string".to_string(),
+                    "short_authentication_string".to_owned(),
                     short_authentication_string.join(","),
                 );
                 if let Err(e) = controller.event_tx.send(msg) {
@@ -626,7 +626,7 @@ async fn sas_verification_handler(
             }
             SasState::Accepted { accepted_protocols } => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::Accepted".to_string();
+                let event_type = "SasState::Accepted".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let mut msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -636,23 +636,23 @@ async fn sas_verification_handler(
                     sender.clone(),
                 );
                 msg.set_content(
-                    "key_agreement_protocol".to_string(),
+                    "key_agreement_protocol".to_owned(),
                     accepted_protocols.key_agreement_protocol.to_string(),
                 );
-                msg.set_content("hash".to_string(), accepted_protocols.hash.to_string());
+                msg.set_content("hash".to_owned(), accepted_protocols.hash.to_string());
                 let short_auth_string = accepted_protocols
                     .short_auth_string
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>();
-                msg.set_content("short_auth_string".to_string(), short_auth_string.join(","));
+                msg.set_content("short_auth_string".to_owned(), short_auth_string.join(","));
                 if let Err(e) = controller.event_tx.send(msg) {
                     error!("Dropping flow for {}: {}", flow_id, e);
                 }
             }
             SasState::Confirmed => {
                 let device_id = client.device_id()?;
-                let event_type = "SasState::Confirmed".to_string();
+                let event_type = "SasState::Confirmed".to_owned();
                 info!("{} got {}", device_id, event_type);
                 let msg = VerificationEvent::new(
                     client.core.client().clone(),
@@ -709,15 +709,15 @@ impl VerificationController {
                         ev.event_id.to_string(),
                         ev.sender,
                     );
-                    msg.set_content("body".to_string(), content.body.clone());
-                    msg.set_content("from_device".to_string(), content.from_device.to_string());
+                    msg.set_content("body".to_owned(), content.body.clone());
+                    msg.set_content("from_device".to_owned(), content.from_device.to_string());
                     let methods = content
                         .methods
                         .iter()
                         .map(|x| x.to_string())
                         .collect::<Vec<String>>();
-                    msg.set_content("methods".to_string(), methods.join(","));
-                    msg.set_content("to".to_string(), content.to.to_string());
+                    msg.set_content("methods".to_owned(), methods.join(","));
+                    msg.set_content("to".to_owned(), content.to.to_string());
                     // this may be the past event occurred when device was off
                     // so this event has no timestamp field unlike AnyToDeviceEvent::KeyVerificationRequest
                     if let Err(e) = me.event_tx.send(msg) {
@@ -756,7 +756,7 @@ impl VerificationController {
                             evt.sender,
                         );
                         msg.set_content(
-                            "from_device".to_string(),
+                            "from_device".to_owned(),
                             evt.content.from_device.to_string(),
                         );
                         let methods = evt
@@ -765,9 +765,9 @@ impl VerificationController {
                             .iter()
                             .map(ToString::to_string)
                             .collect::<Vec<String>>();
-                        msg.set_content("methods".to_string(), methods.join(","));
+                        msg.set_content("methods".to_owned(), methods.join(","));
                         msg.set_content(
-                            "timestamp".to_string(),
+                            "timestamp".to_owned(),
                             evt.content.timestamp.get().to_string(),
                         );
                         if let Err(e) = me.event_tx.send(msg) {
@@ -786,7 +786,7 @@ impl VerificationController {
                             evt.sender,
                         );
                         msg.set_content(
-                            "from_device".to_string(),
+                            "from_device".to_owned(),
                             evt.content.from_device.to_string(),
                         );
                         let methods = evt
@@ -795,7 +795,7 @@ impl VerificationController {
                             .iter()
                             .map(ToString::to_string)
                             .collect::<Vec<String>>();
-                        msg.set_content("methods".to_string(), methods.join(","));
+                        msg.set_content("methods".to_owned(), methods.join(","));
                         if let Err(e) = me.event_tx.send(msg) {
                             error!("Dropping flow for {}: {}", evt.content.transaction_id, e);
                         }
@@ -812,7 +812,7 @@ impl VerificationController {
                             evt.sender,
                         );
                         msg.set_content(
-                            "from_device".to_string(),
+                            "from_device".to_owned(),
                             evt.content.from_device.to_string(),
                         );
                         match evt.content.method {
@@ -823,7 +823,7 @@ impl VerificationController {
                                     .map(ToString::to_string)
                                     .collect::<Vec<String>>();
                                 msg.set_content(
-                                    "key_agreement_protocols".to_string(),
+                                    "key_agreement_protocols".to_owned(),
                                     key_agreement_protocols.join(","),
                                 );
                                 let hashes = content
@@ -831,14 +831,14 @@ impl VerificationController {
                                     .iter()
                                     .map(ToString::to_string)
                                     .collect::<Vec<String>>();
-                                msg.set_content("hashes".to_string(), hashes.join(","));
+                                msg.set_content("hashes".to_owned(), hashes.join(","));
                                 let message_authentication_codes = content
                                     .message_authentication_codes
                                     .iter()
                                     .map(ToString::to_string)
                                     .collect::<Vec<String>>();
                                 msg.set_content(
-                                    "message_authentication_codes".to_string(),
+                                    "message_authentication_codes".to_owned(),
                                     message_authentication_codes.join(","),
                                 );
                                 let short_authentication_string = content
@@ -847,7 +847,7 @@ impl VerificationController {
                                     .map(ToString::to_string)
                                     .collect::<Vec<String>>();
                                 msg.set_content(
-                                    "short_authentication_string".to_string(),
+                                    "short_authentication_string".to_owned(),
                                     short_authentication_string.join(","),
                                 );
                             }
@@ -859,7 +859,7 @@ impl VerificationController {
                                         return;
                                     }
                                 };
-                                msg.set_content("secret".to_string(), secret);
+                                msg.set_content("secret".to_owned(), secret);
                             }
                             _ => {}
                         }
@@ -878,7 +878,7 @@ impl VerificationController {
                             evt.content.transaction_id.to_string(),
                             evt.sender,
                         );
-                        msg.set_content("key".to_string(), evt.content.key.to_string());
+                        msg.set_content("key".to_owned(), evt.content.key.to_string());
                         if let Err(e) = me.event_tx.send(msg) {
                             error!("Dropping flow for {}: {}", evt.content.transaction_id, e);
                         }
@@ -895,13 +895,13 @@ impl VerificationController {
                             evt.sender,
                         );
                         if let AcceptMethod::SasV1(content) = evt.content.method {
-                            msg.set_content("hash".to_string(), content.hash.to_string());
+                            msg.set_content("hash".to_owned(), content.hash.to_string());
                             msg.set_content(
-                                "key_agreement_protocol".to_string(),
+                                "key_agreement_protocol".to_owned(),
                                 content.key_agreement_protocol.to_string(),
                             );
                             msg.set_content(
-                                "message_authentication_code".to_string(),
+                                "message_authentication_code".to_owned(),
                                 content.message_authentication_code.to_string(),
                             );
                             let short_authentication_string = content
@@ -910,11 +910,11 @@ impl VerificationController {
                                 .map(|x| x.as_str().into())
                                 .collect::<Vec<String>>();
                             msg.set_content(
-                                "short_authentication_string".to_string(),
+                                "short_authentication_string".to_owned(),
                                 short_authentication_string.join(","),
                             );
                             msg.set_content(
-                                "commitment".to_string(),
+                                "commitment".to_owned(),
                                 content.commitment.to_string(),
                             );
                         }
@@ -933,8 +933,8 @@ impl VerificationController {
                             evt.content.transaction_id.to_string(),
                             evt.sender,
                         );
-                        msg.set_content("code".to_string(), evt.content.code.to_string());
-                        msg.set_content("reason".to_string(), evt.content.reason);
+                        msg.set_content("code".to_owned(), evt.content.code.to_string());
+                        msg.set_content("reason".to_owned(), evt.content.reason);
                         if let Err(e) = me.event_tx.send(msg) {
                             error!("Dropping flow for {}: {}", evt.content.transaction_id, e);
                         }
@@ -950,7 +950,7 @@ impl VerificationController {
                             evt.content.transaction_id.to_string(),
                             evt.sender,
                         );
-                        msg.set_content("keys".to_string(), evt.content.keys.to_string());
+                        msg.set_content("keys".to_owned(), evt.content.keys.to_string());
                         let mac = match serde_json::to_string(&evt.content.mac) {
                             Ok(e) => e,
                             Err(e) => {
@@ -958,7 +958,7 @@ impl VerificationController {
                                 return;
                             }
                         };
-                        msg.set_content("mac".to_string(), mac);
+                        msg.set_content("mac".to_owned(), mac);
                         if let Err(e) = me.event_tx.send(msg) {
                             error!("Dropping flow for {}: {}", evt.content.transaction_id, e);
                         }

--- a/native/acter/src/api/verification.rs
+++ b/native/acter/src/api/verification.rs
@@ -714,7 +714,7 @@ impl VerificationController {
                     let methods = content
                         .methods
                         .iter()
-                        .map(|x| x.to_string())
+                        .map(ToString::to_string)
                         .collect::<Vec<String>>();
                     msg.set_content("methods".to_owned(), methods.join(","));
                     msg.set_content("to".to_owned(), content.to.to_string());

--- a/native/acter/src/platform/native.rs
+++ b/native/acter/src/platform/native.rs
@@ -208,7 +208,7 @@ pub fn rotate_log_file() -> Result<String> {
             bail!("You didn’t set up file logger.");
         }
     }
-    Ok("".to_string())
+    Ok("".to_owned())
 }
 
 fn parse_log_level(level: &str) -> Level {

--- a/native/cli/src/action/execute.rs
+++ b/native/cli/src/action/execute.rs
@@ -49,11 +49,11 @@ impl ExecuteOpts {
                     .collect::<Vec<_>>()
             };
             for (key, (is_required, is_space)) in input_values {
-                if let Some(res) = mapped_inputs.get(key.as_str()) {
+                if let Some(res) = mapped_inputs.get(key.as_str()).cloned() {
                     if !is_space {
                         bail!("{key} : non-space input values not yet supported");
                     }
-                    tmpl_engine.add_ref(key.to_string(), "space".to_owned(), res.to_string())?;
+                    tmpl_engine.add_ref(key.clone(), "space".to_owned(), res.to_owned())?;
                 } else if is_required {
                     if key != "main" {
                         bail!("Missing required input value {key} for {tmpl_path:?}");

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -521,7 +521,7 @@ impl Activity {
             | ActivityContent::RoomTombstone(_)
             | ActivityContent::RoomTopic(_)
             | ActivityContent::SpaceChild(_)
-            | ActivityContent::SpaceParent(_) => "/activities".to_string(), // fallback for state events
+            | ActivityContent::SpaceParent(_) => "/activities".to_owned(), // fallback for state events
         }
     }
 
@@ -970,11 +970,11 @@ impl Activity {
             | AnyActerModel::CommentUpdate(_)
             | AnyActerModel::AttachmentUpdate(_)
             | AnyActerModel::ReadReceipt(_) => Err(crate::Error::Custom(
-                "Converting model into activity not yet supported".to_string(),
+                "Converting model into activity not yet supported".to_owned(),
             )),
             #[cfg(any(test, feature = "testing"))]
             AnyActerModel::TestModel(_) => Err(crate::Error::Custom(
-                "Converting test model into activity not supported".to_string(),
+                "Converting test model into activity not supported".to_owned(),
             )),
         }
     }

--- a/native/core/src/activities.rs
+++ b/native/core/src/activities.rs
@@ -625,7 +625,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.on.event_id.to_owned(),
+                        object_id: e.inner.on.event_id.clone(),
                     });
                 Ok(Self::new(
                     meta,
@@ -645,7 +645,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.on.event_id.to_owned(),
+                        object_id: e.inner.on.event_id.clone(),
                     });
 
                 if let AttachmentContent::Reference(details) = e.inner.content {
@@ -674,7 +674,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.relates_to.event_id.to_owned(),
+                        object_id: e.inner.relates_to.event_id.clone(),
                     });
                 Ok(Self::new(
                     meta,
@@ -695,7 +695,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.to.event_id.to_owned(),
+                        object_id: e.inner.to.event_id.clone(),
                     });
                 Ok(Self::new(
                     meta,
@@ -725,7 +725,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.pin.event_id.to_owned(),
+                        object_id: e.inner.pin.event_id.clone(),
                     });
 
                 if let Some(new_title) = e.inner.title {
@@ -766,7 +766,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.calendar_event.event_id.to_owned(),
+                        object_id: e.inner.calendar_event.event_id.clone(),
                     });
 
                 if let Some(new_title) = e.inner.title {
@@ -809,7 +809,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.to.event_id.to_owned(),
+                        object_id: e.inner.to.event_id.clone(),
                     });
 
                 Ok(Self::new(
@@ -840,7 +840,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.task_list.event_id.to_owned(),
+                        object_id: e.inner.task_list.event_id.clone(),
                     });
 
                 if let Some(new_title) = e.inner.name {
@@ -872,7 +872,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.task_list_id.event_id.to_owned(),
+                        object_id: e.inner.task_list_id.event_id.clone(),
                     });
 
                 Ok(Self::new(
@@ -893,7 +893,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.task.event_id.to_owned(),
+                        object_id: e.inner.task.event_id.clone(),
                     });
 
                 if let Some(new_percent) = e.inner.progress_percent {
@@ -942,7 +942,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.task.event_id.to_owned(),
+                        object_id: e.inner.task.event_id.clone(),
                     });
 
                 Ok(Self::new(meta, ActivityContent::TaskAccept { object }))
@@ -958,7 +958,7 @@ impl Activity {
                     .ok()
                     .and_then(|o| ActivityObject::try_from(&o).ok())
                     .unwrap_or_else(|| ActivityObject::Unknown {
-                        object_id: e.inner.task.event_id.to_owned(),
+                        object_id: e.inner.task.event_id.clone(),
                     });
 
                 Ok(Self::new(meta, ActivityContent::TaskDecline { object }))

--- a/native/core/src/events/calendar.rs
+++ b/native/core/src/events/calendar.rs
@@ -95,8 +95,8 @@ impl EventLocationInfo {
 
     pub fn location_type(&self) -> String {
         match &self.inner {
-            EventLocation::Physical { .. } => "Physical".to_string(),
-            EventLocation::Virtual { .. } => "Virtual".to_string(),
+            EventLocation::Physical { .. } => "Physical".to_owned(),
+            EventLocation::Virtual { .. } => "Virtual".to_owned(),
         }
     }
 

--- a/native/core/src/events/common/labels.rs
+++ b/native/core/src/events/common/labels.rs
@@ -59,10 +59,10 @@ impl<'de> Visitor<'de> for LabelsVisitor {
             if let Some((prefix, res)) = key.split_once(':') {
                 match prefix {
                     // first has priority
-                    "m.type" if me.msgtype.is_none() => me.msgtype = Some(res.to_string()),
-                    "m.tag" => me.tags.push(res.to_string()),
-                    "m.section" => me.sections.push(res.to_string()),
-                    "m.cat" => me.categories.push(res.to_string()),
+                    "m.type" if me.msgtype.is_none() => me.msgtype = Some(res.to_owned()),
+                    "m.tag" => me.tags.push(res.to_owned()),
+                    "m.section" => me.sections.push(res.to_owned()),
+                    "m.cat" => me.categories.push(res.to_owned()),
                     _ => me.others.push(key),
                 }
             } else {
@@ -88,15 +88,11 @@ mod test {
     #[test]
     fn smoketest() -> Result<(), serde_json::Error> {
         let labels = Labels {
-            msgtype: Some("m.message".to_string()),
-            tags: vec![
-                "dog".to_string(),
-                "animal".to_string(),
-                "carnivor".to_string(),
-            ],
-            categories: vec!["animals".to_string()],
-            sections: vec!["work".to_string()],
-            others: vec!["whatever".to_string(), "with:other:test".to_string()],
+            msgtype: Some("m.message".to_owned()),
+            tags: vec!["dog".to_owned(), "animal".to_owned(), "carnivor".to_owned()],
+            categories: vec!["animals".to_owned()],
+            sections: vec!["work".to_owned()],
+            others: vec!["whatever".to_owned(), "with:other:test".to_owned()],
         };
         let ser = serde_json::to_string(&labels)?;
         println!("Serialized: {ser:}");
@@ -109,15 +105,11 @@ mod test {
     #[test]
     fn first_type_has_priority() -> Result<(), serde_json::Error> {
         let labels = Labels {
-            msgtype: Some("m.message".to_string()),
-            tags: vec![
-                "dog".to_string(),
-                "animal".to_string(),
-                "carnivor".to_string(),
-            ],
-            categories: vec!["animals".to_string()],
-            sections: vec!["work".to_string()],
-            others: vec!["m.type:whatever".to_string(), "with:other:test".to_string()],
+            msgtype: Some("m.message".to_owned()),
+            tags: vec!["dog".to_owned(), "animal".to_owned(), "carnivor".to_owned()],
+            categories: vec!["animals".to_owned()],
+            sections: vec!["work".to_owned()],
+            others: vec!["m.type:whatever".to_owned(), "with:other:test".to_owned()],
         };
         let ser = serde_json::to_string(&labels)?;
         println!("Serialized: {ser:}");

--- a/native/core/src/events/common/object_reference.rs
+++ b/native/core/src/events/common/object_reference.rs
@@ -316,26 +316,26 @@ pub enum RefDetails {
 impl RefDetails {
     pub fn type_str(&self) -> String {
         match self {
-            RefDetails::Task { .. } => "task".to_string(),
-            RefDetails::TaskList { .. } => "task-list".to_string(),
-            RefDetails::CalendarEvent { .. } => "calendar-event".to_string(),
-            RefDetails::Link { .. } => "link".to_string(),
-            RefDetails::Room { is_space, .. } if *is_space => "space".to_string(),
-            RefDetails::Room { .. } => "chat".to_string(),
-            RefDetails::SuperInviteToken { .. } => "super-invite".to_string(),
-            RefDetails::Pin { .. } => "pin".to_string(),
-            RefDetails::News { .. } => "news".to_string(),
+            RefDetails::Task { .. } => "task".to_owned(),
+            RefDetails::TaskList { .. } => "task-list".to_owned(),
+            RefDetails::CalendarEvent { .. } => "calendar-event".to_owned(),
+            RefDetails::Link { .. } => "link".to_owned(),
+            RefDetails::Room { is_space, .. } if *is_space => "space".to_owned(),
+            RefDetails::Room { .. } => "chat".to_owned(),
+            RefDetails::SuperInviteToken { .. } => "super-invite".to_owned(),
+            RefDetails::Pin { .. } => "pin".to_owned(),
+            RefDetails::News { .. } => "news".to_owned(),
         }
     }
 
     pub fn embed_action_str(&self) -> String {
         match self {
-            RefDetails::Link { .. } => "link".to_string(),
-            RefDetails::Room { is_space, .. } if *is_space => "space".to_string(),
-            RefDetails::Room { .. } => "chat".to_string(),
-            RefDetails::SuperInviteToken { .. } => "super-invite".to_string(),
-            RefDetails::Pin { .. } => "pin".to_string(),
-            RefDetails::News { .. } => "news".to_string(),
+            RefDetails::Link { .. } => "link".to_owned(),
+            RefDetails::Room { is_space, .. } if *is_space => "space".to_owned(),
+            RefDetails::Room { .. } => "chat".to_owned(),
+            RefDetails::SuperInviteToken { .. } => "super-invite".to_owned(),
+            RefDetails::Pin { .. } => "pin".to_owned(),
+            RefDetails::News { .. } => "news".to_owned(),
             RefDetails::Task { action, .. } => action.to_string(),
             RefDetails::TaskList { action, .. } => action.to_string(),
             RefDetails::CalendarEvent { action, .. } => action.to_string(),

--- a/native/core/src/events/pins.rs
+++ b/native/core/src/events/pins.rs
@@ -115,7 +115,7 @@ mod tests {
             "event_id":"$KwumA4L3M-duXu0I3UA886LvN-BDCKAyxR1skNfnh3c",
             "user_id":"@odo:ds9.acter.global","age":11523850}"#;
         let event = serde_json::from_str::<OriginalPinEvent>(json_raw)?;
-        assert_eq!(event.content.title, "Seat arrangement".to_string());
+        assert_eq!(event.content.title, "Seat arrangement");
         Ok(())
     }
 
@@ -128,7 +128,7 @@ mod tests {
             "event_id":"$KwumA4L3M-duXu0I3UA886LvN-BDCKAyxR1skNfnh3c",
             "user_id":"@odo:ds9.acter.global","age":11523850}"#;
         let event = serde_json::from_str::<OriginalPinEvent>(json_raw)?;
-        assert_eq!(event.content.title, "Seat arrangement".to_string());
+        assert_eq!(event.content.title, "Seat arrangement");
         Ok(())
     }
 }

--- a/native/core/src/events/tasks.rs
+++ b/native/core/src/events/tasks.rs
@@ -279,7 +279,7 @@ impl TaskBuilder {
     fn validate(&self) -> CoreResult<(), String> {
         if let Some(Some(percent)) = &self.progress_percent {
             if *percent > 100 {
-                return Err("Progress percent can’t be higher than 100".to_string());
+                return Err("Progress percent can’t be higher than 100".to_owned());
             }
         }
         Ok(())

--- a/native/core/src/models/attachments.rs
+++ b/native/core/src/models/attachments.rs
@@ -62,7 +62,7 @@ impl AttachmentsManager {
     pub async fn attachments(&self) -> Result<Vec<Attachment>> {
         let attachments = self
             .store
-            .get_list(&Attachment::index_for(self.event_id.to_owned()))
+            .get_list(&Attachment::index_for(self.event_id.clone()))
             .await?
             .filter_map(|e| match e {
                 AnyActerModel::Attachment(c) => Some(c),
@@ -110,12 +110,12 @@ impl AttachmentsManager {
 
     pub fn draft_builder(&self) -> AttachmentBuilder {
         AttachmentBuilder::default()
-            .on(self.event_id.to_owned())
+            .on(self.event_id.clone())
             .to_owned()
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     pub async fn save(&self) -> Result<ExecuteReference> {
@@ -154,7 +154,7 @@ impl Attachment {
 
     pub fn updater(&self) -> AttachmentUpdateBuilder {
         AttachmentUpdateBuilder::default()
-            .attachment(self.meta.event_id.to_owned())
+            .attachment(self.meta.event_id.clone())
             .to_owned()
     }
 
@@ -163,7 +163,7 @@ impl Attachment {
         store: &Store,
         redaction_model: Option<RedactedActerModel>,
     ) -> Result<Vec<ExecuteReference>> {
-        let belongs_to = self.inner.on.event_id.to_owned();
+        let belongs_to = self.inner.on.event_id.clone();
         trace!(event_id=?self.event_id(), ?belongs_to, "applying attachment");
 
         let manager = {
@@ -206,9 +206,9 @@ impl Attachment {
 impl ActerModel for Attachment {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            Attachment::index_for(self.inner.on.event_id.to_owned()),
-            IndexKey::ObjectHistory(self.inner.on.event_id.to_owned()),
-            IndexKey::RoomHistory(self.meta.room_id.to_owned()),
+            Attachment::index_for(self.inner.on.event_id.clone()),
+            IndexKey::ObjectHistory(self.inner.on.event_id.clone()),
+            IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
     fn event_meta(&self) -> &EventMeta {
@@ -277,8 +277,8 @@ pub struct AttachmentUpdate {
 impl ActerModel for AttachmentUpdate {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            IndexKey::ObjectHistory(self.inner.attachment.event_id.to_owned()),
-            IndexKey::RoomHistory(self.meta.room_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.attachment.event_id.clone()),
+            IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
 
@@ -287,7 +287,7 @@ impl ActerModel for AttachmentUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.attachment.event_id.to_owned()])
+        Some(vec![self.inner.attachment.event_id.clone()])
     }
 
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {

--- a/native/core/src/models/calendar/event.rs
+++ b/native/core/src/models/calendar/event.rs
@@ -174,7 +174,7 @@ impl ActerModel for CalendarEventUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.calendar_event.event_id.to_owned()])
+        Some(vec![self.inner.calendar_event.event_id.clone()])
     }
 }
 

--- a/native/core/src/models/comments.rs
+++ b/native/core/src/models/comments.rs
@@ -84,12 +84,12 @@ impl CommentsManager {
 
     pub fn draft_builder(&self) -> CommentBuilder {
         CommentBuilder::default()
-            .on(self.event_id.to_owned())
+            .on(self.event_id.clone())
             .to_owned()
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     pub async fn save(&self) -> Result<ExecuteReference> {
@@ -132,14 +132,15 @@ impl Comment {
 
     pub fn updater(&self) -> CommentUpdateBuilder {
         CommentUpdateBuilder::default()
-            .comment(self.meta.event_id.to_owned())
+            .comment(self.meta.event_id.clone())
             .to_owned()
     }
 
     pub fn reply_builder(&self) -> CommentBuilder {
+        let event_id = self.meta.event_id.clone();
         CommentBuilder::default()
-            .on(self.on.event_id.to_owned())
-            .reply_to(Some(self.meta.event_id.to_owned().into()))
+            .on(self.on.event_id.clone())
+            .reply_to(Some(event_id.into()))
             .to_owned()
     }
 
@@ -150,7 +151,7 @@ impl Comment {
             .as_ref()
             .map(|r| r.event_ids.clone())
             .unwrap_or_default();
-        references.push(self.inner.on.event_id.to_owned());
+        references.push(self.inner.on.event_id.clone());
         references
     }
 }
@@ -162,8 +163,8 @@ impl ActerModel for Comment {
             .into_iter()
             .map(Comment::index_for)
             .collect::<Vec<_>>();
-        indizes.push(IndexKey::ObjectHistory(self.inner.on.event_id.to_owned()));
-        indizes.push(IndexKey::RoomHistory(self.meta.room_id.to_owned()));
+        indizes.push(IndexKey::ObjectHistory(self.inner.on.event_id.clone()));
+        indizes.push(IndexKey::RoomHistory(self.meta.room_id.clone()));
         indizes
     }
 
@@ -248,8 +249,8 @@ pub struct CommentUpdate {
 impl ActerModel for CommentUpdate {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            IndexKey::ObjectHistory(self.inner.comment.event_id.to_owned()),
-            IndexKey::RoomHistory(self.meta.room_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.comment.event_id.clone()),
+            IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
     fn event_meta(&self) -> &EventMeta {
@@ -257,7 +258,7 @@ impl ActerModel for CommentUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.comment.event_id.to_owned()])
+        Some(vec![self.inner.comment.event_id.clone()])
     }
 
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {

--- a/native/core/src/models/invites.rs
+++ b/native/core/src/models/invites.rs
@@ -141,7 +141,7 @@ impl InvitationsManager {
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     pub async fn save(&self) -> Result<Vec<ExecuteReference>> {
@@ -154,7 +154,7 @@ impl InvitationsManager {
         let mut full_manager = MyInvitesManager::load(&self.store).await;
         let is_invited = self.stats.invited.contains(self.store.user_id());
         let was_changed = if is_invited {
-            full_manager.invited_to.insert(self.event_id.to_owned())
+            full_manager.invited_to.insert(self.event_id.clone())
         } else {
             full_manager.invited_to.remove(&self.event_id)
         };
@@ -196,7 +196,7 @@ impl ActerModel for ExplicitInvite {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
             ExplicitInvite::index_for(self.inner.to.event_id.clone()),
-            IndexKey::ObjectHistory(self.inner.to.event_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.to.event_id.clone()),
             IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
@@ -210,7 +210,7 @@ impl ActerModel for ExplicitInvite {
     }
 
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {
-        let belongs_to = self.inner.to.event_id.to_owned();
+        let belongs_to = self.inner.to.event_id.clone();
         trace!(event_id=?self.event_id(), ?belongs_to, "applying invite");
 
         let manager = {

--- a/native/core/src/models/news.rs
+++ b/native/core/src/models/news.rs
@@ -125,7 +125,7 @@ impl ActerModel for NewsEntryUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.news_entry.event_id.to_owned()])
+        Some(vec![self.inner.news_entry.event_id.clone()])
     }
 }
 

--- a/native/core/src/models/pins.rs
+++ b/native/core/src/models/pins.rs
@@ -51,7 +51,7 @@ impl ActerModel for Pin {
         vec![
             IndexKey::RoomSection(self.meta.room_id.clone(), SectionIndex::Pins),
             IndexKey::Section(SectionIndex::Pins),
-            IndexKey::ObjectHistory(self.meta.event_id.to_owned()),
+            IndexKey::ObjectHistory(self.meta.event_id.clone()),
             IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
@@ -113,8 +113,8 @@ pub struct PinUpdate {
 impl ActerModel for PinUpdate {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            IndexKey::ObjectHistory(self.inner.pin.event_id.to_owned()),
-            IndexKey::RoomHistory(self.meta.room_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.pin.event_id.clone()),
+            IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
 
@@ -127,7 +127,7 @@ impl ActerModel for PinUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.pin.event_id.to_owned()])
+        Some(vec![self.inner.pin.event_id.clone()])
     }
 }
 

--- a/native/core/src/models/reactions.rs
+++ b/native/core/src/models/reactions.rs
@@ -98,7 +98,7 @@ impl ReactionManager {
     }
 
     pub fn construct_like_event(&self) -> ReactionEventContent {
-        self.construct_reaction_event(LIKE_HEART.to_string())
+        self.construct_reaction_event(LIKE_HEART.to_owned())
     }
 
     pub fn construct_reaction_event(&self, key: String) -> ReactionEventContent {

--- a/native/core/src/models/reactions.rs
+++ b/native/core/src/models/reactions.rs
@@ -184,7 +184,7 @@ impl ReactionManager {
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     pub async fn save(&self) -> Result<ExecuteReference> {
@@ -227,7 +227,7 @@ impl Reaction {
         store: &Store,
         redaction_model: Option<RedactedActerModel>,
     ) -> Result<Vec<ExecuteReference>> {
-        let belongs_to = self.inner.relates_to.event_id.to_owned();
+        let belongs_to = self.inner.relates_to.event_id.clone();
         trace!(event_id=?self.event_id(), ?belongs_to, "applying reaction");
 
         let manager = {
@@ -266,8 +266,8 @@ impl Reaction {
 impl ActerModel for Reaction {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            Reaction::index_for(self.inner.relates_to.event_id.to_owned()),
-            IndexKey::ObjectHistory(self.inner.relates_to.event_id.to_owned()),
+            Reaction::index_for(self.inner.relates_to.event_id.clone()),
+            IndexKey::ObjectHistory(self.inner.relates_to.event_id.clone()),
             IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }

--- a/native/core/src/models/read_receipts.rs
+++ b/native/core/src/models/read_receipts.rs
@@ -87,7 +87,7 @@ impl ReadReceiptsManager {
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     async fn save(&self) -> Result<ExecuteReference> {
@@ -130,7 +130,7 @@ impl ReadReceipt {
     }
 
     async fn apply(&self, store: &Store) -> Result<Vec<ExecuteReference>> {
-        let belongs_to = self.inner.on.event_id.to_owned();
+        let belongs_to = self.inner.on.event_id.clone();
         trace!(event_id=?self.event_id(), ?belongs_to, "applying read receipt");
 
         let model = store.get(&belongs_to).await?;
@@ -155,8 +155,8 @@ impl ReadReceipt {
 impl ActerModel for ReadReceipt {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            ReadReceipt::index_for(self.inner.on.event_id.to_owned()),
-            IndexKey::ObjectHistory(self.inner.on.event_id.to_owned()),
+            ReadReceipt::index_for(self.inner.on.event_id.clone()),
+            IndexKey::ObjectHistory(self.inner.on.event_id.clone()),
             IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }

--- a/native/core/src/models/rsvp.rs
+++ b/native/core/src/models/rsvp.rs
@@ -75,13 +75,11 @@ impl RsvpManager {
     }
 
     pub fn draft_builder(&self) -> RsvpBuilder {
-        RsvpBuilder::default()
-            .to(self.event_id.to_owned())
-            .to_owned()
+        RsvpBuilder::default().to(self.event_id.clone()).to_owned()
     }
 
     pub fn update_key(&self) -> ExecuteReference {
-        Self::stats_field_for(self.event_id.to_owned())
+        Self::stats_field_for(self.event_id.clone())
     }
 
     pub async fn save(&self) -> Result<ExecuteReference> {
@@ -123,7 +121,7 @@ impl ActerModel for Rsvp {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
             Rsvp::index_for(self.inner.to.event_id.clone()),
-            IndexKey::ObjectHistory(self.inner.to.event_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.to.event_id.clone()),
             IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
@@ -137,7 +135,7 @@ impl ActerModel for Rsvp {
     }
 
     async fn execute(self, store: &Store) -> Result<Vec<ExecuteReference>> {
-        let belongs_to = self.inner.to.event_id.to_owned();
+        let belongs_to = self.inner.to.event_id.clone();
         trace!(event_id=?self.event_id(), ?belongs_to, "applying rsvp");
 
         let manager = {

--- a/native/core/src/models/status/mod.rs
+++ b/native/core/src/models/status/mod.rs
@@ -296,7 +296,7 @@ impl TryFrom<AnyStateEvent> for RoomStatus {
 
 impl ActerModel for RoomStatus {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
-        vec![IndexKey::RoomHistory(self.meta.room_id.to_owned())]
+        vec![IndexKey::RoomHistory(self.meta.room_id.clone())]
     }
 
     fn event_meta(&self) -> &EventMeta {

--- a/native/core/src/models/stories.rs
+++ b/native/core/src/models/stories.rs
@@ -111,8 +111,8 @@ pub struct StoryUpdate {
 impl ActerModel for StoryUpdate {
     fn indizes(&self, _user_id: &UserId) -> Vec<IndexKey> {
         vec![
-            IndexKey::ObjectHistory(self.inner.story_entry.event_id.to_owned()),
-            IndexKey::RoomHistory(self.meta.room_id.to_owned()),
+            IndexKey::ObjectHistory(self.inner.story_entry.event_id.clone()),
+            IndexKey::RoomHistory(self.meta.room_id.clone()),
         ]
     }
 
@@ -125,7 +125,7 @@ impl ActerModel for StoryUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.story_entry.event_id.to_owned()])
+        Some(vec![self.inner.story_entry.event_id.clone()])
     }
 }
 

--- a/native/core/src/models/tasks/task.rs
+++ b/native/core/src/models/tasks/task.rs
@@ -139,7 +139,7 @@ impl ActerModel for Task {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.task_list_id.event_id.to_owned()])
+        Some(vec![self.inner.task_list_id.event_id.clone()])
     }
 
     fn transition(&mut self, model: &AnyActerModel) -> Result<bool> {
@@ -199,7 +199,7 @@ impl ActerModel for TaskUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.task.event_id.to_owned()])
+        Some(vec![self.inner.task.event_id.clone()])
     }
 }
 
@@ -282,7 +282,7 @@ impl ActerModel for TaskSelfAssign {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.task.event_id.to_owned()])
+        Some(vec![self.inner.task.event_id.clone()])
     }
 }
 
@@ -356,7 +356,7 @@ impl ActerModel for TaskSelfUnassign {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.task.event_id.to_owned()])
+        Some(vec![self.inner.task.event_id.clone()])
     }
 }
 

--- a/native/core/src/models/tasks/task_list.rs
+++ b/native/core/src/models/tasks/task_list.rs
@@ -57,7 +57,7 @@ impl TaskList {
 
     pub fn updater(&self) -> TaskListUpdateBuilder {
         TaskListUpdateBuilder::default()
-            .task_list(self.meta.event_id.to_owned())
+            .task_list(self.meta.event_id.clone())
             .to_owned()
     }
 }
@@ -153,7 +153,7 @@ impl ActerModel for TaskListUpdate {
     }
 
     fn belongs_to(&self) -> Option<Vec<OwnedEventId>> {
-        Some(vec![self.inner.task_list.event_id.to_owned()])
+        Some(vec![self.inner.task_list.event_id.clone()])
     }
 }
 

--- a/native/core/src/spaces.rs
+++ b/native/core/src/spaces.rs
@@ -370,7 +370,7 @@ impl CoreClient {
 
             let me = SpaceRelation {
                 target_type,
-                room_id: target.to_owned(),
+                room_id: target.clone(),
                 suggested: false,
                 via: original.content.via.clone(),
             };
@@ -436,19 +436,19 @@ impl CoreClient {
                 .unwrap_or_else(|| target.to_string());
             let me = SpaceRelation {
                 target_type,
-                room_id: target.to_owned(),
+                room_id: target.clone(),
                 suggested: original.content.suggested,
                 via: original.content.via.clone(),
             };
             children.push((order, me))
         }
 
-        children.sort_by_key(|(x, _)| x.to_owned());
+        children.sort_by_key(|(k, _)| k.clone());
 
         Ok(SpaceRelations {
             main_parent,
             other_parents: parents,
-            children: children.into_iter().map(|(_, c)| c).collect(),
+            children: children.into_iter().map(|(_, r)| r).collect(),
         })
     }
 }

--- a/native/core/src/store.rs
+++ b/native/core/src/store.rs
@@ -225,7 +225,7 @@ impl Store {
         let key = mdl.event_id().to_owned();
         let user_id = self.user_id();
         let room_id = mdl.room_id().to_owned();
-        let keys_changed = vec![key.to_owned()];
+        let keys_changed = vec![key.clone()];
         trace!(user = ?user_id, ?key, "saving");
         let mut new_indizes = mdl.indizes(user_id);
         let mut removed_indizes = Vec::new();
@@ -313,7 +313,7 @@ impl Store {
 
     pub async fn clear_room(&self, room_id: &OwnedRoomId) -> Result<Vec<ExecuteReference>> {
         info!(?room_id, "clearing room");
-        let idx = IndexKey::RoomModels(room_id.to_owned());
+        let idx = IndexKey::RoomModels(room_id.clone());
         let mut total_changed = {
             let mut dirty = self.dirty.lock()?; // hold the lock
             let mut total_changed = Vec::new();

--- a/native/core/src/templates/values.rs
+++ b/native/core/src/templates/values.rs
@@ -18,8 +18,8 @@ impl UserValue {
         let user_id = c
             .user_id()
             .ok_or(Error::Remap(
-                "user".to_string(),
-                "missing user_id".to_string(),
+                "user".to_owned(),
+                "missing user_id".to_owned(),
             ))?
             .to_string();
         let display_name = match c.account().get_display_name().await {


### PR DESCRIPTION
This PR is just only mechanical transition.
- Replace `.to_owned()` with proper `.clone()`
- Replace `.to_string()` with proper `.clone()` or `.to_owned()`
- Replace `.to_string()` with `ToString::to_string`