### PR TITLE
Can able to select space on boost.

### DIFF
--- a/.changes/3098-able-to-select-space-boost.md
+++ b/.changes/3098-able-to-select-space-boost.md
@@ -1,0 +1,1 @@
+- [Fix] : Now, user can select space from action on boost creation.

--- a/app/lib/features/news/providers/news_post_editor_providers.dart
+++ b/app/lib/features/news/providers/news_post_editor_providers.dart
@@ -100,7 +100,7 @@ class NewsStateNotifier extends StateNotifier<NewsPostState> {
   Future<void> selectSpaceToShare(BuildContext context) async {
     final selectedSpaceId = await selectSpaceDrawer(
       context: context,
-      canCheck: (m) => m?.canString('CanPostNews') == true,
+      canCheck: (m) => m?.canString('CanInvite') == true,
     );
     RefDetails? refDetails;
     if (selectedSpaceId != null) {

--- a/app/lib/features/news/providers/news_post_editor_providers.dart
+++ b/app/lib/features/news/providers/news_post_editor_providers.dart
@@ -98,7 +98,10 @@ class NewsStateNotifier extends StateNotifier<NewsPostState> {
   }
 
   Future<void> selectSpaceToShare(BuildContext context) async {
-    final selectedSpaceId = await selectSpaceDrawer(context: context);
+    final selectedSpaceId = await selectSpaceDrawer(
+      context: context,
+      canCheck: (m) => m?.canString('CanPostNews') == true,
+    );
     RefDetails? refDetails;
     if (selectedSpaceId != null) {
       final selectedSpace = await ref.read(


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3-meta/issues/1019

This PR addresses the space section action issue now, user can select space for boost action.

**_Note : There was a permission issue, it was there earlier, but it was removed somehow. I’ve re-added the permission now, and users can select the space to create a Boost._**

**Reference video :** 

https://github.com/user-attachments/assets/fd55ce0e-6735-4042-b5d6-6553fbd90562