### PR TITLE
Fixing the jumping around of the chat editor while typing

### DIFF
--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -38,7 +38,6 @@ class ChatEditor extends ConsumerStatefulWidget {
 
 class _ChatEditorState extends ConsumerState<ChatEditor> {
   EditorState textEditorState = EditorState.blank();
-  // late EditorScrollController scrollController;
   StreamSubscription<EditorTransactionValue>? _updateListener;
   final ValueNotifier<bool> _isInputEmptyNotifier = ValueNotifier(true);
   Timer? _debounceTimer;
@@ -46,12 +45,10 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
   @override
   void initState() {
     super.initState();
-    // scrollController = EditorScrollController(editorState: textEditorState);
     _updateListener?.cancel();
     // listener for editor input state
     _updateListener = textEditorState.transactionStream.listen((data) {
       _editorUpdate(data.$2);
-      // _updateContentHeight();
     });
 
     WidgetsBinding.instance.addPostFrameCallback((_) => _loadDraft());
@@ -285,7 +282,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
         shrinkWrap: false,
         disableAutoScroll: false,
         editorState: textEditorState,
-        // scrollController: scrollController,
         maxHeight: MediaQuery.sizeOf(context).height * 0.2,
         minHeight: 24,
         onChanged: (body, html) {

--- a/app/test/toolkit/html_editor/html_editor_test.dart
+++ b/app/test/toolkit/html_editor/html_editor_test.dart
@@ -155,10 +155,7 @@ void main() {
 
     testWidgets('renders with HTML content', (tester) async {
       final htmlContent = '<p>Hello <strong>World</strong></p>';
-      final document = ActerDocumentHelpers.parse(
-        'Hello World',
-        htmlContent: htmlContent,
-      );
+      final document = defaultHtmlCodec.decode(htmlContent);
       final editorState = EditorState(document: document);
 
       await tester.pumpWidget(
@@ -205,11 +202,15 @@ void main() {
       final docNode = editorState.getNodeAtPath([0]);
       if (docNode != null) {
         // add multiple lines to force height increase
-        transaction.replaceText(
-          docNode,
-          0,
-          0,
-          'Line 1\nLine 2\nLine 3\nLine 4\nLine 5',
+        transaction.insertNodes(
+          [0],
+          [
+            paragraphNode(text: 'Line 1'),
+            paragraphNode(text: 'Line 2'),
+            paragraphNode(text: 'Line 3'),
+            paragraphNode(text: 'Line 4'),
+            paragraphNode(text: 'Line 5'),
+          ],
         );
         editorState.apply(transaction);
       }
@@ -249,12 +250,9 @@ void main() {
       final docNode = editorState.getNodeAtPath([0]);
       if (docNode != null) {
         // Add many lines to try to exceed max height
-        transaction.replaceText(
-          docNode,
+        transaction.insertNodes([
           0,
-          0,
-          List.generate(20, (i) => 'Line $i').join('\n'),
-        );
+        ], List.generate(20, (i) => paragraphNode(text: 'Line $i')));
         editorState.apply(transaction);
       }
 
@@ -291,9 +289,7 @@ void main() {
         transaction.replaceText(docNode, 0, 0, 'Some text');
         editorState.apply(transaction);
 
-        final clearTransaction = editorState.transaction;
-        clearTransaction.replaceText(docNode, 0, 9, '');
-        editorState.apply(clearTransaction);
+        editorState.clear();
       }
 
       // wait for height animation


### PR DESCRIPTION
extracted from #3056 . Fixes #3068 .


https://github.com/user-attachments/assets/3978db1e-8ff5-4888-8c0a-ac8d315deaf1



Unfortunately, as the video shows, it does re-introduce the problem of not properly resizing on wrapping inputs.