### PR TITLE
mention read api

### DIFF
--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1100,9 +1100,10 @@ object TimelineEventItem {
     fn space_parent_content() -> Option<SpaceParentContent>;
 
     /// Whether the whole room is mentioned.
-    fn mentioned_room() -> bool;
+    fn room_mentioned() -> bool;
 
     /// The list of mentioned users.
+    /// Available only when sender didn't mention the whole room
     fn mentioned_users() -> Vec<string>;
 
     /// original event id, if this msg is reply to another msg

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1103,7 +1103,7 @@ object TimelineEventItem {
     fn room_mentioned() -> bool;
 
     /// The list of mentioned users.
-    /// Available only when sender didn't mention the whole room
+    /// Available only when sender didn’t mention the whole room
     fn mentioned_users() -> Vec<string>;
 
     /// original event id, if this msg is reply to another msg
@@ -4287,7 +4287,7 @@ object BackupManager {
     /// Open the existing secret store using the given key and import the keys
     fn recover(secret: string) -> Future<Result<bool>>;
 
-    /// the backup key as it was stored last, might be empty if there isn't any stored
+    /// the backup key as it was stored last, might be empty if there isn’t any stored
     fn stored_enc_key() -> Future<Result<OptionString>>;
 
     /// When was the key stored as unix timestamp. 0 if nothing was found

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -1099,6 +1099,12 @@ object TimelineEventItem {
     /// covers m.space.parent
     fn space_parent_content() -> Option<SpaceParentContent>;
 
+    /// Whether the whole room is mentioned.
+    fn mentioned_room() -> bool;
+
+    /// The list of mentioned users.
+    fn mentioned_users() -> Vec<string>;
+
     /// original event id, if this msg is reply to another msg
     fn in_reply_to_id() -> Option<string>;
 

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -476,7 +476,7 @@ impl TimelineEventItem {
 
     pub fn mentioned_users(&self) -> Vec<String> {
         self.mentions.as_ref().map_or_else(
-            || vec![],
+            || Vec::new(),
             |m| m.user_ids.iter().map(ToString::to_string).collect(),
         )
     }

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -475,10 +475,9 @@ impl TimelineEventItem {
     }
 
     pub fn mentioned_users(&self) -> Vec<String> {
-        self.mentions.as_ref().map_or_else(
-            || Vec::new(),
-            |m| m.user_ids.iter().map(ToString::to_string).collect(),
-        )
+        self.mentions.as_ref().map_or_else(Vec::new, |m| {
+            m.user_ids.iter().map(ToString::to_string).collect()
+        })
     }
 
     pub fn in_reply_to_id(&self) -> Option<String> {

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -470,7 +470,7 @@ impl TimelineEventItem {
         }
     }
 
-    pub fn mentioned_room(&self) -> bool {
+    pub fn room_mentioned(&self) -> bool {
         self.mentions.as_ref().map_or_else(|| false, |m| m.room)
     }
 

--- a/native/acter/src/api/timeline/item.rs
+++ b/native/acter/src/api/timeline/item.rs
@@ -23,7 +23,7 @@ use matrix_sdk_base::ruma::{
         },
         receipt::Receipt,
         room::message::MessageType,
-        FullStateEventContent,
+        FullStateEventContent, Mentions,
     },
     OwnedEventId, OwnedRoomAliasId, OwnedTransactionId, OwnedUserId,
 };
@@ -112,6 +112,8 @@ pub struct TimelineEventItem {
     #[builder(default)]
     content: Option<TimelineEventContent>,
     #[builder(default)]
+    mentions: Option<Mentions>,
+    #[builder(default)]
     in_reply_to_id: Option<OwnedEventId>,
     #[builder(default)]
     in_reply_to_event: Option<Box<TimelineEventItem>>,
@@ -140,6 +142,9 @@ impl TimelineEventItemBuilder {
                     let msg_type = msg.msgtype();
                     self.msg_type(Some(msg_type.msgtype().to_owned()));
                     self.content(TimelineEventContent::try_from(msg_type).ok());
+                    if let Some(mentions) = msg.mentions() {
+                        self.mentions(Some(mentions.clone()));
+                    }
                     if let Some(in_reply_to) = &msg_like.in_reply_to {
                         self.in_reply_to_id(Some(in_reply_to.event_id.clone()));
                         if let TimelineDetails::Ready(event) = &in_reply_to.event {
@@ -463,6 +468,17 @@ impl TimelineEventItem {
         } else {
             None
         }
+    }
+
+    pub fn mentioned_room(&self) -> bool {
+        self.mentions.as_ref().map_or_else(|| false, |m| m.room)
+    }
+
+    pub fn mentioned_users(&self) -> Vec<String> {
+        self.mentions.as_ref().map_or_else(
+            || vec![],
+            |m| m.user_ids.iter().map(ToString::to_string).collect(),
+        )
     }
 
     pub fn in_reply_to_id(&self) -> Option<String> {

--- a/native/test/src/tests.rs
+++ b/native/test/src/tests.rs
@@ -8,6 +8,7 @@ mod categories;
 mod formatted_body;
 mod invitation;
 mod media_msg;
+mod mention;
 mod msg_draft;
 mod msg_edit;
 mod news;

--- a/native/test/src/tests/mention.rs
+++ b/native/test/src/tests/mention.rs
@@ -73,7 +73,7 @@ async fn sisko_mentions_kyra_worf() -> Result<()> {
     sisko_timeline.send_message(Box::new(draft)).await?;
 
     // wait for kyra sync to catch up
-    let (event_id, mentioned_room, mentioned_users) =
+    let (event_id, room_mentioned, mentioned_users) =
         Retry::spawn(retry_strategy.clone(), || async {
             for v in kyra_convo.items().await {
                 if let Some(result) = match_mentioned_msg(&v, "Hello, there") {
@@ -86,11 +86,11 @@ async fn sisko_mentions_kyra_worf() -> Result<()> {
 
     info!("kyra found sisko mentioned her: {}", event_id);
 
-    assert!(!mentioned_room);
+    assert!(!room_mentioned);
     assert!(mentioned_users.contains(&kyra_id));
 
     // wait for worf sync to catch up
-    let (event_id, mentioned_room, mentioned_users) = Retry::spawn(retry_strategy, || async {
+    let (event_id, room_mentioned, mentioned_users) = Retry::spawn(retry_strategy, || async {
         for v in worf_convo.items().await {
             if let Some(result) = match_mentioned_msg(&v, "Hello, there") {
                 return Ok(result);
@@ -102,7 +102,7 @@ async fn sisko_mentions_kyra_worf() -> Result<()> {
 
     info!("worf found sisko mentioned him: {}", event_id);
 
-    assert!(!mentioned_room);
+    assert!(!room_mentioned);
     assert!(mentioned_users.contains(&worf_id));
 
     Ok(())
@@ -118,7 +118,7 @@ fn match_mentioned_msg(msg: &TimelineItem, body: &str) -> Option<(String, bool, 
                 if let Some(event_id) = event_item.event_id() {
                     return Some((
                         event_id,
-                        event_item.mentioned_room(),
+                        event_item.room_mentioned(),
                         event_item.mentioned_users(),
                     ));
                 }

--- a/native/test/src/tests/mention.rs
+++ b/native/test/src/tests/mention.rs
@@ -1,0 +1,126 @@
+use acter::api::TimelineItem;
+use anyhow::{bail, Result};
+use tokio_retry::{
+    strategy::{jitter, FibonacciBackoff},
+    Retry,
+};
+use tracing::info;
+
+use crate::utils::random_users_with_random_convo;
+
+#[tokio::test]
+async fn sisko_mentions_kyra_worf() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let (users, room_id) = random_users_with_random_convo("mention", 2).await?;
+    let mut sisko = users[0].clone();
+    let mut kyra = users[1].clone();
+    let mut worf = users[2].clone();
+
+    // wait for sisko sync to catch up
+    let sisko_sync = sisko.start_sync();
+    sisko_sync.await_has_synced_history().await?;
+
+    let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
+    Retry::spawn(retry_strategy.clone(), || async {
+        sisko.convo(room_id.to_string()).await
+    })
+    .await?;
+
+    let sisko_convo = sisko.convo(room_id.to_string()).await?;
+    let sisko_timeline = sisko_convo.timeline_stream();
+
+    // wait for kyra sync to catch up
+    let kyra_sync = kyra.start_sync();
+    kyra_sync.await_has_synced_history().await?;
+
+    for invited in kyra.invited_rooms().iter() {
+        info!(" - accepting {:?}", invited.room_id());
+        invited.join().await?;
+    }
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        kyra.convo(room_id.to_string()).await
+    })
+    .await?;
+
+    let kyra_convo = kyra.convo(room_id.to_string()).await?;
+
+    // wait for worf sync to catch up
+    let worf_sync = worf.start_sync();
+    worf_sync.await_has_synced_history().await?;
+
+    for invited in worf.invited_rooms().iter() {
+        info!(" - accepting {:?}", invited.room_id());
+        invited.join().await?;
+    }
+
+    Retry::spawn(retry_strategy.clone(), || async {
+        worf.convo(room_id.to_string()).await
+    })
+    .await?;
+
+    let worf_convo = worf.convo(room_id.to_string()).await?;
+
+    // sisko sends the text message that mentions kyra and worf
+    let kyra_id = kyra.user_id()?.to_string();
+    let worf_id = worf.user_id()?.to_string();
+    let draft = sisko
+        .text_plain_draft("Hello, there".to_owned())
+        .add_mention(kyra_id.clone())?
+        .add_mention(worf_id.clone())?
+        .clone(); // switch variable from temporary to normal so that send_message can use it
+    sisko_timeline.send_message(Box::new(draft)).await?;
+
+    // wait for kyra sync to catch up
+    let (_, mentioned_room, mentioned_users) = Retry::spawn(retry_strategy.clone(), || async {
+        for v in kyra_convo.items().await {
+            let Some(result) = match_mentioned_msg(&v, "Hello, there") else {
+                continue;
+            };
+            return Ok(result);
+        }
+        bail!("Event not found");
+    })
+    .await?;
+
+    assert!(!mentioned_room);
+    assert!(mentioned_users.contains(&kyra_id));
+
+    // wait for worf sync to catch up
+    let (_, mentioned_room, mentioned_users) = Retry::spawn(retry_strategy, || async {
+        for v in worf_convo.items().await {
+            let Some(result) = match_mentioned_msg(&v, "Hello, there") else {
+                continue;
+            };
+            return Ok(result);
+        }
+        bail!("Event not found");
+    })
+    .await?;
+
+    assert!(!mentioned_room);
+    assert!(mentioned_users.contains(&worf_id));
+
+    Ok(())
+}
+
+fn match_mentioned_msg(msg: &TimelineItem, body: &str) -> Option<(String, bool, Vec<String>)> {
+    info!("match room msg - {:?}", msg.clone());
+    if !msg.is_virtual() {
+        let event_item = msg.event_item().expect("room msg should have event item");
+        if let Some(msg_content) = event_item.msg_content() {
+            if msg_content.body() == body {
+                // exclude the pending msg
+                if let Some(event_id) = event_item.event_id() {
+                    return Some((
+                        event_id,
+                        event_item.mentioned_room(),
+                        event_item.mentioned_users(),
+                    ));
+                }
+            }
+        }
+    }
+    None
+}

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -21797,13 +21797,13 @@ class Api {
           .asFunction<
             _TimelineEventItemSpaceParentContentReturn Function(int)
           >();
-  late final _timelineEventItemMentionedRoomPtr =
+  late final _timelineEventItemRoomMentionedPtr =
       _lookup<ffi.NativeFunction<ffi.Uint8 Function(ffi.IntPtr)>>(
-        "__TimelineEventItem_mentioned_room",
+        "__TimelineEventItem_room_mentioned",
       );
 
-  late final _timelineEventItemMentionedRoom =
-      _timelineEventItemMentionedRoomPtr.asFunction<int Function(int)>();
+  late final _timelineEventItemRoomMentioned =
+      _timelineEventItemRoomMentionedPtr.asFunction<int Function(int)>();
   late final _timelineEventItemMentionedUsersPtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr)>>(
         "__TimelineEventItem_mentioned_users",
@@ -45941,16 +45941,17 @@ class TimelineEventItem {
   }
 
   /// Whether the whole room is mentioned.
-  bool mentionedRoom() {
+  bool roomMentioned() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
-    final tmp1 = _api._timelineEventItemMentionedRoom(tmp0);
+    final tmp1 = _api._timelineEventItemRoomMentioned(tmp0);
     final tmp3 = tmp1;
     final tmp2 = tmp3 > 0;
     return tmp2;
   }
 
   /// The list of mentioned users.
+  /// Available only when sender didn't mention the whole room
   FfiListFfiString mentionedUsers() {
     var tmp0 = 0;
     tmp0 = _box.borrow();

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -45951,7 +45951,7 @@ class TimelineEventItem {
   }
 
   /// The list of mentioned users.
-  /// Available only when sender didn't mention the whole room
+  /// Available only when sender didn’t mention the whole room
   FfiListFfiString mentionedUsers() {
     var tmp0 = 0;
     tmp0 = _box.borrow();
@@ -70279,7 +70279,7 @@ class BackupManager {
     return tmp6;
   }
 
-  /// the backup key as it was stored last, might be empty if there isn't any stored
+  /// the backup key as it was stored last, might be empty if there isn’t any stored
   Future<OptionString> storedEncKey() {
     var tmp0 = 0;
     tmp0 = _box.borrow();

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -21797,6 +21797,20 @@ class Api {
           .asFunction<
             _TimelineEventItemSpaceParentContentReturn Function(int)
           >();
+  late final _timelineEventItemMentionedRoomPtr =
+      _lookup<ffi.NativeFunction<ffi.Uint8 Function(ffi.IntPtr)>>(
+        "__TimelineEventItem_mentioned_room",
+      );
+
+  late final _timelineEventItemMentionedRoom =
+      _timelineEventItemMentionedRoomPtr.asFunction<int Function(int)>();
+  late final _timelineEventItemMentionedUsersPtr =
+      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr)>>(
+        "__TimelineEventItem_mentioned_users",
+      );
+
+  late final _timelineEventItemMentionedUsers =
+      _timelineEventItemMentionedUsersPtr.asFunction<int Function(int)>();
   late final _timelineEventItemInReplyToIdPtr = _lookup<
     ffi.NativeFunction<_TimelineEventItemInReplyToIdReturn Function(ffi.IntPtr)>
   >("__TimelineEventItem_in_reply_to_id");
@@ -45923,6 +45937,30 @@ class TimelineEventItem {
     final tmp4_1 = _Box(_api, tmp4_0, "drop_box_SpaceParentContent");
     tmp4_1._finalizer = _api._registerFinalizer(tmp4_1);
     final tmp2 = SpaceParentContent._(_api, tmp4_1);
+    return tmp2;
+  }
+
+  /// Whether the whole room is mentioned.
+  bool mentionedRoom() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._timelineEventItemMentionedRoom(tmp0);
+    final tmp3 = tmp1;
+    final tmp2 = tmp3 > 0;
+    return tmp2;
+  }
+
+  /// The list of mentioned users.
+  FfiListFfiString mentionedUsers() {
+    var tmp0 = 0;
+    tmp0 = _box.borrow();
+    final tmp1 = _api._timelineEventItemMentionedUsers(tmp0);
+    final tmp3 = tmp1;
+    final ffi.Pointer<ffi.Void> tmp3_0 = ffi.Pointer.fromAddress(tmp3);
+    final tmp3_1 = _Box(_api, tmp3_0, "drop_box_FfiListFfiString");
+    tmp3_1._finalizer = _api._registerFinalizer(tmp3_1);
+    final tmp4 = FfiListFfiString._(_api, tmp3_1);
+    final tmp2 = tmp4;
     return tmp2;
   }
 


### PR DESCRIPTION
Now, `MsgDraft::add_mention()` was implemented, but `MsgContent` has no such method.
As result, we can mention someone when sending msg, but can't know it when receiving msg...

Will implement the mention read api on rust side.