### PR TITLE
Pass text style to non-html text messages, too

### DIFF
--- a/app/lib/features/chat_ng/widgets/events/text_message_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/text_message_event.dart
@@ -87,6 +87,11 @@ class _TextMessageEventState extends ConsumerState<TextMessageEvent> {
             ? colorScheme.onSurface.withValues(alpha: 0.5)
             : colorScheme.onSurface.withValues(alpha: 0.9);
 
+    final textStyle = textTheme.bodySmall?.copyWith(
+      color: color,
+      overflow: widget.isNotice ? TextOverflow.ellipsis : null,
+    );
+
     final html = bodyFormatted;
     if (html != null) {
       return RenderHtml(
@@ -94,10 +99,7 @@ class _TextMessageEventState extends ConsumerState<TextMessageEvent> {
         roomId: widget.roomId,
         shrinkToFit: true,
         maxLines: widget.isReply ? 2 : null,
-        defaultTextStyle: textTheme.bodySmall?.copyWith(
-          color: color,
-          overflow: widget.isNotice ? TextOverflow.ellipsis : null,
-        ),
+        defaultTextStyle: textStyle,
       );
     }
 
@@ -107,6 +109,7 @@ class _TextMessageEventState extends ConsumerState<TextMessageEvent> {
       roomId: widget.roomId,
       shrinkToFit: true,
       maxLines: widget.isReply ? 2 : null,
+      defaultTextStyle: textStyle,
     );
   }
 }

--- a/app/lib/features/chat_ng/widgets/events/text_message_event.dart
+++ b/app/lib/features/chat_ng/widgets/events/text_message_event.dart
@@ -50,20 +50,15 @@ class _TextMessageEventState extends ConsumerState<TextMessageEvent> {
             ? _buildEmojiMessage(context)
             : _buildTextMessage(context);
 
-    if (widget.isReply) {
+    final repliedTo = widget.repliedTo;
+    if (widget.isReply || repliedTo == null) {
       // we return the widget without any additional reply data
       return inner;
     }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (widget.repliedTo != null) ...[
-          widget.repliedTo!,
-          const SizedBox(height: 10),
-        ],
-        inner,
-      ],
+      children: [repliedTo, const SizedBox(height: 10), inner],
     );
   }
 


### PR DESCRIPTION
fixes #3057  .

But unlike what that report stated, the problem wasn't with messages from others, but messages without HTML didn't get the same font settings passed down: 9a7f8f6ecbd8d3ff72022ded59398c2ff627c537

Additionally, f62dd9d7776e64c2cc8324f360a6d7abaf85d5f1 fixes unnecessary columns (with only one item) if we don't have a reply to show either.

Before:

![Bildschirmfoto_2025-06-04_11-44-47](https://github.com/user-attachments/assets/56aa6d81-2507-4742-910c-105864120d18)


After:

![after](https://github.com/user-attachments/assets/b796a925-fd22-470b-867b-56b2193fed0b)


It's subtle but the font on the left isn't bold anymore now.
