### PR TITLE
Editor editable fix

### DIFF
--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -102,6 +102,16 @@ extension ActerEditorStateHelpers on EditorState {
     }
 
     apply(t);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      updateSelectionWithReason(
+        Selection.single(
+          path: document.root.children.last.path,
+          startOffset: document.root.children.last.delta?.length ?? 0,
+        ),
+        reason: SelectionUpdateReason.uiEvent,
+      );
+    });
   }
 
   /// clear the editor text with selection

--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -102,16 +102,6 @@ extension ActerEditorStateHelpers on EditorState {
     }
 
     apply(t);
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      updateSelectionWithReason(
-        Selection.single(
-          path: document.root.children.last.path,
-          startOffset: document.root.children.last.delta?.length ?? 0,
-        ),
-        reason: SelectionUpdateReason.uiEvent,
-      );
-    });
   }
 
   /// clear the editor text with selection

--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -102,6 +102,13 @@ extension ActerEditorStateHelpers on EditorState {
     }
 
     apply(t);
+
+    t = transaction;
+    t.afterSelection = Selection.single(
+      path: document.root.children.last.path,
+      startOffset: document.root.children.last.delta?.length ?? 0,
+    );
+    apply(t);
   }
 
   /// clear the editor text with selection

--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -89,6 +89,7 @@ extension ActerEditorStateHelpers on EditorState {
 
     if (body.isNotEmpty) {
       final newDoc = defaultHtmlCodec.decode(body);
+
       if (newDoc.root.children.isNotEmpty) {
         t.insertNodes([0], newDoc.root.children);
         inserted = true;
@@ -97,7 +98,7 @@ extension ActerEditorStateHelpers on EditorState {
 
     if (!inserted) {
       // per fallback we add one empty paragraph
-      t.insertNode([0, 0], paragraphNode());
+      t.insertNode([0], paragraphNode());
     }
 
     apply(t);
@@ -108,6 +109,8 @@ extension ActerEditorStateHelpers on EditorState {
     if (!document.isEmpty) {
       final t = transaction;
       t.deleteNodes(document.root.children); // clear the page
+      // add empty paragraph to make sure there is a valid node selection
+      t.insertNode([0], paragraphNode());
       apply(t);
 
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -98,6 +98,16 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     if (body.isEmpty) return;
 
     textEditorState.replaceContent(body, msgContent.formattedBody());
+    final docChildren = textEditorState.document.root.children;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      textEditorState.updateSelectionWithReason(
+        Selection.single(
+          path: docChildren.last.path,
+          startOffset: docChildren.last.delta?.length ?? 0,
+        ),
+        reason: SelectionUpdateReason.uiEvent,
+      );
+    });
   }
 
   void _editorUpdate(Transaction data) {

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -98,16 +98,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     if (body.isEmpty) return;
 
     textEditorState.replaceContent(body, msgContent.formattedBody());
-    final docChildren = textEditorState.document.root.children;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      textEditorState.updateSelectionWithReason(
-        Selection.single(
-          path: docChildren.last.path,
-          startOffset: docChildren.last.delta?.length ?? 0,
-        ),
-        reason: SelectionUpdateReason.uiEvent,
-      );
-    });
   }
 
   void _editorUpdate(Transaction data) {

--- a/app/test/toolkit/html_editor/editor_state_helpers_test.dart
+++ b/app/test/toolkit/html_editor/editor_state_helpers_test.dart
@@ -299,8 +299,9 @@ void main() {
         final editorState = EditorState(document: initialDocument);
 
         editorState.replaceContentHTML('');
-
-        expect(editorState.document.root.children.length, equals(0));
+        // should only be one empty paragraph
+        expect(editorState.document.root.children.length, equals(1));
+        expect(editorState.intoHtml(), equals('<br>'));
       });
 
       test('completely replaces existing content', () {
@@ -345,8 +346,9 @@ void main() {
         expect(editorState.document.root.children.length, equals(2));
 
         editorState.clear();
-
-        expect(editorState.document.root.children.length, equals(0));
+        // should only be one empty paragraph
+        expect(editorState.document.root.children.length, equals(1));
+        expect(editorState.intoHtml(), equals('<br>'));
       });
 
       test('does nothing when document is already empty', () async {
@@ -386,7 +388,9 @@ void main() {
 
         editorState.clear();
 
-        expect(editorState.document.root.children.length, equals(0));
+        // should only be one empty paragraph
+        expect(editorState.document.root.children.length, equals(1));
+        expect(editorState.intoHtml(), equals('<br>'));
       });
     });
 
@@ -432,7 +436,9 @@ void main() {
 
         // Clear content
         editorState.clear();
-        expect(editorState.document.root.children.length, equals(0));
+        // should only be one empty paragraph
+        expect(editorState.document.root.children.length, equals(1));
+        expect(editorState.intoHtml(), equals('<br>'));
       });
     });
   });


### PR DESCRIPTION
- Recent changes of editor from #3077 makes editor un-editable in edit/reply states. This PR fixes those issues.

### BEFORE CHANGES:

As you can see I cannot tap at editor to compose message after clearing edit/reply state. Because ```clear()``` fn delete all nodes for editor to be select any node afterwards...

https://github.com/user-attachments/assets/49121c23-80d8-4081-815b-ec069ad0f2f7

### AFTER CHANGES:

Now having a valid empty node, the editor has editable area as well as cursor fixed at the content selection end

https://github.com/user-attachments/assets/c328c13a-d911-4107-a088-515b50061dc8

