### PR TITLE
Message draft fixes

### DIFF
--- a/.changes/3113_message-draft-fixes.md
+++ b/.changes/3113_message-draft-fixes.md
@@ -1,0 +1,1 @@
+- [fix] Chat Editor: bug fixes over message draft not saving and editor cursor selection.

--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -111,14 +111,21 @@ extension ActerEditorStateHelpers on EditorState {
     apply(t);
   }
 
-  /// clear the editor text with selection
-  void clear() async {
+  /// clear the editor text
+  void clear([bool keepSelection = false]) async {
     if (!document.isEmpty) {
       final t = transaction;
       t.deleteNodes(document.root.children); // clear the page
       // add empty paragraph to make sure there is a valid node selection
       t.insertNode([0], paragraphNode());
       apply(t);
+
+      // keep the cursor selection
+      if (keepSelection) {
+        final t = transaction;
+        t.afterSelection = Selection.single(path: [0], startOffset: 0);
+        apply(t);
+      }
     }
   }
 

--- a/app/lib/common/toolkit/html_editor/html_editor.dart
+++ b/app/lib/common/toolkit/html_editor/html_editor.dart
@@ -119,13 +119,6 @@ extension ActerEditorStateHelpers on EditorState {
       // add empty paragraph to make sure there is a valid node selection
       t.insertNode([0], paragraphNode());
       apply(t);
-
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        updateSelectionWithReason(
-          Selection.single(path: [0], startOffset: 0, endOffset: 0),
-          reason: SelectionUpdateReason.uiEvent,
-        );
-      });
     }
   }
 

--- a/app/lib/features/chat_ng/models/chat_editor_state.dart
+++ b/app/lib/features/chat_ng/models/chat_editor_state.dart
@@ -20,7 +20,7 @@ class ChatEditorState {
     MessageAction? actionType,
   }) {
     return ChatEditorState(
-      selectedMsgItem: selectedMsgItem ?? this.selectedMsgItem,
+      selectedMsgItem: selectedMsgItem,
       actionType: actionType ?? this.actionType,
     );
   }

