### PR TITLE
Resolve Crash on Audio Attachment in Chat

### DIFF
--- a/app/lib/features/attachments/widgets/attachment_selection_options.dart
+++ b/app/lib/features/attachments/widgets/attachment_selection_options.dart
@@ -179,7 +179,8 @@ class AttachmentSelectionOptions extends StatelessWidget {
 
   Future<void> onTapAudio(BuildContext context) async {
     FilePickerResult? result = await FilePicker.platform.pickFiles(
-      type: FileType.audio,
+      type: FileType.custom,
+      allowedExtensions: ['mp3', 'wav', 'aac', 'm4a'],
     );
     if (result == null) return;
     List<File> files = [];


### PR DESCRIPTION
Fixes [#3121](https://github.com/acterglobal/a3/issues/3121)

### **Issue**
Using FileType.audio on iOS opens the Apple Music picker, which only allows selecting audio files from the user's Music library. This does not include local audio files like .mp3, .wav, etc., that may exist in the Files app or app sandbox. As a result, attempting to attach such files caused crashes or failed file selections.

#### Switched from:
`type: FileType.audio`

#### to:
`type: FileType.custom,
allowedExtensions: ['mp3', 'wav', 'aac', 'm4a'],`

This change opens the iOS document picker (Files app), allowing users to pick audio files stored locally or from iCloud Drive, resulting in a more reliable and crash-free experience.

### Reference Video:
https://github.com/user-attachments/assets/25cdc41a-21a8-4f2f-ba82-ec141a5407de


