### PR TITLE
Added click actions to activity items in the Activity screen.

### DIFF
--- a/.changes/3149-activity-item-onclick.md
+++ b/.changes/3149-activity-item-onclick.md
@@ -1,0 +1,1 @@
+- [Implement] : Click actions to activity items in the Activity screen, enabling user interaction with individual activity entries.

--- a/.changes/3149-activity-item-onclick.md
+++ b/.changes/3149-activity-item-onclick.md
@@ -1,1 +1,1 @@
-- [Implement] : Click actions to activity items in the Activity screen, enabling user interaction with individual activity entries.
+- [Implement] : Added click actions to activity items in the Activity screen, enabling user interaction with individual activity entries.

--- a/app/lib/features/activities/actions/activity_item_click_action.dart
+++ b/app/lib/features/activities/actions/activity_item_click_action.dart
@@ -42,5 +42,5 @@ void onTapActivityItem(BuildContext context, ActivityObject? activityObject) {
           pathParameters: {'updateId': objectId},
         );
     default: _log.warning('Unknown activity type: $activityType');
-  };
+  }
 }

--- a/app/lib/features/activities/actions/activity_item_click_action.dart
+++ b/app/lib/features/activities/actions/activity_item_click_action.dart
@@ -16,37 +16,31 @@ void onTapActivityItem(BuildContext context, ActivityObject? activityObject) {
     return;
   }
 
-  final activityActions = {
-    'pin': () => context.pushNamed(
+  switch (activityType) {
+    case 'pin': context.pushNamed(
           Routes.pin.name,
           pathParameters: {'pinId': objectId},
-        ),
-    'task': () => context.pushNamed(
+        );
+    case 'task': context.pushNamed(
           Routes.taskItemDetails.name,
           pathParameters: {'taskId': objectId, 'taskListId': taskListId},
-        ),
-    'task-list': () => context.pushNamed(
+        );
+    case 'task-list': context.pushNamed(
           Routes.taskListDetails.name,
           pathParameters: {'taskListId': objectId},
-        ),
-    'event': () => context.pushNamed(
+        );
+    case 'event': context.pushNamed(
           Routes.calendarEvent.name,
           pathParameters: {'calendarId': objectId},
-        ),
-    'news': () => context.pushNamed(
+        );
+    case 'news': context.pushNamed(
           Routes.update.name,
           pathParameters: {'updateId': objectId},
-        ),
-    'story': () => context.pushNamed(
+        );
+    case 'story': context.pushNamed(
           Routes.update.name,
           pathParameters: {'updateId': objectId},
-        ),
+        );
+    default: _log.warning('Unknown activity type: $activityType');
   };
-
-  final action = activityActions[activityType];
-  if (action != null) {
-    action();
-  } else {
-    _log.warning('Unknown activity type: $activityType');
-  }
 }

--- a/app/lib/features/activities/actions/activity_item_click_action.dart
+++ b/app/lib/features/activities/actions/activity_item_click_action.dart
@@ -1,0 +1,55 @@
+import 'package:acter/router/routes.dart';
+import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('ActivityItemClickAction');
+
+void onTapActivityItem(BuildContext context, ActivityObject? activityObject) {
+
+    final String activityType = activityObject?.typeStr() ?? '';
+    final String objectId = activityObject?.objectIdStr() ?? '';
+    final String taskListId = activityObject?.taskListIdStr() ?? '';
+
+    if (activityType.isEmpty || objectId.isEmpty) {
+      _log.info('onTapActivityItem : activityType or objectId is null');
+      return;
+    }
+
+    switch (activityType) {
+      case 'pin':
+        context.pushNamed(Routes.pin.name, pathParameters: {'pinId': objectId});
+        break;
+      case 'task':
+         context.pushNamed(
+            Routes.taskItemDetails.name,
+            pathParameters: {'taskId': objectId, 'taskListId': taskListId},
+          );
+        break;
+      case 'task-list':
+        context.pushNamed(
+          Routes.taskListDetails.name,
+          pathParameters: {'taskListId': objectId},
+        );
+        break;
+      case 'event':
+        context.pushNamed(
+          Routes.calendarEvent.name,
+          pathParameters: {'calendarId': objectId},
+        );
+        break;
+      case 'news':
+        context.pushNamed(
+          Routes.update.name,
+          pathParameters: {'updateId': objectId},
+        );
+        break;
+      case 'story':
+        context.pushNamed(
+          Routes.update.name,
+          pathParameters: {'updateId': objectId},
+        );
+        break;
+    }
+  }

