### PR TITLE
Fix bug in slide swap

### DIFF
--- a/app/lib/features/news/actions/submit_news.dart
+++ b/app/lib/features/news/actions/submit_news.dart
@@ -51,7 +51,7 @@ Future<void> sendNews(BuildContext context, WidgetRef ref) async {
         UpdateSlideType.image => makeImageSlideForNews(ref, slidePost, lang),
         UpdateSlideType.video => makeVideoSlideForNews(ref, slidePost, lang),
       };
-      await draft.addSlide(slide);
+      draft.addSlide(slide);
     } catch (err, s) {
       _log.severe('Failed to process ${slidePost.type} at $slideIdx ', err, s);
       EasyLoading.showError(

--- a/app/lib/features/news/actions/submit_story.dart
+++ b/app/lib/features/news/actions/submit_story.dart
@@ -51,7 +51,7 @@ Future<void> sendStory(BuildContext context, WidgetRef ref) async {
         UpdateSlideType.image => makeImageSlideForStory(ref, slidePost, lang),
         UpdateSlideType.video => makeVideoSlideForStory(ref, slidePost, lang),
       };
-      await draft.addSlide(slide);
+      draft.addSlide(slide);
     } catch (err, s) {
       _log.severe('Failed to process ${slidePost.type} at $slideIdx ', err, s);
       EasyLoading.showError(

--- a/native/acter/api.rsh
+++ b/native/acter/api.rsh
@@ -424,7 +424,7 @@ object NewsEntry {
 
 object NewsEntryDraft {
     /// create news slide draft
-    fn add_slide(base_draft: NewsSlideDraft) -> Future<Result<bool>>;
+    fn add_slide(base_draft: NewsSlideDraft);
 
     /// change position of slides draft of this news entry
     fn swap_slides(from: u8, to:u8);
@@ -535,7 +535,7 @@ object Story {
 
 object StoryDraft {
     /// create news slide draft
-    fn add_slide(base_draft: StorySlideDraft) -> Future<Result<bool>>;
+    fn add_slide(base_draft: StorySlideDraft);
 
     /// change position of slides draft of this news entry
     fn swap_slides(from: u8, to:u8);

--- a/native/acter/src/api/news.rs
+++ b/native/acter/src/api/news.rs
@@ -485,9 +485,8 @@ pub struct NewsEntryDraft {
 }
 
 impl NewsEntryDraft {
-    pub async fn add_slide(&mut self, draft: Box<NewsSlideDraft>) -> Result<bool> {
+    pub fn add_slide(&mut self, draft: Box<NewsSlideDraft>) {
         self.slides.push(*draft);
-        Ok(true)
     }
 
     pub fn slides(&self) -> Vec<NewsSlideDraft> {

--- a/native/acter/src/api/stories.rs
+++ b/native/acter/src/api/stories.rs
@@ -460,9 +460,8 @@ pub struct StoryDraft {
 }
 
 impl StoryDraft {
-    pub async fn add_slide(&mut self, draft: Box<StorySlideDraft>) -> Result<bool> {
+    pub fn add_slide(&mut self, draft: Box<StorySlideDraft>) {
         self.slides.push(*draft);
-        Ok(true)
     }
 
     pub fn slides(&self) -> Vec<StorySlideDraft> {

--- a/native/test/src/tests/media_msg/thumbnail.rs
+++ b/native/test/src/tests/media_msg/thumbnail.rs
@@ -481,7 +481,7 @@ async fn news_can_support_image_thumbnail() -> Result<()> {
             thumb_mimetype.to_owned(),
         )
         .thumbnail_info(None, None, Some(size));
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);
@@ -556,7 +556,7 @@ async fn news_can_support_video_thumbnail() -> Result<()> {
             thumb_mimetype.to_owned(),
         )
         .thumbnail_info(None, None, Some(size));
-    draft.add_slide(Box::new(video_draft.into())).await?;
+    draft.add_slide(Box::new(video_draft.into()));
     draft.send().await?;
 
     let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(10);

--- a/native/test/src/tests/news.rs
+++ b/native/test/src/tests/news.rs
@@ -94,7 +94,7 @@ async fn news_smoketest() -> Result<()> {
     let text_draft = user.text_plain_draft("This is text slide".to_owned());
     let event_id = {
         let mut draft = main_space.news_draft()?;
-        draft.add_slide(Box::new(text_draft.into())).await?;
+        draft.add_slide(Box::new(text_draft.into()));
         draft.send().await?
     };
     print!("draft sent event id: {}", event_id);
@@ -120,7 +120,7 @@ async fn news_plain_text_test() -> Result<()> {
     let body = "This is a simple text";
     let text_draft = user.text_plain_draft(body.to_owned());
     let mut draft = space.news_draft()?;
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -180,7 +180,7 @@ async fn news_slide_color_test() -> Result<()> {
         Some(0xFF112233),
         Some(0xFF112233),
     )?));
-    draft.add_slide(Box::new(slide_draft)).await?;
+    draft.add_slide(Box::new(slide_draft));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -227,7 +227,7 @@ async fn news_markdown_text_test() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.news_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -314,7 +314,7 @@ async fn news_markdown_text_with_reference_test() -> Result<()> {
     let ref_details = pin.ref_details().await?;
     let obj_ref_builder = new_obj_ref_builder(None, Box::new(ref_details))?;
     text_draft.add_reference(Box::new(obj_ref_builder));
-    draft.add_slide(Box::new(text_draft)).await?;
+    draft.add_slide(Box::new(text_draft));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -377,7 +377,7 @@ async fn news_jpg_image_with_text_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/jpg".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -435,7 +435,7 @@ async fn news_png_image_with_text_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/png".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -495,10 +495,10 @@ async fn news_multiple_slide_test() -> Result<()> {
     );
 
     // we add three slides
-    draft.add_slide(Box::new(image_draft.into())).await?;
-    draft.add_slide(Box::new(markdown_draft.into())).await?;
-    draft.add_slide(Box::new(plain_draft.into())).await?;
-    draft.add_slide(Box::new(video_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
+    draft.add_slide(Box::new(markdown_draft.into()));
+    draft.add_slide(Box::new(plain_draft.into()));
+    draft.add_slide(Box::new(video_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -560,7 +560,7 @@ async fn news_like_reaction_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/png".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -649,7 +649,7 @@ async fn news_read_receipt_test() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.news_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy.clone(), || async {
@@ -739,12 +739,12 @@ async fn multi_news_read_receipt_test() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.news_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     let first_news_id = draft.send().await?;
 
     let mut draft = space.news_draft()?;
     let text_draft = user.text_markdown_draft("## This is a second news".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     let second_news_id = draft.send().await?;
 
     let slides = Retry::spawn(retry_strategy.clone(), || async {

--- a/native/test/src/tests/notifications/news.rs
+++ b/native/test/src/tests/notifications/news.rs
@@ -36,7 +36,7 @@ async fn news_notification() -> Result<()> {
     let text_draft = user.text_plain_draft("This is text slide".to_owned());
     let event_id = {
         let mut draft = main_space.news_draft()?;
-        draft.add_slide(Box::new(text_draft.into())).await?;
+        draft.add_slide(Box::new(text_draft.into()));
         draft.send().await?
     };
     tracing::trace!("draft sent event id: {}", event_id);

--- a/native/test/src/tests/stories.rs
+++ b/native/test/src/tests/stories.rs
@@ -94,7 +94,7 @@ async fn story_smoketest() -> Result<()> {
     let text_draft = user.text_plain_draft("This is text slide".to_owned());
     let event_id = {
         let mut draft = main_space.story_draft()?;
-        draft.add_slide(Box::new(text_draft.into())).await?;
+        draft.add_slide(Box::new(text_draft.into()));
         draft.send().await?
     };
     print!("draft sent event id: {}", event_id);
@@ -120,7 +120,7 @@ async fn story_plain_text_test() -> Result<()> {
     let mut draft = space.story_draft()?;
     let body = "This is a simple text";
     let text_draft = user.text_plain_draft(body.to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -180,7 +180,7 @@ async fn story_slide_color_test() -> Result<()> {
         Some(0xFF112233),
         Some(0xFF112233),
     )?));
-    draft.add_slide(Box::new(slide_draft)).await?;
+    draft.add_slide(Box::new(slide_draft));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -227,7 +227,7 @@ async fn story_markdown_text_test() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.story_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -290,7 +290,7 @@ async fn story_jpg_image_with_text_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/jpg".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -348,7 +348,7 @@ async fn story_png_image_with_text_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/png".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -409,10 +409,10 @@ async fn story_multiple_slide_test() -> Result<()> {
     );
 
     // we add three slides
-    draft.add_slide(Box::new(image_draft.into())).await?;
-    draft.add_slide(Box::new(markdown_draft.into())).await?;
-    draft.add_slide(Box::new(plain_draft.into())).await?;
-    draft.add_slide(Box::new(video_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
+    draft.add_slide(Box::new(markdown_draft.into()));
+    draft.add_slide(Box::new(plain_draft.into()));
+    draft.add_slide(Box::new(video_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -474,7 +474,7 @@ async fn story_like_reaction_test() -> Result<()> {
         tmp_file.path().to_string_lossy().to_string(),
         "image/png".to_owned(),
     );
-    draft.add_slide(Box::new(image_draft.into())).await?;
+    draft.add_slide(Box::new(image_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {
@@ -563,7 +563,7 @@ async fn story_read_receipt_test() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.story_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy.clone(), || async {
@@ -655,14 +655,14 @@ async fn multi_story_read_receipt_test() -> Result<()> {
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
     let first_story_id = {
         let mut draft = space.story_draft()?;
-        draft.add_slide(Box::new(text_draft.into())).await?;
+        draft.add_slide(Box::new(text_draft.into()));
         draft.send().await?
     };
 
     let text_draft = user.text_markdown_draft("## This is a second story".to_owned());
     let second_story_id = {
         let mut draft = space.story_draft()?;
-        draft.add_slide(Box::new(text_draft.into())).await?;
+        draft.add_slide(Box::new(text_draft.into()));
         draft.send().await?
     };
 

--- a/native/test/src/tests/sync.rs
+++ b/native/test/src/tests/sync.rs
@@ -23,7 +23,7 @@ async fn history_sync_restart() -> Result<()> {
     let space = user.space(room_id.to_string()).await?;
     let mut draft = space.news_draft()?;
     let text_draft = user.text_markdown_draft("## This is a simple text".to_owned());
-    draft.add_slide(Box::new(text_draft.into())).await?;
+    draft.add_slide(Box::new(text_draft.into()));
     draft.send().await?;
 
     Retry::spawn(retry_strategy, || async {

--- a/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
+++ b/packages/rust_sdk/lib/acter_flutter_sdk_ffi.dart
@@ -2571,48 +2571,6 @@ class Api {
     return tmp7;
   }
 
-  bool? __newsEntryDraftAddSlideFuturePoll(
-    int boxed,
-    int postCobject,
-    int port,
-  ) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _newsEntryDraftAddSlideFuturePoll(tmp1, tmp3, tmp5);
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 = utf8.decode(
-        tmp10_0.asTypedList(tmp11),
-        allowMalformed: true,
-      );
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final tmp7 = tmp13 > 0;
-    return tmp7;
-  }
-
   EventId? __newsEntryDraftSendFuturePoll(
     int boxed,
     int postCobject,
@@ -2961,44 +2919,6 @@ class Api {
     final tmp13_1 = _Box(this, tmp13_0, "drop_box_CommentsManager");
     tmp13_1._finalizer = this._registerFinalizer(tmp13_1);
     final tmp7 = CommentsManager._(this, tmp13_1);
-    return tmp7;
-  }
-
-  bool? __storyDraftAddSlideFuturePoll(int boxed, int postCobject, int port) {
-    final tmp0 = boxed;
-    final tmp2 = postCobject;
-    final tmp4 = port;
-    var tmp1 = 0;
-    var tmp3 = 0;
-    var tmp5 = 0;
-    tmp1 = tmp0;
-    tmp3 = tmp2;
-    tmp5 = tmp4;
-    final tmp6 = _storyDraftAddSlideFuturePoll(tmp1, tmp3, tmp5);
-    final tmp8 = tmp6.arg0;
-    final tmp9 = tmp6.arg1;
-    final tmp10 = tmp6.arg2;
-    final tmp11 = tmp6.arg3;
-    final tmp12 = tmp6.arg4;
-    final tmp13 = tmp6.arg5;
-    if (tmp8 == 0) {
-      return null;
-    }
-    if (tmp9 == 0) {
-      debugAllocation("handle error", tmp10, tmp11);
-      final ffi.Pointer<ffi.Uint8> tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-      final tmp9_0 = utf8.decode(
-        tmp10_0.asTypedList(tmp11),
-        allowMalformed: true,
-      );
-      if (tmp11 > 0) {
-        final ffi.Pointer<ffi.Void> tmp10_0;
-        tmp10_0 = ffi.Pointer.fromAddress(tmp10);
-        this.__deallocate(tmp10_0, tmp12, 1);
-      }
-      throw tmp9_0;
-    }
-    final tmp7 = tmp13 > 0;
     return tmp7;
   }
 
@@ -19806,12 +19726,12 @@ class Api {
   late final _newsEntryRefDetails =
       _newsEntryRefDetailsPtr.asFunction<int Function(int)>();
   late final _newsEntryDraftAddSlidePtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
         "__NewsEntryDraft_add_slide",
       );
 
   late final _newsEntryDraftAddSlide =
-      _newsEntryDraftAddSlidePtr.asFunction<int Function(int, int)>();
+      _newsEntryDraftAddSlidePtr.asFunction<void Function(int, int)>();
   late final _newsEntryDraftSwapSlidesPtr = _lookup<
     ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.Uint8, ffi.Uint8)>
   >("__NewsEntryDraft_swap_slides");
@@ -20009,12 +19929,12 @@ class Api {
 
   late final _storyComments = _storyCommentsPtr.asFunction<int Function(int)>();
   late final _storyDraftAddSlidePtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.IntPtr)>>(
         "__StoryDraft_add_slide",
       );
 
   late final _storyDraftAddSlide =
-      _storyDraftAddSlidePtr.asFunction<int Function(int, int)>();
+      _storyDraftAddSlidePtr.asFunction<void Function(int, int)>();
   late final _storyDraftSwapSlidesPtr = _lookup<
     ffi.NativeFunction<ffi.Void Function(ffi.IntPtr, ffi.Uint8, ffi.Uint8)>
   >("__StoryDraft_swap_slides");
@@ -31065,21 +30985,6 @@ class Api {
           .asFunction<
             _NewsEntryRefDetailsFuturePollReturn Function(int, int, int)
           >();
-  late final _newsEntryDraftAddSlideFuturePollPtr = _lookup<
-    ffi.NativeFunction<
-      _NewsEntryDraftAddSlideFuturePollReturn Function(
-        ffi.IntPtr,
-        ffi.IntPtr,
-        ffi.Int64,
-      )
-    >
-  >("__NewsEntryDraft_add_slide_future_poll");
-
-  late final _newsEntryDraftAddSlideFuturePoll =
-      _newsEntryDraftAddSlideFuturePollPtr
-          .asFunction<
-            _NewsEntryDraftAddSlideFuturePollReturn Function(int, int, int)
-          >();
   late final _newsEntryDraftSendFuturePollPtr = _lookup<
     ffi.NativeFunction<
       _NewsEntryDraftSendFuturePollReturn Function(
@@ -31198,21 +31103,6 @@ class Api {
   late final _storyCommentsFuturePoll =
       _storyCommentsFuturePollPtr
           .asFunction<_StoryCommentsFuturePollReturn Function(int, int, int)>();
-  late final _storyDraftAddSlideFuturePollPtr = _lookup<
-    ffi.NativeFunction<
-      _StoryDraftAddSlideFuturePollReturn Function(
-        ffi.IntPtr,
-        ffi.IntPtr,
-        ffi.Int64,
-      )
-    >
-  >("__StoryDraft_add_slide_future_poll");
-
-  late final _storyDraftAddSlideFuturePoll =
-      _storyDraftAddSlideFuturePollPtr
-          .asFunction<
-            _StoryDraftAddSlideFuturePollReturn Function(int, int, int)
-          >();
   late final _storyDraftSendFuturePollPtr = _lookup<
     ffi.NativeFunction<
       _StoryDraftSendFuturePollReturn Function(
@@ -41151,19 +41041,14 @@ class NewsEntryDraft {
   NewsEntryDraft._(this._api, this._box);
 
   /// create news slide draft
-  Future<bool> addSlide(NewsSlideDraft baseDraft) {
+  void addSlide(NewsSlideDraft baseDraft) {
     final tmp1 = baseDraft;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1._box.move();
-    final tmp3 = _api._newsEntryDraftAddSlide(tmp0, tmp2);
-    final tmp5 = tmp3;
-    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
-    final tmp5_1 = _Box(_api, tmp5_0, "__NewsEntryDraft_add_slide_future_drop");
-    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
-    final tmp4 = _nativeFuture(tmp5_1, _api.__newsEntryDraftAddSlideFuturePoll);
-    return tmp4;
+    _api._newsEntryDraftAddSlide(tmp0, tmp2);
+    return;
   }
 
   /// change position of slides draft of this news entry
@@ -41650,19 +41535,14 @@ class StoryDraft {
   StoryDraft._(this._api, this._box);
 
   /// create news slide draft
-  Future<bool> addSlide(StorySlideDraft baseDraft) {
+  void addSlide(StorySlideDraft baseDraft) {
     final tmp1 = baseDraft;
     var tmp0 = 0;
     var tmp2 = 0;
     tmp0 = _box.borrow();
     tmp2 = tmp1._box.move();
-    final tmp3 = _api._storyDraftAddSlide(tmp0, tmp2);
-    final tmp5 = tmp3;
-    final ffi.Pointer<ffi.Void> tmp5_0 = ffi.Pointer.fromAddress(tmp5);
-    final tmp5_1 = _Box(_api, tmp5_0, "__StoryDraft_add_slide_future_drop");
-    tmp5_1._finalizer = _api._registerFinalizer(tmp5_1);
-    final tmp4 = _nativeFuture(tmp5_1, _api.__storyDraftAddSlideFuturePoll);
-    return tmp4;
+    _api._storyDraftAddSlide(tmp0, tmp2);
+    return;
   }
 
   /// change position of slides draft of this news entry
@@ -75688,21 +75568,6 @@ class _NewsEntryRefDetailsFuturePollReturn extends ffi.Struct {
   external int arg5;
 }
 
-class _NewsEntryDraftAddSlideFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.IntPtr()
-  external int arg2;
-  @ffi.UintPtr()
-  external int arg3;
-  @ffi.UintPtr()
-  external int arg4;
-  @ffi.Uint8()
-  external int arg5;
-}
-
 class _NewsEntryDraftSendFuturePollReturn extends ffi.Struct {
   @ffi.Uint8()
   external int arg0;
@@ -75820,21 +75685,6 @@ class _StoryCommentsFuturePollReturn extends ffi.Struct {
   @ffi.UintPtr()
   external int arg4;
   @ffi.IntPtr()
-  external int arg5;
-}
-
-class _StoryDraftAddSlideFuturePollReturn extends ffi.Struct {
-  @ffi.Uint8()
-  external int arg0;
-  @ffi.Uint8()
-  external int arg1;
-  @ffi.IntPtr()
-  external int arg2;
-  @ffi.UintPtr()
-  external int arg3;
-  @ffi.UintPtr()
-  external int arg4;
-  @ffi.Uint8()
   external int arg5;
 }
 


### PR DESCRIPTION
Now we have the code for slide swapping.

```rs
    pub fn swap_slides(&mut self, from: u8, to: u8) -> Result<&mut Self> {
        let content = self.content.build()?;
        let mut slides = content.slides.expect("content slides");
        if to > slides.len() as u8 {
            bail!("upper bound is exceeded")
        }
->      slides.swap(from as usize, to as usize);
        self.content.slides(Some(slides));
        Ok(self)
    }
```

But via rust test I found it occurs the following error.

`index out of bounds: the len is 1 but the index is 1`

Will fix this error.