### PR TITLE
Simplify the emoji check to be only regexp again

### DIFF
--- a/app/lib/features/chat_ng/utils.dart
+++ b/app/lib/features/chat_ng/utils.dart
@@ -74,30 +74,11 @@ const List<MaterialAccentColor> chatBubbleDisplayNameColors =
 
 // inspired by https://github.com/mathiasbynens/emoji-regex under MIT license
 final _emojiRegex = RegExp(
-  r'(\p{RI}{2}|(?![#*\d](?!\uFE0F?\u20E3))\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?)(?:\u200D\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?))*)',
+  r'^(\p{RI}{2}|(?![#*\d](?!\uFE0F?\u20E3))\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?)(?:\u200D\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?))*|\s)+$',
   unicode: true,
 );
 
-bool isOnlyEmojis(String text) {
-  final trimmed = text.trim();
-  if (trimmed.isEmpty) return false;
-
-  // Remove all emoji matches from the text
-  String textWithoutEmojis = trimmed;
-  final matches = _emojiRegex.allMatches(trimmed);
-
-  // Remove emoji matches in reverse order to maintain correct indices
-  final sortedMatches =
-      matches.toList()..sort((a, b) => b.start.compareTo(a.start));
-  for (final match in sortedMatches) {
-    textWithoutEmojis =
-        textWithoutEmojis.substring(0, match.start) +
-        textWithoutEmojis.substring(match.end);
-  }
-
-  // After removing all emojis, only whitespace should remain for emoji-only text
-  return textWithoutEmojis.trim().isEmpty;
-}
+bool isOnlyEmojis(String text) => _emojiRegex.hasMatch(text.trim());
 
 extension ColorAsCssString on Color {
   String toCssString() =>

--- a/app/test/features/chat_ng/utils_test.dart
+++ b/app/test/features/chat_ng/utils_test.dart
@@ -27,6 +27,21 @@ void main() {
       expect(isOnlyEmojis('Hello 😊 World'), false);
     });
 
+    test(
+      'should return false for mulitline text with emojis and plaintext',
+      () {
+        expect(isOnlyEmojis('Hello \n😊'), false);
+        expect(isOnlyEmojis('😊\n World'), false);
+        expect(isOnlyEmojis('Hello\n😊👍🎉\nWorld'), false);
+      },
+    );
+
+    test('should return true for mulitline with only emojis', () {
+      expect(isOnlyEmojis('👍🎉 \n😊'), true);
+      expect(isOnlyEmojis('😊\n 👍🎉'), true);
+      expect(isOnlyEmojis('👍🎉\n😊👍🎉\n\r\t  👍🎉'), true);
+    });
+
     test('should return false for plain text', () {
       expect(isOnlyEmojis('Hello'), false);
       expect(isOnlyEmojis('123'), false);


### PR DESCRIPTION
improves the fix of #3096 by going back to a simple regexp that passes all our tests.

also added more tests that are closer to the bug we had: a multiline text with single lines that only contain emoji.