--- a/app/lib/features/activities/actions/activity_item_click_action.dart
+++ b/app/lib/features/activities/actions/activity_item_click_action.dart
@@ -7,49 +7,46 @@ import 'package:logging/logging.dart';
 final _log = Logger('ActivityItemClickAction');
 
 void onTapActivityItem(BuildContext context, ActivityObject? activityObject) {
+  final String activityType = activityObject?.typeStr() ?? '';
+  final String objectId = activityObject?.objectIdStr() ?? '';
+  final String taskListId = activityObject?.taskListIdStr() ?? '';
 
-    final String activityType = activityObject?.typeStr() ?? '';
-    final String objectId = activityObject?.objectIdStr() ?? '';
-    final String taskListId = activityObject?.taskListIdStr() ?? '';
+  if (activityType.isEmpty || objectId.isEmpty) {
+    _log.info('onTapActivityItem : activityType or objectId is null');
+    return;
+  }
 
-    if (activityType.isEmpty || objectId.isEmpty) {
-      _log.info('onTapActivityItem : activityType or objectId is null');
-      return;
-    }
-
-    switch (activityType) {
-      case 'pin':
-        context.pushNamed(Routes.pin.name, pathParameters: {'pinId': objectId});
-        break;
-      case 'task':
-         context.pushNamed(
-            Routes.taskItemDetails.name,
-            pathParameters: {'taskId': objectId, 'taskListId': taskListId},
-          );
-        break;
-      case 'task-list':
-        context.pushNamed(
+  final activityActions = {
+    'pin': () => context.pushNamed(
+          Routes.pin.name,
+          pathParameters: {'pinId': objectId},
+        ),
+    'task': () => context.pushNamed(
+          Routes.taskItemDetails.name,
+          pathParameters: {'taskId': objectId, 'taskListId': taskListId},
+        ),
+    'task-list': () => context.pushNamed(
           Routes.taskListDetails.name,
           pathParameters: {'taskListId': objectId},
-        );
-        break;
-      case 'event':
-        context.pushNamed(
+        ),
+    'event': () => context.pushNamed(
           Routes.calendarEvent.name,
           pathParameters: {'calendarId': objectId},
-        );
-        break;
-      case 'news':
-        context.pushNamed(
+        ),
+    'news': () => context.pushNamed(
           Routes.update.name,
           pathParameters: {'updateId': objectId},
-        );
-        break;
-      case 'story':
-        context.pushNamed(
+        ),
+    'story': () => context.pushNamed(
           Routes.update.name,
           pathParameters: {'updateId': objectId},
-        );
-        break;
-    }
+        ),
+  };
+
+  final action = activityActions[activityType];
+  if (action != null) {
+    action();
+  } else {
+    _log.warning('Unknown activity type: $activityType');
   }
+}

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/providers/room_providers.dart';
 
 class ActivityBiggerVisualContainerWidget extends ConsumerWidget {
   final ActivityObject? activityObject;
+  final VoidCallback? onTap;
   final String userId;
   final String roomId;
   final String actionTitle;
@@ -23,6 +24,7 @@ class ActivityBiggerVisualContainerWidget extends ConsumerWidget {
   const ActivityBiggerVisualContainerWidget({
     super.key,
     this.activityObject,
+    this.onTap,
     required this.userId,
     required this.roomId,
     required this.actionTitle,
@@ -47,7 +49,9 @@ class ActivityBiggerVisualContainerWidget extends ConsumerWidget {
             .valueOrNull ??
         userId;
 
-    return Container(
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
       padding: const EdgeInsets.symmetric(vertical: 10),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -69,8 +73,9 @@ class ActivityBiggerVisualContainerWidget extends ConsumerWidget {
                 _buildSubtitleOrTime(),
               ],
             ),
-          ),
-        ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart
@@ -9,6 +9,7 @@ import 'package:acter/common/providers/room_providers.dart';
 
 class ActivityIndividualActionContainerWidget extends ConsumerWidget {
   final ActivityObject? activityObject;
+  final VoidCallback? onTap;
   final String userId;
   final String roomId;
   final String actionTitle;
@@ -21,6 +22,7 @@ class ActivityIndividualActionContainerWidget extends ConsumerWidget {
   const ActivityIndividualActionContainerWidget({
     super.key,
     this.activityObject,
+    this.onTap,
     required this.userId,
     required this.roomId,
     required this.actionTitle,
@@ -43,7 +45,9 @@ class ActivityIndividualActionContainerWidget extends ConsumerWidget {
             .valueOrNull ??
         userId;
 
-    return Container(
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
       padding: const EdgeInsets.symmetric(vertical: 10),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -66,6 +70,7 @@ class ActivityIndividualActionContainerWidget extends ConsumerWidget {
             ),
           ),
         ],
+        ),
       ),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_space_core_actions_container_widget.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/containers/activity_space_core_actions_container_widget.dart
@@ -9,6 +9,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class ActivitySpaceCoreActionsContainerWidget extends ConsumerWidget {
   final ActivityObject? activityObject;
+  final VoidCallback? onTap;
   final String userId;
   final String roomId;
   final String actionTitle;
@@ -18,6 +19,7 @@ class ActivitySpaceCoreActionsContainerWidget extends ConsumerWidget {
   const ActivitySpaceCoreActionsContainerWidget({
     super.key,
     this.activityObject,
+    this.onTap,
     required this.userId,
     required this.roomId,
     required this.actionTitle,
@@ -36,7 +38,9 @@ class ActivitySpaceCoreActionsContainerWidget extends ConsumerWidget {
             .valueOrNull ??
         userId;
 
-    return Container(
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
       padding: const EdgeInsets.symmetric(vertical: 10),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -48,6 +52,7 @@ class ActivitySpaceCoreActionsContainerWidget extends ConsumerWidget {
           const SizedBox(width: 10),
           _buildTitleOrTime(context, displayName),
         ],
+      ),
       ),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/attachment.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -14,6 +15,7 @@ class ActivityAttachmentItemWidget extends StatelessWidget {
     final subType = activity.subTypeStr();
     final (icon, label) = getAttachmentIconAndLabel(context, subType ?? '');
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIconBgColor: Colors.blue,
       actionIconColor: Colors.white,
       actionIcon: PhosphorIconsRegular.paperclip,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/comment.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -16,6 +17,7 @@ class ActivityCommentItemWidget extends ConsumerWidget {
     final activityObject = activity.object();
     final originServerTs = activity.originServerTs();
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       activityObject: activityObject,
       actionIcon: PhosphorIconsRegular.chatCenteredDots,
       actionIconBgColor: Colors.amber.shade800,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/creation.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/creation.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -11,16 +12,18 @@ class ActivityCreationItemWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final activityObject = activity.object();
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.add,
       actionIconBgColor: Colors.deepPurple,
       actionIconColor: Colors.white,
       actionTitle:
-          '${L10n.of(context).creation} ${activity.object()?.typeStr() ?? ''}',
-      activityObject: activity.object(),
+          '${L10n.of(context).creation} ${activityObject?.typeStr() ?? ''}',
+      activityObject: activityObject,
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
-      target: activity.object()?.title() ?? '',
+      target: activityObject?.title() ?? '',
       originServerTs: activity.originServerTs(),
     );
   }

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/descriptionChange.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/descriptionChange.dart
@@ -1,4 +1,5 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -24,6 +25,7 @@ class ActivityDescriptionChangeItemWidget extends ConsumerWidget {
     final userId = activity.senderIdStr();
 
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activity.object()),
       actionIcon: PhosphorIconsThin.pencilLine,
       actionTitle: getMessage(lang, userId) ?? '',
       target: '',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/eventDateChange.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/eventDateChange.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +13,7 @@ class ActivityEventDateChangeItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       target: activityObject?.title() ?? '',
       actionIcon: Icons.access_time,
       actionIconColor: Colors.white,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/otherChanges.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/otherChanges.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -13,6 +14,7 @@ class ActivityOtherChangesItemWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activity.object()),
       actionIcon: PhosphorIconsRegular.pencilLine,
       actionIconBgColor: Colors.blueGrey,
       actionIconColor: Colors.white,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/references.dart
@@ -1,5 +1,6 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/common/widgets/acter_icon_picker/utils.dart';
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -16,6 +17,7 @@ class ActivityReferencesItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       activityObject: activityObject,
       actionIcon: PhosphorIconsRegular.link,
       actionIconBgColor: Colors.blue,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomAvatar.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomAvatar.dart
@@ -1,8 +1,10 @@
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_space_core_actions_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
+import 'package:acter/router/routes.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class ActivityRoomAvatarItemWidget extends ConsumerWidget {
   final Activity activity;
@@ -12,6 +14,7 @@ class ActivityRoomAvatarItemWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ActivitySpaceCoreActionsContainerWidget(
+      onTap: () => context.pushNamed(Routes.space.name, pathParameters: {'spaceId': activity.roomIdStr()}),
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       actionTitle: L10n.of(context).updatedSpaceAvatar,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomName.dart
@@ -1,8 +1,10 @@
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_space_core_actions_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
+import 'package:acter/router/routes.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class ActivityRoomNameItemWidget extends ConsumerWidget {
   final Activity activity;
@@ -12,6 +14,7 @@ class ActivityRoomNameItemWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ActivitySpaceCoreActionsContainerWidget(
+      onTap: () => context.pushNamed(Routes.space.name, pathParameters: {'spaceId': activity.roomIdStr()}),
       userId: activity.senderIdStr(),
       roomId: activity.roomIdStr(),
       actionTitle: L10n.of(context).updatedSpaceName,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/roomTopic.dart
@@ -1,9 +1,11 @@
 import 'package:acter/common/themes/colors/color_scheme.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
+import 'package:acter/router/routes.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
@@ -19,6 +21,7 @@ class ActivityRoomTopicItemWidget extends ConsumerWidget {
     final lang = L10n.of(context);
     final userId = activity.senderIdStr();
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => context.pushNamed(Routes.space.name, pathParameters: {'spaceId': activity.roomIdStr()}),
       userId: userId,
       roomId: activity.roomIdStr(),
       actionTitle: getMessage(lang, userId) ?? '',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpMaybe.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpMaybe.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +13,7 @@ class ActivityEventRSVPMayBeItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       target: activityObject?.title() ?? '',
       actionIcon: Icons.question_mark,
       actionTitle: L10n.of(context).mayBe,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpNo.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpNo.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +13,7 @@ class ActivityEventRSVPNoItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       target: activityObject?.title() ?? '',
       actionIcon: Icons.close_rounded,
       actionTitle: L10n.of(context).notGoingTo,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpYes.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/rsvpYes.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -11,6 +12,7 @@ class ActivityEventRSVPYesItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final activityObject = activity.object();
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       target: activityObject?.title() ?? '',
       actionIcon: Icons.check,
       actionIconBgColor: Colors.green.shade400,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskAccepted.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskAccepted.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +13,7 @@ class ActivityTaskAcceptedItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.done,
       actionTitle: L10n.of(context).acceptedTask,
       actionIconColor: Colors.green.shade400,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskAdd.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskAdd.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -11,6 +12,7 @@ class ActivityTaskAddItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final activityObject = activity.object();
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.add_circle_outline,
       actionTitle: L10n.of(context).addedTaskOn,
       target: activityObject?.title() ?? '',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskComplete.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskComplete.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -11,6 +12,7 @@ class ActivityTaskCompleteItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final activityObject = activity.object();
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.done,
       actionTitle: L10n.of(context).completedTask,
       actionIconColor: Colors.white,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskDecline.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskDecline.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -11,6 +12,7 @@ class ActivityTaskDeclineItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final activityObject = activity.object();
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.close_rounded,
       actionTitle: L10n.of(context).declinedTask,
       actionIconColor: Colors.red.shade400,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskDueDateChange.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskDueDateChange.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -15,6 +16,7 @@ class ActivityTaskDueDateChangedItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.access_time,
       actionTitle: L10n.of(context).rescheduledTask,
       target: activityObject?.title() ?? '',

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskReOpen.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/taskReOpen.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_individual_action_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -12,6 +13,7 @@ class ActivityTaskReOpenItemWidget extends StatelessWidget {
     final activityObject = activity.object();
 
     return ActivityIndividualActionContainerWidget(
+      onTap: () => onTapActivityItem(context, activityObject),
       actionIcon: Icons.restart_alt,
       target: activityObject?.title() ?? '',
       actionTitle: L10n.of(context).reOpenedTask,

--- a/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/titleChange.dart
+++ b/app/lib/features/activities/widgets/space_activities_section/item_widgets/type_widgets/titleChange.dart
@@ -1,3 +1,4 @@
+import 'package:acter/features/activities/actions/activity_item_click_action.dart';
 import 'package:acter/features/activities/widgets/space_activities_section/item_widgets/containers/activity_bigger_visual_container_widget.dart';
 import 'package:acter/l10n/generated/l10n.dart';
 import 'package:acter_flutter_sdk/acter_flutter_sdk_ffi.dart';
@@ -19,6 +20,7 @@ class ActivityTitleChangeItemWidget extends ConsumerWidget {
 
     final userId = activity.senderIdStr();
     return ActivityBiggerVisualContainerWidget(
+      onTap: () => onTapActivityItem(context, activity.object()),
       activityObject: activity.object(),
       userId: userId,
       roomId: activity.roomIdStr(),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 0.0.1+1
 
 environment:
-  sdk: ">=3.7.0"
-  flutter: ^3.29.0
+  sdk: ">=3.8.1"
+  flutter: ^3.32.4
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Implemented https://github.com/acterglobal/a3/issues/3147

- This PR adds click actions to activity items in the Activity screen. Users can now interact with individual activity entries, allowing for improved navigation or functionality based on the selected item.

- Click events have been specifically added to bigger visual elements, individual user actions, and space core actions,

### Reference video:

https://github.com/user-attachments/assets/c161cc7c-23bb-4c02-8d4f-4863f573d6ed