--- a/app/lib/features/chat_ng/utils.dart
+++ b/app/lib/features/chat_ng/utils.dart
@@ -13,7 +13,6 @@ Future<void> saveMsgDraft(
   final chat = await ref.read(chatProvider(roomId).future);
   final chatEditorState = ref.read(chatEditorStateProvider);
   final messageId = chatEditorState.selectedMsgItem?.eventId();
-
   if (chat != null) {
     if (messageId != null) {
       if (chatEditorState.isEditing) {

--- a/app/lib/features/chat_ng/utils.dart
+++ b/app/lib/features/chat_ng/utils.dart
@@ -14,12 +14,15 @@ Future<void> saveMsgDraft(
   final chatEditorState = ref.read(chatEditorStateProvider);
   final messageId = chatEditorState.selectedMsgItem?.eventId();
 
-  if (chat != null && messageId != null) {
-    if (chatEditorState.isEditing) {
-      await chat.saveMsgDraft(text, htmlText, 'edit', messageId);
-    } else if (chatEditorState.isReplying) {
-      await chat.saveMsgDraft(text, htmlText, 'reply', messageId);
+  if (chat != null) {
+    if (messageId != null) {
+      if (chatEditorState.isEditing) {
+        await chat.saveMsgDraft(text, htmlText, 'edit', messageId);
+      } else if (chatEditorState.isReplying) {
+        await chat.saveMsgDraft(text, htmlText, 'reply', messageId);
+      }
     } else {
+      // no message id, create a unreferenced draft
       await chat.saveMsgDraft(text, htmlText, 'new', null);
     }
   }

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -278,7 +278,6 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
     return Padding(
       padding: const EdgeInsets.only(top: 15),
       child: HtmlEditor(
-        key: Key('html-editor-${widget.roomId}'),
         footer: null,
         // if provided, will activate mentions
         roomId: widget.roomId,

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor.dart
@@ -87,10 +87,14 @@ class _ChatEditorState extends ConsumerState<ChatEditor> {
       if (next.isReplying &&
           (next.actionType != prev?.actionType ||
               next.selectedMsgItem != prev?.selectedMsgItem)) {
-        textEditorState.updateSelectionWithReason(
-          null,
-          reason: SelectionUpdateReason.uiEvent,
+        // set selection of editor for composing
+        final t = textEditorState.transaction;
+        t.afterSelection = Selection.single(
+          path: textEditorState.document.root.children.last.path,
+          startOffset:
+              textEditorState.document.root.children.last.delta?.length ?? 0,
         );
+        textEditorState.apply(t);
         saveMsgDraft(body, bodyHtml, widget.roomId, ref);
       }
     });

--- a/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_actions_preview.dart
+++ b/app/lib/features/chat_ng/widgets/chat_editor/chat_editor_actions_preview.dart
@@ -1,7 +1,6 @@
 import 'package:acter/common/providers/room_providers.dart';
 import 'package:acter/common/toolkit/html_editor/html_editor.dart';
 import 'package:acter/features/chat_ng/providers/chat_room_messages_provider.dart';
-import 'package:acter/features/chat_ng/utils.dart';
 import 'package:acter/features/chat_ng/widgets/events/file_message_event.dart';
 import 'package:acter/features/chat_ng/widgets/events/image_message_event.dart';
 import 'package:acter/features/chat_ng/widgets/events/text_message_event.dart';
@@ -89,22 +88,20 @@ class ChatEditorActionsPreview extends ConsumerWidget {
         GestureDetector(
           key: closePreviewKey,
           onTap: () async {
-            final isEdit = ref.read(chatEditorStateProvider).isEditing;
             final notifier = ref.read(chatEditorStateProvider.notifier);
-
-            notifier.unsetActions();
+            final isEdit = ref.read(chatEditorStateProvider).isEditing;
             if (isEdit) {
               textEditorState.clear();
-            } else {
-              final body = textEditorState.intoMarkdown();
-              final bodyHtml = textEditorState.intoHtml();
-
-              await saveMsgDraft(body, bodyHtml, roomId, ref);
-              textEditorState.updateSelectionWithReason(
-                Selection.single(path: [0], startOffset: body.length - 1),
-                reason: SelectionUpdateReason.uiEvent,
-              );
             }
+            notifier.unsetActions();
+            // clear the text, but we still keep selection
+            final t = textEditorState.transaction;
+            final docChildren = textEditorState.document.root.children;
+            t.afterSelection = Selection.single(
+              path: docChildren.last.path,
+              startOffset: docChildren.last.delta?.length ?? 0,
+            );
+            textEditorState.apply(t);
           },
           child: const Icon(Atlas.xmark_circle),
         ),


### PR DESCRIPTION
# DESCRIPTION:

- It has been observed that composer draft is unusual in its states because of some issues regarding it saving procedure. This PR attempts to fix those, as well as some reducing some unnecessary calls over draft to save, along with selection fixes. Most of the changes explanation have been commented out, while some can be also visually reviewed. But the best approach is **_REVIEW BY COMMIT_**.

1. [dc342e7](https://github.com/acterglobal/a3/pull/3113/commits/dc342e7e981f088b94a5f938269f1b1f32978a86) `new` draft not saving fixes:

### BEFORE:

https://github.com/user-attachments/assets/495c3043-416e-4d83-b07b-d18687de4340

### AFTER:

https://github.com/user-attachments/assets/d7d4f9f8-6a25-40e6-ab90-645ae9a61f55

2. [a0a8603](https://github.com/acterglobal/a3/pull/3113/commits/a0a8603b50151cb4b400aa306a1645329d0a7a2a) explained in [comment](https://github.com/acterglobal/a3/pull/3113/files#r2157612910) about dart classic `copyWith()` bug on nullable objects.

3. [da86317](https://github.com/acterglobal/a3/pull/3113/commits/da86317d486af5f70a7499024a0ce90eca367fed) Selection fixes.

### BEFORE: see how going over room would show selection cursor on empty draft which is unintended for desktop.

https://github.com/user-attachments/assets/d5797e8c-a9ce-496c-907d-845c030eb301

### AFTER:  it'd not set selection when draft is empty :)

https://github.com/user-attachments/assets/b349cfcb-a5ae-450d-b7a9-8a9a3225fe69

4. ## COMPLETE PREVIEW showing the fixes over draft and selection states.

https://github.com/user-attachments/assets/6f0147f3-618a-4c71-87b8-20e18c1f0378

