### PR TITLE
Fix message with emoji rendering issue

### DIFF
--- a/app/lib/features/chat_ng/utils.dart
+++ b/app/lib/features/chat_ng/utils.dart
@@ -74,13 +74,29 @@ const List<MaterialAccentColor> chatBubbleDisplayNameColors =
 
 // inspired by https://github.com/mathiasbynens/emoji-regex under MIT license
 final _emojiRegex = RegExp(
-  r'^(\p{RI}{2}|(?![#*\d](?!\uFE0F?\u20E3))\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?)(?:\u200D\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?))*|\s)+$',
+  r'(\p{RI}{2}|(?![#*\d](?!\uFE0F?\u20E3))\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?)(?:\u200D\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?))*)',
   unicode: true,
-  multiLine: true,
 );
 
 bool isOnlyEmojis(String text) {
-  return _emojiRegex.hasMatch(text.trim());
+  final trimmed = text.trim();
+  if (trimmed.isEmpty) return false;
+
+  // Remove all emoji matches from the text
+  String textWithoutEmojis = trimmed;
+  final matches = _emojiRegex.allMatches(trimmed);
+
+  // Remove emoji matches in reverse order to maintain correct indices
+  final sortedMatches =
+      matches.toList()..sort((a, b) => b.start.compareTo(a.start));
+  for (final match in sortedMatches) {
+    textWithoutEmojis =
+        textWithoutEmojis.substring(0, match.start) +
+        textWithoutEmojis.substring(match.end);
+  }
+
+  // After removing all emojis, only whitespace should remain for emoji-only text
+  return textWithoutEmojis.trim().isEmpty;
 }
 
 extension ColorAsCssString on Color {

--- a/app/test/features/chat_ng/utils_test.dart
+++ b/app/test/features/chat_ng/utils_test.dart
@@ -45,5 +45,27 @@ void main() {
       expect(isOnlyEmojis('👨‍💻'), true); // Person with profession
       expect(isOnlyEmojis('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), true); // Regional indicator
     });
+
+    test(
+      'should return false for multiline text with multiple whitespace characters',
+      () {
+        expect(
+          isOnlyEmojis('Weekly Product Update 🚀 \n\r\nHello dear community!'),
+          false,
+        );
+        expect(
+          isOnlyEmojis('Line 1\n\r\nLine 2\r\n\tIndented line\n\r\nFinal line'),
+          false,
+        );
+        expect(
+          isOnlyEmojis('\n\r\t  Text with various whitespace  \t\r\n'),
+          false,
+        );
+        expect(
+          isOnlyEmojis('🚀\n\r\nActual text content\r\n\t- Bullet point'),
+          false,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Fixes https://github.com/acterglobal/a3/issues/3095

Update `_emojiRegex` and `isOnlyEmojis` code logic to fix this issue.

additional unit test to ensure that it will work with text with emoji and \n\r\t characters in future. Doesn't affect older scenarios as all the older test cases gets passed with new logic as well.

![Emoji message render issue](https://github.com/user-attachments/assets/7cca6396-503d-4387-9c42-c503c19ef36b)
