### PR TITLE
Choosing a boost/story, the click now works with radio button.

### DIFF
--- a/.changes/3158-boost-story-selection.md
+++ b/.changes/3158-boost-story-selection.md
@@ -1,0 +1,1 @@
+- [Fix] : Click-to-choose boost/story now works correctly with radio buttons at time of boost/story creation.

--- a/app/lib/features/news/pages/add_news/add_news_post_to_page.dart
+++ b/app/lib/features/news/pages/add_news/add_news_post_to_page.dart
@@ -176,10 +176,7 @@ class _AddNewsPostToPageState extends ConsumerState<AddNewsPostToPage> {
                 return Radio(
                   value: postTypeSelection,
                   groupValue: postType,
-                  onChanged:
-                      isEnable
-                          ? (value) => selectedPostType.value = postType
-                          : null,
+                  onChanged: isEnable ? (value) => selectedPostType.value = postTypeSelection : null,
                   toggleable: isEnable,
                 );
               },

--- a/app/test/features/events/pages/create_event_page_test.dart
+++ b/app/test/features/events/pages/create_event_page_test.dart
@@ -287,8 +287,14 @@ void main() {
       await tester.tap(find.text('OK'));
       await tester.pump();
 
+      // Wait for any pending timers to complete
+      await tester.pumpAndSettle(const Duration(seconds: 3));
+
       // Verify end date is not updated
       expect(find.text('14'), findsNothing);
+      
+      // Ensure all EasyLoading operations are dismissed
+      await tester.pump(const Duration(seconds: 1));
     });
 
     testWidgets('handles end time validation correctly', (tester) async {


### PR DESCRIPTION
Fixes https://github.com/acterglobal/a3-meta/issues/1026

- Fixes the issue where boost/story selection didn't work with radio buttons.
- Clicking now correctly selects the chosen option

### Reference video : 

https://github.com/user-attachments/assets/652b919d-6046-4c93-a517-46c401ddf0ac
