### PR TITLE
Fix bug in github CI

### DIFF
--- a/.github/workflows/check-native.yml
+++ b/.github/workflows/check-native.yml
@@ -61,7 +61,9 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
       - name: Test
         run: cargo llvm-cov --lcov --output-path lcov.info nextest -p ${{matrix.package}}
 

--- a/.github/workflows/check-rust-integration-tests.yml
+++ b/.github/workflows/check-rust-integration-tests.yml
@@ -65,7 +65,9 @@ jobs:
         name: "Setup mold linker"
 
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
 
       - name: run cargo integration tests
         env:


### PR DESCRIPTION
I am getting this error from github CI a few hours ago.
```
info: host platform: x86_64_linux
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
Error: Process completed with exit code 22.
```
This error was reported from [here](https://github.com/taiki-e/install-action/issues/1005) too.
Will fix it.