### PR TITLE
beta version tag removed from activity screen

### DIFF
--- a/.changes/3117-beta-tag-removed-from-activities.md
+++ b/.changes/3117-beta-tag-removed-from-activities.md
@@ -1,0 +1,1 @@
+- [Fixes] : The beta tag has been removed because all activities of user are now fully implemented and covered.

--- a/.changes/3117-beta-tag-removed-from-activities.md
+++ b/.changes/3117-beta-tag-removed-from-activities.md
@@ -1,1 +1,1 @@
-- [Fixes] : The beta tag has been removed because all activities of user are now fully implemented and covered.
+- [Fixes] : The beta tag has been removed because all activities of user are now fully implemented and covered. 

--- a/app/lib/features/activities/widgets/space_activities_section/space_activities_section_widget.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/space_activities_section_widget.dart
@@ -1,5 +1,3 @@
-import 'package:acter/common/actions/open_link.dart';
-import 'package:acter/common/widgets/info_widget.dart';
 import 'package:acter/features/activities/providers/activities_providers.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/activity_date_item_widget.dart';
 import 'package:acter/features/space/widgets/space_sections/section_header.dart';
@@ -18,20 +16,6 @@ Widget? buildSpaceActivitiesSectionWidget(BuildContext context, WidgetRef ref) {
         title: L10n.of(context).spaceActivities,
         showSectionBg: false,
         isShowSeeAllButton: false,
-      ),
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: InfoWidget(
-          title: L10n.of(context).betaVersion,
-          subTitle: L10n.of(context).spaceAcitivitiesBetaInfo,
-          trailing: const Icon(Icons.arrow_forward_ios),
-          onTap:
-              () => openLink(
-                ref: ref,
-                target: 'https://github.com/acterglobal/a3/issues/2597',
-                lang: L10n.of(context),
-              ),
-        ),
       ),
       ListView.builder(
         padding: const EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
Fixes, https://github.com/acterglobal/a3/issues/3116

- In this PR, the beta tag version is removed because all user activities are now fully covered.

### Reference image: 

![Screenshot 2025-06-20 at 1 09 44 PM](https://github.com/user-attachments/assets/78a1b01c-74c8-4509-a0e5-12baa862e1ea)
